### PR TITLE
Mark `from_std` functions as `unsafe`.

### DIFF
--- a/cap-async-std/src/fs/dir_entry.rs
+++ b/cap-async-std/src/fs/dir_entry.rs
@@ -31,21 +31,22 @@ impl DirEntry {
     /// Open the file for reading.
     #[inline]
     pub fn open(&self) -> io::Result<File> {
-        self.inner.open().map(|f| File::from_std(f.into()))
+        let file = self.inner.open()?.into();
+        Ok(unsafe { File::from_std(file) })
     }
 
     /// Open the file with the given options.
     #[inline]
     pub fn open_with(&self, options: &OpenOptions) -> io::Result<File> {
-        self.inner
-            .open_with(options)
-            .map(|f| File::from_std(f.into()))
+        let file = self.inner.open_with(options)?.into();
+        Ok(unsafe { File::from_std(file) })
     }
 
     /// Open the entry as a directory.
     #[inline]
     pub fn open_dir(&self) -> io::Result<Dir> {
-        self.inner.open_dir().map(|f| Dir::from_std_file(f.into()))
+        let file = self.inner.open_dir()?.into();
+        Ok(unsafe { Dir::from_std_file(file) })
     }
 
     /// Removes the file from its filesystem.

--- a/cap-async-std/src/fs/file.rs
+++ b/cap-async-std/src/fs/file.rs
@@ -31,8 +31,13 @@ pub struct File {
 
 impl File {
     /// Constructs a new instance of `Self` from the given `async_std::fs::File`.
+    ///
+    /// # Safety
+    ///
+    /// `async_std::fs::File` is not sandboxed and may access any path that the host
+    /// process has access to.
     #[inline]
-    pub fn from_std(std: fs::File) -> Self {
+    pub unsafe fn from_std(std: fs::File) -> Self {
         Self { std }
     }
 

--- a/cap-async-std/src/fs/mod.rs
+++ b/cap-async-std/src/fs/mod.rs
@@ -14,10 +14,10 @@
 //! This combined with a lack of absolute paths provides a natural
 //! capability-oriented interface.
 //!
-//! This crate uses the existing `std::path::Path` rather than having its own
-//! path type, however while `std::path::Path` is mostly just a pure datatype,
-//! it includes aliases for several `std::fs` functions. To preserve the
-//! capability-oriented interface, avoid using `std::path::Path`'s
+//! This crate uses the existing `async_std::path::Path` rather than having its own
+//! path type, however while `async_std::path::Path` is mostly just a pure datatype,
+//! it includes aliases for several `async_std::fs` functions. To preserve the
+//! capability-oriented interface, avoid using `async_std::path::Path`'s
 //! `canonicalize`, `read_link`, `read_dir`, `metadata`, and `symlink_metadata`
 //! functions.
 //!

--- a/cap-async-std/src/fs_utf8/dir.rs
+++ b/cap-async-std/src/fs_utf8/dir.rs
@@ -32,8 +32,13 @@ impl Dir {
     ///
     /// To prevent race conditions on Windows, the file must be opened without
     /// `FILE_SHARE_DELETE`.
+    ///
+    /// # Safety
+    ///
+    /// `async_std::fs::File` is not sandboxed and may access any path that the host
+    /// process has access to.
     #[inline]
-    pub fn from_std_file(std_file: fs::File) -> Self {
+    pub unsafe fn from_std_file(std_file: fs::File) -> Self {
         Self::from_cap_std(crate::fs::Dir::from_std_file(std_file))
     }
 
@@ -322,11 +327,11 @@ impl Dir {
 
     /// Changes the permissions found on a file or a directory.
     ///
-    /// This corresponds to [`std::fs::set_permissions`], but only accesses paths
+    /// This corresponds to [`async_std::fs::set_permissions`], but only accesses paths
     /// relative to `self`. Also, on some platforms, this function may fail if the
     /// file or directory cannot be opened for reading or writing first.
     ///
-    /// [`std::fs::set_permissions`]: https://doc.rust-lang.org/std/fs/fn.set_permissions.html
+    /// [`async_std::fs::set_permissions`]: https://docs.rs/async-std/latest/async_std/fs/fn.set_permissions.html
     pub fn set_permissions<P: AsRef<str>>(&self, path: P, perm: Permissions) -> io::Result<()> {
         let path = from_utf8(path)?;
         self.cap_std.set_permissions(path, perm)

--- a/cap-async-std/src/fs_utf8/file.rs
+++ b/cap-async-std/src/fs_utf8/file.rs
@@ -30,8 +30,13 @@ pub struct File {
 
 impl File {
     /// Constructs a new instance of `Self` from the given `async_std::fs::File`.
+    ///
+    /// # Safety
+    ///
+    /// `async_std::fs::File` is not sandboxed and may access any path that the host
+    /// process has access to.
     #[inline]
-    pub fn from_std(std: fs::File) -> Self {
+    pub unsafe fn from_std(std: fs::File) -> Self {
         Self::from_cap_std(crate::fs::File::from_std(std))
     }
 

--- a/cap-async-std/src/fs_utf8/mod.rs
+++ b/cap-async-std/src/fs_utf8/mod.rs
@@ -32,7 +32,7 @@ pub use read_dir::*;
 // Re-export things from `cap_std::fs` that we can use as-is.
 pub use crate::fs::{DirBuilder, FileType, Metadata, OpenOptions, Permissions};
 
-fn from_utf8<P: AsRef<str>>(path: P) -> std::io::Result<std::path::PathBuf> {
+fn from_utf8<P: AsRef<str>>(path: P) -> std::io::Result<async_std::path::PathBuf> {
     #[cfg(not(windows))]
     let path = {
         #[cfg(unix)]
@@ -50,7 +50,7 @@ fn from_utf8<P: AsRef<str>>(path: P) -> std::io::Result<std::path::PathBuf> {
     Ok(path.into())
 }
 
-fn to_utf8<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<String> {
+fn to_utf8<P: AsRef<async_std::path::Path>>(path: P) -> std::io::Result<String> {
     // For now, for WASI use the same logic as other OS's, but
     // in the future, the idea is we could avoid this.
     let osstr = path.as_ref().as_os_str();

--- a/cap-async-std/src/lib.rs
+++ b/cap-async-std/src/lib.rs
@@ -45,3 +45,6 @@ pub mod fs_utf8;
 pub mod net;
 pub mod os;
 pub mod time;
+// For now, re-export `path`; see
+// https://github.com/bytecodealliance/cap-std/issues/88
+pub use async_std::path;

--- a/cap-async-std/src/net/catalog.rs
+++ b/cap-async-std/src/net/catalog.rs
@@ -20,7 +20,7 @@ impl Catalog {
             self.cap.check_addr(&addr)?;
             // TODO: when compiling for WASI, use WASI-specific methods instead
             match net::TcpListener::bind(addr).await {
-                Ok(tcp_listener) => return Ok(TcpListener::from_std(tcp_listener)),
+                Ok(tcp_listener) => return Ok(unsafe { TcpListener::from_std(tcp_listener) }),
                 Err(e) => last_err = Some(e),
             }
         }
@@ -39,7 +39,7 @@ impl Catalog {
             self.cap.check_addr(&addr)?;
             // TODO: when compiling for WASI, use WASI-specific methods instead
             match net::TcpStream::connect(addr).await {
-                Ok(tcp_stream) => return Ok(TcpStream::from_std(tcp_stream)),
+                Ok(tcp_stream) => return Ok(unsafe { TcpStream::from_std(tcp_stream) }),
                 Err(e) => last_err = Some(e),
             }
         }
@@ -59,7 +59,7 @@ impl Catalog {
         for addr in addrs {
             self.cap.check_addr(&addr)?;
             match net::UdpSocket::bind(addr).await {
-                Ok(udp_socket) => return Ok(UdpSocket::from_std(udp_socket)),
+                Ok(udp_socket) => return Ok(unsafe { UdpSocket::from_std(udp_socket) }),
                 Err(e) => last_err = Some(e),
             }
         }

--- a/cap-async-std/src/net/incoming.rs
+++ b/cap-async-std/src/net/incoming.rs
@@ -18,8 +18,13 @@ pub struct Incoming<'a> {
 
 impl<'a> Incoming<'a> {
     /// Constructs a new instance of `Self` from the given `async_std::net::Incoming`.
+    ///
+    /// # Safety
+    ///
+    /// `async_std::net::Incoming` is not sandboxed and may access any address that the host
+    /// process has access to.
     #[inline]
-    pub fn from_std(std: net::Incoming<'a>) -> Self {
+    pub unsafe fn from_std(std: net::Incoming<'a>) -> Self {
         Self { std }
     }
 }
@@ -29,8 +34,12 @@ impl<'a> Stream for Incoming<'a> {
 
     #[inline]
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        Stream::poll_next(Pin::new(&mut self.std), cx)
-            .map(|poll| poll.map(|result| result.map(TcpStream::from_std)))
+        Stream::poll_next(Pin::new(&mut self.std), cx).map(|poll| {
+            poll.map(|result| {
+                let tcp_stream = result?;
+                Ok(unsafe { TcpStream::from_std(tcp_stream) })
+            })
+        })
     }
 
     #[inline]

--- a/cap-async-std/src/net/tcp_stream.rs
+++ b/cap-async-std/src/net/tcp_stream.rs
@@ -27,8 +27,13 @@ pub struct TcpStream {
 
 impl TcpStream {
     /// Constructs a new instance of `Self` from the given `async_std::net::TcpStream`.
+    ///
+    /// # Safety
+    ///
+    /// `async_std::net::TcpStream` is not sandboxed and may access any address that the host
+    /// process has access to.
     #[inline]
-    pub fn from_std(std: net::TcpStream) -> Self {
+    pub unsafe fn from_std(std: net::TcpStream) -> Self {
         Self { std }
     }
 

--- a/cap-async-std/src/net/udp_socket.rs
+++ b/cap-async-std/src/net/udp_socket.rs
@@ -26,8 +26,13 @@ pub struct UdpSocket {
 
 impl UdpSocket {
     /// Constructs a new instance of `Self` from the given `async_std::net::UdpSocket`.
+    ///
+    /// # Safety
+    ///
+    /// `async_std::net::UdpSocket` is not sandboxed and may access any address that the host
+    /// process has access to.
     #[inline]
-    pub fn from_std(std: net::UdpSocket) -> Self {
+    pub unsafe fn from_std(std: net::UdpSocket) -> Self {
         Self { std }
     }
 

--- a/cap-async-std/src/os/unix/net/unix_datagram.rs
+++ b/cap-async-std/src/os/unix/net/unix_datagram.rs
@@ -28,8 +28,13 @@ pub struct UnixDatagram {
 
 impl UnixDatagram {
     /// Constructs a new instance of `Self` from the given `async_std::os::unix::net::UnixDatagram`.
+    ///
+    /// # Safety
+    ///
+    /// `async_std::os::unix::net::UnixDatagram` is not sandboxed and may access any address that
+    /// the host process has access to.
     #[inline]
-    pub fn from_std(std: unix::net::UnixDatagram) -> Self {
+    pub unsafe fn from_std(std: unix::net::UnixDatagram) -> Self {
         Self { std }
     }
 
@@ -42,7 +47,8 @@ impl UnixDatagram {
     /// [`async_std::os::unix::net::UnixDatagram::unbound`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.unbound
     #[inline]
     pub fn unbound() -> io::Result<Self> {
-        unix::net::UnixDatagram::unbound().map(Self::from_std)
+        let unix_datagram = unix::net::UnixDatagram::unbound()?;
+        Ok(unsafe { Self::from_std(unix_datagram) })
     }
 
     /// Creates an unnamed pair of connected sockets.
@@ -54,7 +60,8 @@ impl UnixDatagram {
     /// [`async_std::os::unix::net::UnixDatagram::pair`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.pair
     #[inline]
     pub fn pair() -> io::Result<(Self, Self)> {
-        unix::net::UnixDatagram::pair().map(|(a, b)| (Self::from_std(a), Self::from_std(b)))
+        unix::net::UnixDatagram::pair()
+            .map(|(a, b)| unsafe { (Self::from_std(a), Self::from_std(b)) })
     }
 
     // async_std doesn't have `try_clone`.

--- a/cap-async-std/src/os/unix/net/unix_stream.rs
+++ b/cap-async-std/src/os/unix/net/unix_stream.rs
@@ -26,8 +26,13 @@ pub struct UnixStream {
 
 impl UnixStream {
     /// Constructs a new instance of `Self` from the given `async_std::os::unix::net::UnixStream`.
+    ///
+    /// # Safety
+    ///
+    /// `async_std::os::unix::net::UnixStream` is not sandboxed and may access any address that
+    /// the host process has access to.
     #[inline]
-    pub fn from_std(std: unix::net::UnixStream) -> Self {
+    pub unsafe fn from_std(std: unix::net::UnixStream) -> Self {
         Self { std }
     }
 
@@ -40,7 +45,8 @@ impl UnixStream {
     /// [`async_std::os::unix::net::UnixStream::pair`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixStream.html#method.pair
     #[inline]
     pub fn pair() -> io::Result<(Self, Self)> {
-        unix::net::UnixStream::pair().map(|(a, b)| (Self::from_std(a), Self::from_std(b)))
+        unix::net::UnixStream::pair()
+            .map(|(a, b)| unsafe { (Self::from_std(a), Self::from_std(b)) })
     }
 
     // async_std doesn't have `try_clone`.

--- a/cap-dir-ext/src/dir_ext.rs
+++ b/cap-dir-ext/src/dir_ext.rs
@@ -315,22 +315,22 @@ impl DirExt for cap_async_std::fs::Dir {
     #[cfg(not(windows))]
     #[inline]
     fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(&self, src: P, dst: Q) -> io::Result<()> {
-        self.symlink(src, dst)
+        self.symlink(src.as_ref(), dst.as_ref())
     }
 
     #[cfg(not(windows))]
     #[inline]
     fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(&self, src: P, dst: Q) -> io::Result<()> {
-        self.symlink(src, dst)
+        self.symlink(src.as_ref(), dst.as_ref())
     }
 
     #[cfg(windows)]
     #[inline]
     fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(&self, src: P, dst: Q) -> io::Result<()> {
         if self.metadata(src.as_ref())?.is_dir() {
-            self.symlink_dir(src, dst)
+            self.symlink_dir(src.as_ref(), dst.as_ref())
         } else {
-            self.symlink_file(src, dst)
+            self.symlink_file(src.as_ref(), dst.as_ref())
         }
     }
 

--- a/cap-std/src/fs/dir_entry.rs
+++ b/cap-std/src/fs/dir_entry.rs
@@ -30,19 +30,22 @@ impl DirEntry {
     /// Open the file for reading.
     #[inline]
     pub fn open(&self) -> io::Result<File> {
-        self.inner.open().map(File::from_std)
+        let file = self.inner.open()?;
+        Ok(unsafe { File::from_std(file) })
     }
 
     /// Open the file with the given options.
     #[inline]
     pub fn open_with(&self, options: &OpenOptions) -> io::Result<File> {
-        self.inner.open_with(options).map(File::from_std)
+        let file = self.inner.open_with(options)?;
+        Ok(unsafe { File::from_std(file) })
     }
 
     /// Open the entry as a directory.
     #[inline]
     pub fn open_dir(&self) -> io::Result<Dir> {
-        self.inner.open_dir().map(Dir::from_std_file)
+        let dir = self.inner.open_dir()?;
+        Ok(unsafe { Dir::from_std_file(dir) })
     }
 
     /// Removes the file from its filesystem.

--- a/cap-std/src/fs/file.rs
+++ b/cap-std/src/fs/file.rs
@@ -36,8 +36,12 @@ pub struct File {
 
 impl File {
     /// Constructs a new instance of `Self` from the given `std::fs::File`.
+    ///
+    /// # Safety
+    ///
+    /// `std::fs::File` is not sandboxed and may access any path that the host
     #[inline]
-    pub fn from_std(std: fs::File) -> Self {
+    pub unsafe fn from_std(std: fs::File) -> Self {
         Self { std }
     }
 
@@ -108,7 +112,8 @@ impl File {
     /// [`std::fs::File::try_clone`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.try_clone
     #[inline]
     pub fn try_clone(&self) -> io::Result<Self> {
-        Ok(Self::from_std(self.std.try_clone()?))
+        let file = self.std.try_clone()?;
+        Ok(unsafe { Self::from_std(file) })
     }
 
     /// Changes the permissions on the underlying file.

--- a/cap-std/src/fs_utf8/dir.rs
+++ b/cap-std/src/fs_utf8/dir.rs
@@ -31,8 +31,13 @@ impl Dir {
     ///
     /// To prevent race conditions on Windows, the file must be opened without
     /// `FILE_SHARE_DELETE`.
+    ///
+    /// # Safety
+    ///
+    /// `std::fs::File` is not sandboxed and may access any path that the host
+    /// process has access to.
     #[inline]
-    pub fn from_std_file(std_file: fs::File) -> Self {
+    pub unsafe fn from_std_file(std_file: fs::File) -> Self {
         Self::from_cap_std(crate::fs::Dir::from_std_file(std_file))
     }
 

--- a/cap-std/src/fs_utf8/file.rs
+++ b/cap-std/src/fs_utf8/file.rs
@@ -35,8 +35,12 @@ pub struct File {
 
 impl File {
     /// Constructs a new instance of `Self` from the given `std::fs::File`.
+    ///
+    /// # Safety
+    ///
+    /// `std::fs::File` is not sandboxed and may access any path that the host
     #[inline]
-    pub fn from_std(std: fs::File) -> Self {
+    pub unsafe fn from_std(std: fs::File) -> Self {
         Self::from_cap_std(crate::fs::File::from_std(std))
     }
 

--- a/cap-std/src/lib.rs
+++ b/cap-std/src/lib.rs
@@ -45,3 +45,6 @@ pub mod fs_utf8;
 pub mod net;
 pub mod os;
 pub mod time;
+// For now, re-export `path`; see
+// https://github.com/bytecodealliance/cap-std/issues/88
+pub use std::path;

--- a/cap-std/src/net/catalog.rs
+++ b/cap-std/src/net/catalog.rs
@@ -20,7 +20,7 @@ impl Catalog {
             self.cap.check_addr(&addr)?;
             // TODO: when compiling for WASI, use WASI-specific methods instead
             match net::TcpListener::bind(addr) {
-                Ok(tcp_listener) => return Ok(TcpListener::from_std(tcp_listener)),
+                Ok(tcp_listener) => return Ok(unsafe { TcpListener::from_std(tcp_listener) }),
                 Err(e) => last_err = Some(e),
             }
         }
@@ -39,7 +39,7 @@ impl Catalog {
             self.cap.check_addr(&addr)?;
             // TODO: when compiling for WASI, use WASI-specific methods instead
             match net::TcpStream::connect(addr) {
-                Ok(tcp_stream) => return Ok(TcpStream::from_std(tcp_stream)),
+                Ok(tcp_stream) => return Ok(unsafe { TcpStream::from_std(tcp_stream) }),
                 Err(e) => last_err = Some(e),
             }
         }
@@ -56,7 +56,8 @@ impl Catalog {
         timeout: Duration,
     ) -> io::Result<TcpStream> {
         self.cap.check_addr(addr)?;
-        net::TcpStream::connect_timeout(addr, timeout).map(TcpStream::from_std)
+        let tcp_stream = net::TcpStream::connect_timeout(addr, timeout)?;
+        Ok(unsafe { TcpStream::from_std(tcp_stream) })
     }
 
     #[inline]
@@ -67,7 +68,7 @@ impl Catalog {
         for addr in addrs {
             self.cap.check_addr(&addr)?;
             match net::UdpSocket::bind(addr) {
-                Ok(udp_socket) => return Ok(UdpSocket::from_std(udp_socket)),
+                Ok(udp_socket) => return Ok(unsafe { UdpSocket::from_std(udp_socket) }),
                 Err(e) => last_err = Some(e),
             }
         }

--- a/cap-std/src/net/tcp_stream.rs
+++ b/cap-std/src/net/tcp_stream.rs
@@ -28,8 +28,13 @@ pub struct TcpStream {
 
 impl TcpStream {
     /// Constructs a new instance of `Self` from the given `std::net::TcpStream`.
+    ///
+    /// # Safety
+    ///
+    /// `std::net::TcpStream` is not sandboxed and may access any address that the host
+    /// process has access to.
     #[inline]
-    pub fn from_std(std: net::TcpStream) -> Self {
+    pub unsafe fn from_std(std: net::TcpStream) -> Self {
         Self { std }
     }
 
@@ -60,7 +65,8 @@ impl TcpStream {
     /// [`std::net::TcpStream::try_clone`]: https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.try_clone
     #[inline]
     pub fn try_clone(&self) -> io::Result<Self> {
-        Ok(Self::from_std(self.std.try_clone()?))
+        let tcp_stream = self.std.try_clone()?;
+        Ok(unsafe { Self::from_std(tcp_stream) })
     }
 
     /// Sets the read timeout to the timeout specified.

--- a/cap-std/src/net/udp_socket.rs
+++ b/cap-std/src/net/udp_socket.rs
@@ -26,8 +26,13 @@ pub struct UdpSocket {
 
 impl UdpSocket {
     /// Constructs a new instance of `Self` from the given `std::net::UdpSocket`.
+    ///
+    /// # Safety
+    ///
+    /// `std::net::UdpSocket` is not sandboxed and may access any address that the host
+    /// process has access to.
     #[inline]
-    pub fn from_std(std: net::UdpSocket) -> Self {
+    pub unsafe fn from_std(std: net::UdpSocket) -> Self {
         Self { std }
     }
 
@@ -78,7 +83,8 @@ impl UdpSocket {
     /// [`std::net::UdpSocket::try_clone`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.try_clone
     #[inline]
     pub fn try_clone(&self) -> io::Result<Self> {
-        Ok(Self::from_std(self.std.try_clone()?))
+        let udp_socket = self.std.try_clone()?;
+        Ok(unsafe { Self::from_std(udp_socket) })
     }
 
     /// Sets the read timeout to the timeout specified.

--- a/cap-std/src/os/unix/net/incoming.rs
+++ b/cap-std/src/os/unix/net/incoming.rs
@@ -13,8 +13,13 @@ pub struct Incoming<'a> {
 
 impl<'a> Incoming<'a> {
     /// Constructs a new instance of `Self` from the given `std::os::unix::net::Incoming`.
+    ///
+    /// # Safety
+    ///
+    /// `std::net::Incoming` is not sandboxed and may access any address that the host
+    /// process has access to.
     #[inline]
-    pub fn from_std(std: unix::net::Incoming<'a>) -> Self {
+    pub unsafe fn from_std(std: unix::net::Incoming<'a>) -> Self {
         Self { std }
     }
 }
@@ -24,9 +29,10 @@ impl<'a> Iterator for Incoming<'a> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        self.std
-            .next()
-            .map(|result| result.map(UnixStream::from_std))
+        self.std.next().map(|result| {
+            let unix_stream = result?;
+            Ok(unsafe { UnixStream::from_std(unix_stream) })
+        })
     }
 
     #[inline]

--- a/cap-std/src/os/unix/net/unix_datagram.rs
+++ b/cap-std/src/os/unix/net/unix_datagram.rs
@@ -29,8 +29,13 @@ pub struct UnixDatagram {
 
 impl UnixDatagram {
     /// Constructs a new instance of `Self` from the given `std::os::unix::net::UnixDatagram`.
+    ///
+    /// # Safety
+    ///
+    /// `std::os::unix::net::UnixDatagram` is not sandboxed and may access any address that
+    /// the host process has access to.
     #[inline]
-    pub fn from_std(std: unix::net::UnixDatagram) -> Self {
+    pub unsafe fn from_std(std: unix::net::UnixDatagram) -> Self {
         Self { std }
     }
 
@@ -43,7 +48,8 @@ impl UnixDatagram {
     /// [`std::os::unix::net::UnixDatagram::unbound`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.unbound
     #[inline]
     pub fn unbound() -> io::Result<Self> {
-        unix::net::UnixDatagram::unbound().map(Self::from_std)
+        let unix_datagram = unix::net::UnixDatagram::unbound()?;
+        Ok(unsafe { Self::from_std(unix_datagram) })
     }
 
     /// Creates an unnamed pair of connected sockets.
@@ -55,7 +61,8 @@ impl UnixDatagram {
     /// [`std::os::unix::net::UnixDatagram::pair`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.pair
     #[inline]
     pub fn pair() -> io::Result<(Self, Self)> {
-        unix::net::UnixDatagram::pair().map(|(a, b)| (Self::from_std(a), Self::from_std(b)))
+        unix::net::UnixDatagram::pair()
+            .map(|(a, b)| unsafe { (Self::from_std(a), Self::from_std(b)) })
     }
 
     /// Creates a new independently owned handle to the underlying socket.
@@ -65,7 +72,8 @@ impl UnixDatagram {
     /// [`std::os::unix::net::UnixDatagram::try_clone`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.try_clone
     #[inline]
     pub fn try_clone(&self) -> io::Result<Self> {
-        Ok(Self::from_std(self.std.try_clone()?))
+        let unix_datagram = self.std.try_clone()?;
+        Ok(unsafe { Self::from_std(unix_datagram) })
     }
 
     /// Returns the address of this socket.

--- a/examples/async_std_fs_misc.rs
+++ b/examples/async_std_fs_misc.rs
@@ -33,7 +33,7 @@ fn touch(dir: &mut Dir, path: &Path) -> io::Result<()> {
 
 #[async_std::main]
 async fn main() {
-    let mut cwd = Dir::from_std_file(async_std::fs::File::open(".").await.expect("!"));
+    let mut cwd = unsafe { Dir::open_ambient_dir(".") }.expect("!");
 
     println!("`mkdir a`");
 

--- a/examples/std_fs_misc.rs
+++ b/examples/std_fs_misc.rs
@@ -32,7 +32,7 @@ fn touch(dir: &mut Dir, path: &Path) -> io::Result<()> {
 }
 
 fn main() {
-    let mut cwd = Dir::from_std_file(std::fs::File::open(".").expect("!"));
+    let mut cwd = unsafe { Dir::open_ambient_dir(".") }.expect("!");
 
     println!("`mkdir a`");
 


### PR DESCRIPTION
These functions take arguments which may be constructed with APIs that
use ambient authorities, so mark them as unsafe.