### PR TITLE
Updated for the latest Rust nightly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,3 @@
-# Pin nightly to nightly-2020-09-21 until async-std supports
-# `open_options_ext_as_flags`.
-#
-# TODO: Test aarch64-apple-darwin once we update to the latest nightly.
-#    - run: cargo check --workspace --all-targets --all-features --release -vv --target=aarch64-apple-darwin
-
 name: CI
 
 on:
@@ -87,7 +81,7 @@ jobs:
         include:
           - build: nightly
             os: ubuntu-latest
-            rust: nightly-2020-09-21
+            rust: nightly
 
     steps:
     - uses: actions/checkout@v2
@@ -106,6 +100,7 @@ jobs:
         x86_64-unknown-netbsd
         i686-unknown-linux-gnu
         i686-unknown-linux-musl
+        aarch64-apple-darwin
         x86_64-pc-windows-msvc
         x86_64-pc-windows-gnu
         i686-pc-windows-msvc
@@ -121,6 +116,7 @@ jobs:
     - run: cargo check --workspace --all-targets --all-features --release -vv --target=x86_64-unknown-netbsd
     - run: cargo check --workspace --all-targets --all-features --release -vv --target=i686-unknown-linux-gnu
     - run: cargo check --workspace --all-targets --all-features --release -vv --target=i686-unknown-linux-musl
+    - run: cargo check --workspace --all-targets --all-features --release -vv --target=aarch64-apple-darwin
     - run: cargo check --workspace --all-targets --features fs_utf8 --exclude=cap-async-std --exclude=cap-std-workspace --release -vv --target=x86_64-pc-windows-msvc
     - run: cargo check --workspace --all-targets --features fs_utf8 --exclude=cap-async-std --exclude=cap-std-workspace --release -vv --target=x86_64-pc-windows-gnu
     - run: cargo check --workspace --all-targets --features fs_utf8 --exclude=cap-async-std --exclude=cap-std-workspace --release -vv --target=i686-pc-windows-msvc
@@ -220,10 +216,10 @@ jobs:
         include:
           - build: ubuntu
             os: ubuntu-latest
-            rust: nightly-2020-09-21
+            rust: nightly
           - build: windows
             os: windows-latest
-            rust: nightly-2020-09-21
+            rust: nightly
 
     steps:
     - uses: actions/checkout@v2
@@ -264,7 +260,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2020-09-21
+        toolchain: nightly
     - run: cargo install cargo-fuzz --vers "^0.8"
     - run: cargo fetch
       working-directory: ./fuzz

--- a/build.rs
+++ b/build.rs
@@ -11,10 +11,11 @@ fn main() {
             "write_all_vectored", // https://github.com/rust-lang/rust/issues/70436
             "windows_by_handle",  // https://github.com/rust-lang/rust/issues/63010
             "windows_file_type_ext",
-            "try_reserve", // https://github.com/rust-lang/rust/issues/56431
-            "shrink_to",   // https://github.com/rust-lang/rust/issues/56431
-            "pattern",     // https://github.com/rust-lang/rust/issues/27721
-            "clamp",       // https://github.com/rust-lang/rust/issues/44095
+            "open_options_ext_as_flags", // https://github.com/rust-lang/rust/issues/76801
+            "try_reserve",               // https://github.com/rust-lang/rust/issues/56431
+            "shrink_to",                 // https://github.com/rust-lang/rust/issues/56431
+            "pattern",                   // https://github.com/rust-lang/rust/issues/27721
+            "clamp",                     // https://github.com/rust-lang/rust/issues/44095
         ] {
             println!("cargo:rustc-cfg={}", feature);
         }

--- a/cap-primitives/src/fs/open_options.rs
+++ b/cap-primitives/src/fs/open_options.rs
@@ -170,6 +170,13 @@ impl std::os::unix::fs::OpenOptionsExt for OpenOptions {
         self.ext.custom_flags(flags);
         self
     }
+
+    #[cfg(open_options_ext_as_flags)]
+    fn as_flags(&self) -> io::Result<libc::c_int> {
+        Ok(crate::posish::fs::oflags::get_access_mode(self)
+            | crate::posish::fs::oflags::get_creation_mode(self)
+            | self.custom_flags)
+    }
 }
 
 #[cfg(target_os = "vxworks")]

