### PR TITLE
Add a `FileTypeExt` feature.

### DIFF
--- a/cap-fs-ext/src/file_type_ext.rs
+++ b/cap-fs-ext/src/file_type_ext.rs
@@ -1,0 +1,110 @@
+#[cfg(windows)]
+use cap_primitives::fs::_WindowsFileTypeExt;
+
+/// Extension trait for `FileType`.
+pub trait FileTypeExt {
+    /// Returns `true` if this file type is a block device.
+    ///
+    /// This corresponds to
+    /// [`std::os::unix::fs::FileTypeExt::is_block_device`], except that it's
+    /// supported on Windows platforms as well.
+    ///
+    /// [`std::os::unix::fs::FileTypeExt::is_block_device`]: https://doc.rust-lang.org/stable/std/os/unix/fs/trait.FileTypeExt.html#tymethod.is_block_device
+    fn is_block_device(&self) -> bool;
+
+    /// Returns `true` if this file type is a char device.
+    ///
+    /// This corresponds to
+    /// [`std::os::unix::fs::FileTypeExt::is_char_device`], except that it's
+    /// supported on Windows platforms as well.
+    ///
+    /// [`std::os::unix::fs::FileTypeExt::is_char_device`]: https://doc.rust-lang.org/stable/std/os/unix/fs/trait.FileTypeExt.html#tymethod.is_char_device
+    fn is_char_device(&self) -> bool;
+
+    /// Returns `true` if this file type is a fifo.
+    ///
+    /// This corresponds to
+    /// [`std::os::unix::fs::FileTypeExt::is_fifo`], except that it's supported
+    /// on Windows platforms as well.
+    ///
+    /// [`std::os::unix::fs::FileTypeExt::is_fifo`]: https://doc.rust-lang.org/stable/std/os/unix/fs/trait.FileTypeExt.html#tymethod.is_fifo
+    fn is_fifo(&self) -> bool;
+
+    /// Returns `true` if this file type is a socket.
+    ///
+    /// This corresponds to
+    /// [`std::os::unix::fs::FileTypeExt::is_socket`], except that it's
+    /// supported on Windows platforms as well.
+    ///
+    /// [`std::os::unix::fs::FileTypeExt::is_socket`]: https://doc.rust-lang.org/stable/std/os/unix/fs/trait.FileTypeExt.html#tymethod.is_socket
+    fn is_socket(&self) -> bool;
+}
+
+#[cfg(not(windows))]
+impl FileTypeExt for std::fs::FileType {
+    #[inline]
+    fn is_block_device(&self) -> bool {
+        std::os::unix::fs::FileTypeExt::is_block_device(self)
+    }
+
+    #[inline]
+    fn is_char_device(&self) -> bool {
+        std::os::unix::fs::FileTypeExt::is_char_device(self)
+    }
+
+    #[inline]
+    fn is_fifo(&self) -> bool {
+        std::os::unix::fs::FileTypeExt::is_fifo(self)
+    }
+
+    #[inline]
+    fn is_socket(&self) -> bool {
+        std::os::unix::fs::FileTypeExt::is_socket(self)
+    }
+}
+
+#[cfg(all(not(windows), any(feature = "std", feature = "async_std")))]
+impl FileTypeExt for cap_primitives::fs::FileType {
+    #[inline]
+    fn is_block_device(&self) -> bool {
+        std::os::unix::fs::FileTypeExt::is_block_device(self)
+    }
+
+    #[inline]
+    fn is_char_device(&self) -> bool {
+        std::os::unix::fs::FileTypeExt::is_char_device(self)
+    }
+
+    #[inline]
+    fn is_fifo(&self) -> bool {
+        std::os::unix::fs::FileTypeExt::is_fifo(self)
+    }
+
+    #[inline]
+    fn is_socket(&self) -> bool {
+        std::os::unix::fs::FileTypeExt::is_socket(self)
+    }
+}
+
+#[cfg(all(windows, any(feature = "std", feature = "async_std")))]
+impl FileTypeExt for cap_primitives::fs::FileType {
+    #[inline]
+    fn is_block_device(&self) -> bool {
+        unsafe { _WindowsFileTypeExt::is_block_device(self) }
+    }
+
+    #[inline]
+    fn is_char_device(&self) -> bool {
+        unsafe { _WindowsFileTypeExt::is_char_device(self) }
+    }
+
+    #[inline]
+    fn is_fifo(&self) -> bool {
+        unsafe { _WindowsFileTypeExt::is_fifo(self) }
+    }
+
+    #[inline]
+    fn is_socket(&self) -> bool {
+        unsafe { _WindowsFileTypeExt::is_socket(self) }
+    }
+}

