### PR TITLE
Handle Windows systems with symlinks not enabled.

### DIFF
--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -11,7 +11,10 @@ use std::{
     path::Path,
     str,
 };
-use sys_common::io::{tmpdir, TempDir};
+use sys_common::{
+    io::{tmpdir, TempDir},
+    symlink_supported,
+};
 
 #[cfg(not(windows))]
 fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(src: P, tmpdir: &TempDir, dst: Q) -> io::Result<()> {
@@ -212,6 +215,10 @@ fn file_test_directoryinfo_readdir() {
 
 #[test]
 fn follow_dotdot_symlink() {
+    if !symlink_supported() {
+        return;
+    }
+
     let tmpdir = tmpdir();
     check!(tmpdir.create_dir_all("a/b"));
     check!(symlink_dir("..", &tmpdir, "a/b/c"));
@@ -234,6 +241,10 @@ fn follow_dotdot_symlink() {
 
 #[test]
 fn follow_file_symlink() {
+    if !symlink_supported() {
+        return;
+    }
+
     let tmpdir = tmpdir();
 
     check!(tmpdir.create("file"));
@@ -414,6 +425,10 @@ fn symlink_hard_link_ambient() {
     #[cfg(windows)]
     use std::os::windows::fs::symlink_file;
 
+    if !symlink_supported() {
+        return;
+    }
+
     let dir = tempfile::tempdir().unwrap();
 
     check!(std::fs::File::create(dir.path().join("file")));
@@ -469,6 +484,10 @@ fn symlink_hard_link_ambient() {
 /// symbolic links.
 #[test]
 fn symlink_hard_link() {
+    if !symlink_supported() {
+        return;
+    }
+
     let tmpdir = tmpdir();
 
     check!(tmpdir.create("file"));

--- a/tests/sys_common/mod.rs
+++ b/tests/sys_common/mod.rs
@@ -48,3 +48,38 @@ macro_rules! error_contains {
         }
     };
 }
+
+// The following is derived from Rust's src/tools/cargo/crates/cargo-test-support/src/lib.rs
+// at revision a78a62fc996ba16f7a111c99520b23f77029f4eb.
+
+#[cfg(windows)]
+#[allow(dead_code)]
+pub fn symlink_supported() -> bool {
+    let dir = tempfile::tempdir().unwrap();
+
+    let src = dir.path().join("symlink_src");
+    std::fs::write(&src, "").unwrap();
+    let dst = dir.path().join("symlink_dst");
+    let result = match std::os::windows::fs::symlink_file(&src, &dst) {
+        Ok(_) => {
+            std::fs::remove_file(&dst).unwrap();
+            true
+        }
+        Err(e) => {
+            eprintln!(
+                "symlinks not supported: {:?}\n\
+                 Windows 10 users should enable developer mode.",
+                e
+            );
+            false
+        }
+    };
+    std::fs::remove_file(&src).unwrap();
+    return result;
+}
+
+#[cfg(not(windows))]
+#[allow(dead_code)]
+pub fn symlink_supported() -> bool {
+    true
+}


### PR DESCRIPTION
On Windows, symlinks are not enabled by default, so add checks to the
tests which use symlinks.