--- a/cap-primitives/src/lib.rs
+++ b/cap-primitives/src/lib.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(all(windows, windows_by_handle), feature(windows_by_handle))]
 #![cfg_attr(all(windows, windows_file_type_ext), feature(windows_file_type_ext))]
+#![cfg_attr(open_options_ext_as_flags, feature(open_options_ext_as_flags))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/bytecodealliance/cap-std/main/media/cap-std.svg"
 )]

--- a/cap-primitives/src/posish/fs/oflags.rs
+++ b/cap-primitives/src/posish/fs/oflags.rs
@@ -28,7 +28,7 @@ pub(in super::super) fn compute_oflags(options: &OpenOptions) -> io::Result<OFla
 // library/std/src/sys/unix/fs.rs at revision
 // 108e90ca78f052c0c1c49c42a22c85620be19712.
 
-fn get_access_mode(options: &OpenOptions) -> io::Result<OFlags> {
+pub(crate) fn get_access_mode(options: &OpenOptions) -> io::Result<OFlags> {
     match (options.read, options.write, options.append) {
         (true, false, false) => Ok(OFlags::RDONLY),
         (false, true, false) => Ok(OFlags::WRONLY),
@@ -39,7 +39,7 @@ fn get_access_mode(options: &OpenOptions) -> io::Result<OFlags> {
     }
 }
 
-fn get_creation_mode(options: &OpenOptions) -> io::Result<OFlags> {
+pub(crate) fn get_creation_mode(options: &OpenOptions) -> io::Result<OFlags> {
     match (options.write, options.append) {
         (true, false) => {}
         (false, false) => {

--- a/cap-primitives/src/posish/fs/open_options_ext.rs
+++ b/cap-primitives/src/posish/fs/open_options_ext.rs
@@ -11,15 +11,13 @@ impl OpenOptionsExt {
             custom_flags: 0,
         }
     }
-}
 
-impl std::os::unix::fs::OpenOptionsExt for OpenOptionsExt {
-    fn mode(&mut self, mode: u32) -> &mut Self {
+    pub(crate) fn mode(&mut self, mode: u32) -> &mut Self {
         self.mode = mode;
         self
     }
 
-    fn custom_flags(&mut self, flags: i32) -> &mut Self {
+    pub(crate) fn custom_flags(&mut self, flags: i32) -> &mut Self {
         self.custom_flags = flags;
         self
     }

--- a/cap-primitives/src/winx/fs/open_options_ext.rs
+++ b/cap-primitives/src/winx/fs/open_options_ext.rs
@@ -19,30 +19,28 @@ impl OpenOptionsExt {
             security_qos_flags: 0,
         }
     }
-}
 
-impl std::os::windows::fs::OpenOptionsExt for OpenOptionsExt {
-    fn access_mode(&mut self, mode: u32) -> &mut Self {
+    pub(crate) fn access_mode(&mut self, mode: u32) -> &mut Self {
         self.access_mode = Some(mode);
         self
     }
 
-    fn share_mode(&mut self, share: u32) -> &mut Self {
+    pub(crate) fn share_mode(&mut self, share: u32) -> &mut Self {
         self.share_mode = share;
         self
     }
 
-    fn custom_flags(&mut self, flags: u32) -> &mut Self {
+    pub(crate) fn custom_flags(&mut self, flags: u32) -> &mut Self {
         self.custom_flags = flags;
         self
     }
 
-    fn attributes(&mut self, attributes: u32) -> &mut Self {
+    pub(crate) fn attributes(&mut self, attributes: u32) -> &mut Self {
         self.attributes = attributes;
         self
     }
 
-    fn security_qos_flags(&mut self, flags: u32) -> &mut Self {
+    pub(crate) fn security_qos_flags(&mut self, flags: u32) -> &mut Self {
         self.security_qos_flags = flags | winbase::SECURITY_SQOS_PRESENT;
         self
     }


### PR DESCRIPTION
This removes the pinned nightly version and updates to support `open_options_ext_as_flags`. It's waiting on support in `async-std` for that feature.