--- a/cap-fs-ext/src/lib.rs
+++ b/cap-fs-ext/src/lib.rs
@@ -13,11 +13,13 @@
 )]
 
 mod dir_ext;
+mod file_type_ext;
 mod metadata_ext;
 mod open_options_follow_ext;
 
 #[cfg(all(any(feature = "std", feature = "async_std"), feature = "fs_utf8"))]
 pub use dir_ext::DirExtUtf8;
 pub use dir_ext::{DirExt, SystemTimeSpec};
+pub use file_type_ext::FileTypeExt;
 pub use metadata_ext::MetadataExt;
 pub use open_options_follow_ext::{FollowSymlinks, OpenOptionsFollowExt};

--- a/cap-primitives/src/fs/file_type.rs
+++ b/cap-primitives/src/fs/file_type.rs
@@ -1,7 +1,6 @@
 //! The `FileType` struct.
 
 use crate::fs::FileTypeExt;
-use std::fs;
 
 /// `FileType`'s inner state.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -33,20 +32,6 @@ enum Inner {
 pub struct FileType(Inner);
 
 impl FileType {
-    /// Constructs a new instance of `Self` from the given `std::fs::FileType`.
-    #[inline]
-    pub(crate) fn from_std(std: fs::FileType) -> Self {
-        if std.is_dir() {
-            Self::dir()
-        } else if std.is_file() {
-            Self::file()
-        } else if let Some(ext) = FileTypeExt::from_std(std) {
-            Self::ext(ext)
-        } else {
-            Self::unknown()
-        }
-    }
-
     /// Creates a `FileType` for which `is_dir()` returns `true`.
     #[inline]
     pub const fn dir() -> Self {
@@ -163,4 +148,20 @@ impl std::os::windows::fs::FileTypeExt for FileType {
     fn is_symlink_file(&self) -> bool {
         self.0 == Inner::Ext(FileTypeExt::symlink_file())
     }
+}
+
+/// Extension trait to allow `is_block_device` etc. to be exposed by
+/// the `cap-fs-ext` crate.
+///
+/// # Safety
+///
+/// This is hidden from the main API since this functionality isn't present in `std`.
+/// Use `cap_fs_ext::FileTypeExt` instead of calling this directly.
+#[cfg(windows)]
+#[doc(hidden)]
+pub trait _WindowsFileTypeExt {
+    unsafe fn is_block_device(&self) -> bool;
+    unsafe fn is_char_device(&self) -> bool;
+    unsafe fn is_fifo(&self) -> bool;
+    unsafe fn is_socket(&self) -> bool;
 }

--- a/cap-primitives/src/posish/fs/metadata_ext.rs
+++ b/cap-primitives/src/posish/fs/metadata_ext.rs
@@ -30,7 +30,8 @@ pub(crate) struct MetadataExt {
 }
 
 impl MetadataExt {
-    /// Constructs a new instance of `Self` from the given `std::fs::Metadata`.
+    /// Constructs a new instance of `Self` from the given `std::fs::File` and
+    /// `std::fs::Metadata`.
     #[inline]
     pub(crate) fn from(_file: &fs::File, std: &fs::Metadata) -> io::Result<Self> {
         // On Posish-style platforms, the `Metadata` has everything we need.

--- a/cap-primitives/src/winx/fs/dir_entry_inner.rs
+++ b/cap-primitives/src/winx/fs/dir_entry_inner.rs
@@ -1,6 +1,7 @@
 use super::open_options_to_std;
 use crate::fs::{
-    open, open_ambient_dir, FileType, FollowSymlinks, Metadata, OpenOptions, ReadDir, ReadDirInner,
+    open, open_ambient_dir, FileType, FileTypeExt, FollowSymlinks, Metadata, OpenOptions, ReadDir,
+    ReadDirInner,
 };
 use std::{ffi::OsString, fmt, fs, io};
 
@@ -58,7 +59,7 @@ impl DirEntryInner {
 
     #[inline]
     pub(crate) fn file_type(&self) -> io::Result<FileType> {
-        self.std.file_type().map(FileType::from_std)
+        self.std.file_type().map(FileTypeExt::from_std)
     }
 
     #[inline]

--- a/cap-primitives/src/winx/fs/file_type_ext.rs
+++ b/cap-primitives/src/winx/fs/file_type_ext.rs
@@ -1,40 +1,72 @@
-use std::fs;
+use crate::fs::FileType;
+use std::{fs, io, os::windows::io::AsRawHandle};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub(crate) enum FileTypeExt {
+    CharacterDevice,
+    Fifo,
     #[cfg(feature = "windows_file_type_ext")]
     SymlinkFile,
-
     #[cfg(feature = "windows_file_type_ext")]
     SymlinkDir,
-
-    #[cfg(not(feature = "windows_file_type_ext"))]
     SymlinkUnknown,
 }
 
 impl FileTypeExt {
-    /// Constructs a new instance of `Self` from the given `std::fs::FileType`.
-    #[cfg(feature = "windows_file_type_ext")]
-    #[inline]
-    pub(crate) fn from_std(std: fs::FileType) -> Option<Self> {
-        use std::os::windows::fs::FileTypeExt;
-        Some(if std.is_symlink_file() {
-            Self::SymlinkFile
-        } else if std.is_symlink_dir() {
-            Self::SymlinkDir
-        } else {
-            return None;
-        })
+    /// Constructs a new instance of `Self` from the given `std::fs::File` and
+    /// `std::fs::Metadata`.
+    pub(crate) fn from(file: &fs::File, metadata: &fs::Metadata) -> io::Result<FileType> {
+        // Check for the things we can do with just metadata.
+        let file_type = Self::from_just_metadata(metadata);
+        if file_type != FileType::unknown() {
+            return Ok(file_type);
+        }
+
+        // Use the open file to check for one of the exotic file types.
+        let file_type = unsafe { winx::file::get_file_type(file.as_raw_handle())? };
+        if file_type.is_char() {
+            return Ok(FileType::ext(FileTypeExt::CharacterDevice));
+        }
+        if file_type.is_pipe() {
+            return Ok(FileType::ext(FileTypeExt::Fifo));
+        }
+
+        Ok(FileType::unknown())
     }
 
-    #[cfg(not(feature = "windows_file_type_ext"))]
+    /// Constructs a new instance of `Self` from the given `std::fs::Metadata`.
     #[inline]
-    pub(crate) fn from_std(std: fs::FileType) -> Option<Self> {
-        Some(if std.is_symlink() {
-            Self::SymlinkUnknown
-        } else {
-            return None;
-        })
+    pub(crate) fn from_just_metadata(metadata: &fs::Metadata) -> FileType {
+        let std = metadata.file_type();
+        Self::from_std(std)
+    }
+
+    /// Constructs a new instance of `Self` from the given `std::fs::FileType`.
+    #[inline]
+    pub(crate) fn from_std(std: fs::FileType) -> FileType {
+        if std.is_file() {
+            return FileType::file();
+        }
+        if std.is_dir() {
+            return FileType::dir();
+        }
+
+        #[cfg(feature = "windows_file_type_ext")]
+        {
+            use std::os::windows::fs::FileTypeExt;
+            if std.is_symlink_file() {
+                return FileType::ext(Self::SymlinkFile);
+            }
+            if std.is_symlink_dir() {
+                return FileType::ext(Self::SymlinkDir);
+            }
+        }
+
+        if std.is_symlink() {
+            return FileType::ext(Self::SymlinkUnknown);
+        }
+
+        FileType::unknown()
     }
 
     /// Creates a `FileType` for which `is_symlink_file()` returns `true`.
@@ -53,7 +85,35 @@ impl FileTypeExt {
 
     #[inline]
     pub(crate) fn is_symlink(&self) -> bool {
-        // All current `FileTypeExt` types are symlinks.
-        true
+        match self {
+            #[cfg(feature = "windows_file_type_ext")]
+            Self::SymlinkFile | Self::SymlinkDir => true,
+            Self::SymlinkUnknown => true,
+            _ => false,
+        }
+    }
+}
+
+#[cfg(windows)]
+#[doc(hidden)]
+impl crate::fs::_WindowsFileTypeExt for crate::fs::FileType {
+    #[inline]
+    unsafe fn is_block_device(&self) -> bool {
+        false
+    }
+
+    #[inline]
+    unsafe fn is_char_device(&self) -> bool {
+        *self == FileType::ext(FileTypeExt::CharacterDevice)
+    }
+
+    #[inline]
+    unsafe fn is_fifo(&self) -> bool {
+        *self == FileType::ext(FileTypeExt::Fifo)
+    }
+
+    #[inline]
+    unsafe fn is_socket(&self) -> bool {
+        false
     }
 }

--- a/tests/file-type-ext.rs
+++ b/tests/file-type-ext.rs
@@ -1,0 +1,37 @@
+// This file contains tests for `cap_fs_ext::FileTypeExt`.
+
+#[macro_use]
+mod sys_common;
+
+use cap_fs_ext::FileTypeExt;
+use sys_common::io::tmpdir;
+
+#[test]
+fn test_file_type_ext() {
+    let tmpdir = tmpdir();
+    let a = check!(tmpdir.create("a"));
+
+    let tmpdir_metadata = check!(tmpdir.dir_metadata());
+    let a_metadata = check!(a.metadata());
+
+    assert!(!tmpdir_metadata.file_type().is_char_device());
+    assert!(!a_metadata.file_type().is_char_device());
+
+    assert!(!tmpdir_metadata.file_type().is_block_device());
+    assert!(!a_metadata.file_type().is_block_device());
+
+    assert!(!tmpdir_metadata.file_type().is_fifo());
+    assert!(!a_metadata.file_type().is_fifo());
+
+    assert!(!tmpdir_metadata.file_type().is_socket());
+    assert!(!a_metadata.file_type().is_socket());
+
+    assert!(tmpdir_metadata.file_type().is_dir());
+    assert!(!a_metadata.file_type().is_dir());
+
+    assert!(!tmpdir_metadata.file_type().is_file());
+    assert!(a_metadata.file_type().is_file());
+
+    assert!(!tmpdir_metadata.file_type().is_symlink());
+    assert!(!a_metadata.file_type().is_symlink());
+}

--- a/tests/metadata-ext.rs
+++ b/tests/metadata-ext.rs
@@ -7,7 +7,7 @@ use cap_fs_ext::MetadataExt;
 use sys_common::io::tmpdir;
 
 #[test]
-fn test_cap_fs_ext() {
+fn test_metadata_ext() {
     let tmpdir = tmpdir();
     let a = check!(tmpdir.create("a"));
     let b = check!(tmpdir.create("b"));


### PR DESCRIPTION
This allows testing for character, block, and other special types of
files in a portable manner.