### PR TITLE
Fully switch to plain cfg attributes for nightly features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ winx = "0.21.0"
 
 [features]
 default = []
-nightly = []
 fs_utf8 = ["cap-std/fs_utf8", "cap-async-std/fs_utf8"]
 
 [badges]

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,18 @@
 fn main() {
-    match rustc_version::version_meta()
+    if let rustc_version::Channel::Nightly = rustc_version::version_meta()
         .expect("query rustc release channel")
         .channel
     {
-        rustc_version::Channel::Nightly => {
-            println!("cargo:rustc-cfg=nightly");
+        for feature in &[
+            "can_vector",         // https://github.com/rust-lang/rust/issues/69941
+            "read_initializer",   // https://github.com/rust-lang/rust/issues/42788
+            "seek_convenience",   // https://github.com/rust-lang/rust/issues/59359
+            "with_options",       // https://github.com/rust-lang/rust/issues/65439
+            "write_all_vectored", // https://github.com/rust-lang/rust/issues/70436
+            "windows_by_handle",  // https://github.com/rust-lang/rust/issues/63010
+            "windows_file_type_ext",
+        ] {
+            println!("cargo:rustc-cfg={}", feature);
         }
-        _ => {}
     }
 }

--- a/cap-async-std/Cargo.toml
+++ b/cap-async-std/Cargo.toml
@@ -23,16 +23,4 @@ maintenance = { status = "actively-developed" }
 
 [features]
 default = []
-can_vector = [] # https://github.com/rust-lang/rust/issues/69941
 fs_utf8 = ["arf-strings"]
-nightly = [
-    "with_options",
-    "can_vector",
-    "read_initializer",
-    "write_all_vectored",
-    "seek_convenience",
-]
-read_initializer = [] # https://github.com/rust-lang/rust/issues/42788
-seek_convenience = [] # https://github.com/rust-lang/rust/issues/59359
-with_options = [] # https://github.com/rust-lang/rust/issues/65439
-write_all_vectored = [] # https://github.com/rust-lang/rust/issues/70436

--- a/cap-fs-ext/Cargo.toml
+++ b/cap-fs-ext/Cargo.toml
@@ -24,8 +24,6 @@ default = ["std"]
 fs_utf8 = ["arf-strings"]
 std = ["cap-std"]
 async_std = ["cap-async-std"]
-nightly = ["windows_by_handle"]
-windows_by_handle = [] # https://github.com/rust-lang/rust/issues/63010
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/cap-fs-ext/src/lib.rs
+++ b/cap-fs-ext/src/lib.rs
@@ -1,10 +1,7 @@
 //! Extension traits for `Dir`
 
 #![deny(missing_docs)]
-#![cfg_attr(
-    all(windows, feature = "windows_by_handle"),
-    feature(windows_by_handle)
-)]
+#![cfg_attr(all(windows, windows_by_handle), feature(windows_by_handle))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/bytecodealliance/cap-std/main/media/cap-std.svg"
 )]

--- a/cap-fs-ext/src/metadata_ext.rs
+++ b/cap-fs-ext/src/metadata_ext.rs
@@ -1,7 +1,7 @@
-#[cfg(all(windows, feature = "windows_by_handle"))]
+#[cfg(all(windows, windows_by_handle))]
 use std::os::windows::fs::MetadataExt as _WindowsByHandle;
 
-#[cfg(all(windows, not(feature = "windows_by_handle")))]
+#[cfg(all(windows, not(windows_by_handle)))]
 use cap_primitives::fs::_WindowsByHandle;
 
 /// Extension trait for `Metadata`.
@@ -51,7 +51,7 @@ impl MetadataExt for std::fs::Metadata {
     }
 }
 
-#[cfg(all(windows, feature = "windows_by_handle"))]
+#[cfg(all(windows, windows_by_handle))]
 impl MetadataExt for std::fs::Metadata {
     #[inline]
     fn dev(&self) -> u64 {

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -38,12 +38,5 @@ winapi = { version = "0.3.9", features = [
     "winioctl"
 ] }
 
-[features]
-default = ["windows_security_qos_flags"]
-nightly = ["windows_by_handle", "windows_file_type_ext"]
-windows_by_handle = [] # https://github.com/rust-lang/rust/issues/63010
-windows_file_type_ext = []
-windows_security_qos_flags = [] # https://github.com/rust-lang/rust/pull/74074
-
 [badges]
 maintenance = { status = "actively-developed" }

--- a/cap-primitives/src/fs/dir_entry.rs
+++ b/cap-primitives/src/fs/dir_entry.rs
@@ -93,7 +93,7 @@ impl DirEntry {
         self.inner.file_name()
     }
 
-    #[cfg(any(not(windows), feature = "windows_by_handle"))]
+    #[cfg(any(not(windows), windows_by_handle))]
     #[cfg_attr(windows, allow(dead_code))]
     #[inline]
     pub(crate) fn is_same_file(&self, metadata: &Metadata) -> io::Result<bool> {

--- a/cap-primitives/src/fs/file_type.rs
+++ b/cap-primitives/src/fs/file_type.rs
@@ -137,7 +137,7 @@ impl std::os::vxworks::fs::FileTypeExt for FileType {
     }
 }
 
-#[cfg(all(windows, feature = "windows_file_type_ext"))]
+#[cfg(all(windows, windows_file_type_ext))]
 impl std::os::windows::fs::FileTypeExt for FileType {
     #[inline]
     fn is_symlink_dir(&self) -> bool {

--- a/cap-primitives/src/fs/metadata.rs
+++ b/cap-primitives/src/fs/metadata.rs
@@ -165,7 +165,7 @@ impl Metadata {
     }
 
     /// Determine if `self` and `other` refer to the same inode on the same device.
-    #[cfg(any(not(windows), feature = "windows_by_handle"))]
+    #[cfg(any(not(windows), windows_by_handle))]
     pub(crate) fn is_same_file(&self, other: &Self) -> bool {
         self.ext.is_same_file(&other.ext)
     }
@@ -350,7 +350,7 @@ impl std::os::vxworks::fs::MetadataExt for Metadata {
     }
 }
 
-#[cfg(all(windows, feature = "windows_by_handle"))]
+#[cfg(all(windows, windows_by_handle))]
 impl std::os::windows::fs::MetadataExt for Metadata {
     #[inline]
     fn file_attributes(&self) -> u32 {
@@ -400,7 +400,7 @@ impl std::os::windows::fs::MetadataExt for Metadata {
 ///
 /// This is hidden from the main API since this functionality isn't present in `std`.
 /// Use `cap_fs_ext::MetadataExt` instead of calling this directly.
-#[cfg(all(windows, not(feature = "windows_by_handle")))]
+#[cfg(all(windows, not(windows_by_handle)))]
 #[doc(hidden)]
 pub trait _WindowsByHandle {
     unsafe fn volume_serial_number(&self) -> Option<u32>;

--- a/cap-primitives/src/fs/open_options.rs
+++ b/cap-primitives/src/fs/open_options.rs
@@ -206,18 +206,10 @@ impl std::os::windows::fs::OpenOptionsExt for OpenOptions {
         self
     }
 
-    /// Re-enable this once https://github.com/rust-lang/rust/pull/74074 is in stable.
-    #[cfg(feature = "windows_security_qos_flags")]
     #[inline]
     fn security_qos_flags(&mut self, flags: u32) -> &mut Self {
         self.ext.security_qos_flags(flags);
         self
-    }
-
-    #[cfg(not(feature = "windows_security_qos_flags"))]
-    #[inline]
-    fn security_qos_flags(&mut self, _flags: u32) -> &mut std::fs::OpenOptions {
-        panic!("OpenOptionsExt::security_qos_flags requires the \"nightly\" feature")
     }
 }
 

--- a/cap-primitives/src/lib.rs
+++ b/cap-primitives/src/lib.rs
@@ -2,14 +2,8 @@
 
 #![deny(missing_docs)]
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
-#![cfg_attr(
-    all(windows, feature = "windows_by_handle"),
-    feature(windows_by_handle)
-)]
-#![cfg_attr(
-    all(windows, feature = "windows_file_type_ext"),
-    feature(windows_file_type_ext)
-)]
+#![cfg_attr(all(windows, windows_by_handle), feature(windows_by_handle))]
+#![cfg_attr(all(windows, windows_file_type_ext), feature(windows_file_type_ext))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/bytecodealliance/cap-std/main/media/cap-std.svg"
 )]

--- a/cap-primitives/src/winx/fs/dir_entry_inner.rs
+++ b/cap-primitives/src/winx/fs/dir_entry_inner.rs
@@ -68,7 +68,7 @@ impl DirEntryInner {
     }
 
     #[inline]
-    #[cfg(feature = "windows_by_handle")]
+    #[cfg(windows_by_handle)]
     pub(crate) fn is_same_file(&self, metadata: &Metadata) -> io::Result<bool> {
         // Don't use `self.metadata()`, because that doesn't include the
         // volume serial number which we need.

--- a/cap-primitives/src/winx/fs/file_type_ext.rs
+++ b/cap-primitives/src/winx/fs/file_type_ext.rs
@@ -5,9 +5,9 @@ use std::{fs, io, os::windows::io::AsRawHandle};
 pub(crate) enum FileTypeExt {
     CharacterDevice,
     Fifo,
-    #[cfg(feature = "windows_file_type_ext")]
+    #[cfg(windows_file_type_ext)]
     SymlinkFile,
-    #[cfg(feature = "windows_file_type_ext")]
+    #[cfg(windows_file_type_ext)]
     SymlinkDir,
     SymlinkUnknown,
 }
@@ -51,7 +51,7 @@ impl FileTypeExt {
             return FileType::dir();
         }
 
-        #[cfg(feature = "windows_file_type_ext")]
+        #[cfg(windows_file_type_ext)]
         {
             use std::os::windows::fs::FileTypeExt;
             if std.is_symlink_file() {
@@ -70,14 +70,14 @@ impl FileTypeExt {
     }
 
     /// Creates a `FileType` for which `is_symlink_file()` returns `true`.
-    #[cfg(feature = "windows_file_type_ext")]
+    #[cfg(windows_file_type_ext)]
     #[inline]
     pub(crate) const fn symlink_file() -> Self {
         Self::SymlinkFile
     }
 
     /// Creates a `FileType` for which `is_symlink_dir()` returns `true`.
-    #[cfg(feature = "windows_file_type_ext")]
+    #[cfg(windows_file_type_ext)]
     #[inline]
     pub(crate) const fn symlink_dir() -> Self {
         Self::SymlinkDir
@@ -86,7 +86,7 @@ impl FileTypeExt {
     #[inline]
     pub(crate) fn is_symlink(&self) -> bool {
         match self {
-            #[cfg(feature = "windows_file_type_ext")]
+            #[cfg(windows_file_type_ext)]
             Self::SymlinkFile | Self::SymlinkDir => true,
             Self::SymlinkUnknown => true,
             _ => false,

--- a/cap-primitives/src/winx/fs/is_same_file.rs
+++ b/cap-primitives/src/winx/fs/is_same_file.rs
@@ -2,7 +2,7 @@ use crate::fs::Metadata;
 use std::{fs, io};
 
 /// Determine if `a` and `b` refer to the same inode on the same device.
-#[cfg(feature = "windows_by_handle")]
+#[cfg(windows_by_handle)]
 #[allow(dead_code)]
 pub(crate) fn is_same_file(a: &fs::File, b: &fs::File) -> io::Result<bool> {
     let a_metadata = Metadata::from_std(a.metadata()?);
@@ -11,7 +11,7 @@ pub(crate) fn is_same_file(a: &fs::File, b: &fs::File) -> io::Result<bool> {
 }
 
 /// Determine if `a` and `b` are metadata for the same inode on the same device.
-#[cfg(feature = "windows_by_handle")]
+#[cfg(windows_by_handle)]
 #[allow(dead_code)]
 pub(crate) fn is_same_file_metadata(a: &Metadata, b: &Metadata) -> io::Result<bool> {
     use std::os::windows::fs::MetadataExt;
@@ -23,12 +23,12 @@ pub(crate) fn is_same_file_metadata(a: &Metadata, b: &Metadata) -> io::Result<bo
 /// This is similar to `is_same_file`, but is conservative, and doesn't depend
 /// on nightly-only features.
 pub(crate) fn is_different_file(a: &fs::File, b: &fs::File) -> io::Result<bool> {
-    #[cfg(feature = "windows_by_handle")]
+    #[cfg(windows_by_handle)]
     {
         is_same_file(a, b).map(|same| !same)
     }
 
-    #[cfg(not(feature = "windows_by_handle"))]
+    #[cfg(not(windows_by_handle))]
     {
         let a_metadata = Metadata::from_std(a.metadata()?);
         let b_metadata = Metadata::from_std(b.metadata()?);
@@ -41,12 +41,12 @@ pub(crate) fn is_different_file(a: &fs::File, b: &fs::File) -> io::Result<bool> 
 /// This is similar to `is_same_file_metadata`, but is conservative, and doesn't depend
 /// on nightly-only features.
 pub(crate) fn is_different_file_metadata(a: &Metadata, b: &Metadata) -> io::Result<bool> {
-    #[cfg(feature = "windows_by_handle")]
+    #[cfg(windows_by_handle)]
     {
         is_same_file_metadata(a, b).map(|same| !same)
     }
 
-    #[cfg(not(feature = "windows_by_handle"))]
+    #[cfg(not(windows_by_handle))]
     {
         // Conservatively just compare creation times.
         Ok(a.created()? != b.created()?)

--- a/cap-primitives/src/winx/fs/metadata_ext.rs
+++ b/cap-primitives/src/winx/fs/metadata_ext.rs
@@ -19,7 +19,7 @@ impl MetadataExt {
     /// `std::fs::Metadata`.
     #[inline]
     pub(crate) fn from(file: &fs::File, std: &fs::Metadata) -> io::Result<Self> {
-        #[cfg(feature = "windows_by_handle")]
+        #[cfg(windows_by_handle)]
         let (volume_serial_number, number_of_links, file_index) = {
             use std::os::windows::fs::MetadataExt;
             (
@@ -29,7 +29,7 @@ impl MetadataExt {
             )
         };
 
-        #[cfg(not(feature = "windows_by_handle"))]
+        #[cfg(not(windows_by_handle))]
         let (volume_serial_number, number_of_links, file_index) = {
             let fileinfo = winx::file::get_fileinfo(file)?;
             (
@@ -81,7 +81,7 @@ impl MetadataExt {
     }
 
     /// Determine if `self` and `other` refer to the same inode on the same device.
-    #[cfg(feature = "windows_by_handle")]
+    #[cfg(windows_by_handle)]
     pub(crate) fn is_same_file(&self, other: &Self) -> bool {
         // From [MSDN]:
         // The identifier (low and high parts) and the volume serial number
@@ -108,7 +108,7 @@ impl MetadataExt {
     }
 }
 
-#[cfg(feature = "windows_by_handle")]
+#[cfg(windows_by_handle)]
 impl std::os::windows::fs::MetadataExt for MetadataExt {
     #[inline]
     fn file_attributes(&self) -> u32 {
@@ -151,7 +151,7 @@ impl std::os::windows::fs::MetadataExt for MetadataExt {
     }
 }
 
-#[cfg(all(windows, not(feature = "windows_by_handle")))]
+#[cfg(all(windows, not(windows_by_handle)))]
 #[doc(hidden)]
 impl crate::fs::_WindowsByHandle for crate::fs::Metadata {
     #[inline]

--- a/cap-primitives/src/winx/fs/open_options_ext.rs
+++ b/cap-primitives/src/winx/fs/open_options_ext.rs
@@ -1,6 +1,4 @@
-#[cfg(feature = "windows_security_qos_flags")]
-use winapi::um::winbase;
-use winapi::um::winnt;
+use winapi::um::{winbase, winnt};
 
 #[derive(Debug, Clone)]
 pub(crate) struct OpenOptionsExt {
@@ -44,15 +42,8 @@ impl std::os::windows::fs::OpenOptionsExt for OpenOptionsExt {
         self
     }
 
-    /// Re-enable this once https://github.com/rust-lang/rust/pull/74074 is in stable.
-    #[cfg(feature = "windows_security_qos_flags")]
     fn security_qos_flags(&mut self, flags: u32) -> &mut Self {
         self.security_qos_flags = flags | winbase::SECURITY_SQOS_PRESENT;
         self
-    }
-
-    #[cfg(not(feature = "windows_security_qos_flags"))]
-    fn security_qos_flags(&mut self, _flags: u32) -> &mut std::fs::OpenOptions {
-        panic!("OpenOptionsExt::security_qos_flags requires the \"nightly\" feature")
     }
 }

--- a/cap-primitives/src/winx/fs/remove_dir_all_impl.rs
+++ b/cap-primitives/src/winx/fs/remove_dir_all_impl.rs
@@ -1,7 +1,7 @@
 use crate::fs::{
     read_dir_unchecked, remove_dir, remove_file, remove_open_dir, stat, FollowSymlinks,
 };
-#[cfg(feature = "windows_file_type_ext")]
+#[cfg(windows_file_type_ext)]
 use std::os::windows::fs::FileTypeExt;
 use std::{
     fs, io,
@@ -28,7 +28,7 @@ pub(crate) fn remove_open_dir_all_impl(dir: fs::File) -> io::Result<()> {
     remove_open_dir(dir)
 }
 
-#[cfg(feature = "windows_file_type_ext")]
+#[cfg(windows_file_type_ext)]
 fn remove_dir_all_recursive(start: &fs::File, path: &Path) -> io::Result<()> {
     // Code derived from `remove_dir_all_recursive` in Rust's
     // library/std/src/sys/windows/fs.rs at revision
@@ -49,7 +49,7 @@ fn remove_dir_all_recursive(start: &fs::File, path: &Path) -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(not(feature = "windows_file_type_ext"))]
+#[cfg(not(windows_file_type_ext))]
 fn remove_dir_all_recursive(start: &fs::File, path: &Path) -> io::Result<()> {
     for child in read_dir_unchecked(start, path)? {
         let child = child?;

--- a/cap-std/Cargo.toml
+++ b/cap-std/Cargo.toml
@@ -22,16 +22,4 @@ maintenance = { status = "actively-developed" }
 
 [features]
 default = []
-can_vector = [] # https://github.com/rust-lang/rust/issues/69941
 fs_utf8 = ["arf-strings"]
-nightly = [
-    "with_options",
-    "can_vector",
-    "read_initializer",
-    "write_all_vectored",
-    "seek_convenience",
-]
-read_initializer = [] # https://github.com/rust-lang/rust/issues/42788
-seek_convenience = [] # https://github.com/rust-lang/rust/issues/59359
-with_options = [] # https://github.com/rust-lang/rust/issues/65439
-write_all_vectored = [] # https://github.com/rust-lang/rust/issues/70436

--- a/cap-std/src/fs/file.rs
+++ b/cap-std/src/fs/file.rs
@@ -1,8 +1,8 @@
-#[cfg(feature = "with_options")]
+#[cfg(with_options)]
 use crate::fs::OpenOptions;
 use crate::fs::{Metadata, Permissions};
 use cap_primitives::fs::is_read_write;
-#[cfg(feature = "read_initializer")]
+#[cfg(read_initializer)]
 use std::io::Initializer;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -57,7 +57,7 @@ impl File {
     ///
     /// [`std::fs::File::with_options`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.with_options
     #[inline]
-    #[cfg(feature = "with_options")]
+    #[cfg(with_options)]
     pub fn with_options() -> OpenOptions {
         OpenOptions::new()
     }
@@ -226,13 +226,13 @@ impl Read for File {
         self.std.read_to_string(buf)
     }
 
-    #[cfg(feature = "can_vector")]
+    #[cfg(can_vector)]
     #[inline]
     fn is_read_vectored(&self) -> bool {
         self.std.is_read_vectored()
     }
 
-    #[cfg(feature = "read_initializer")]
+    #[cfg(read_initializer)]
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
         self.std.initializer()
@@ -265,13 +265,13 @@ impl Read for &File {
         (&mut &self.std).read_to_string(buf)
     }
 
-    #[cfg(feature = "can_vector")]
+    #[cfg(can_vector)]
     #[inline]
     fn is_read_vectored(&self) -> bool {
         (&mut &self.std).is_read_vectored()
     }
 
-    #[cfg(feature = "read_initializer")]
+    #[cfg(read_initializer)]
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
         (&mut &self.std).initializer()
@@ -299,13 +299,13 @@ impl Write for File {
         self.std.write_all(buf)
     }
 
-    #[cfg(feature = "can_vector")]
+    #[cfg(can_vector)]
     #[inline]
     fn is_write_vectored(&self) -> bool {
         self.std.is_write_vectored()
     }
 
-    #[cfg(feature = "write_all_vectored")]
+    #[cfg(write_all_vectored)]
     #[inline]
     fn write_all_vectored(&mut self, bufs: &mut [IoSlice]) -> io::Result<()> {
         self.std.write_all_vectored(bufs)
@@ -333,13 +333,13 @@ impl Write for &File {
         (&mut &self.std).write_all(buf)
     }
 
-    #[cfg(feature = "can_vector")]
+    #[cfg(can_vector)]
     #[inline]
     fn is_write_vectored(&self) -> bool {
         (&mut &self.std).is_write_vectored()
     }
 
-    #[cfg(feature = "write_all_vectored")]
+    #[cfg(write_all_vectored)]
     #[inline]
     fn write_all_vectored(&mut self, bufs: &mut [IoSlice]) -> io::Result<()> {
         (&mut &self.std).write_all_vectored(bufs)
@@ -352,13 +352,13 @@ impl Seek for File {
         self.std.seek(pos)
     }
 
-    #[cfg(feature = "seek_convenience")]
+    #[cfg(seek_convenience)]
     #[inline]
     fn stream_len(&mut self) -> io::Result<u64> {
         self.std.stream_len()
     }
 
-    #[cfg(feature = "seek_convenience")]
+    #[cfg(seek_convenience)]
     #[inline]
     fn stream_position(&mut self) -> io::Result<u64> {
         self.std.stream_position()
@@ -371,13 +371,13 @@ impl Seek for &File {
         (&mut &self.std).seek(pos)
     }
 
-    #[cfg(feature = "seek_convenience")]
+    #[cfg(seek_convenience)]
     #[inline]
     fn stream_len(&mut self) -> io::Result<u64> {
         (&mut &self.std).stream_len()
     }
 
-    #[cfg(feature = "seek_convenience")]
+    #[cfg(seek_convenience)]
     #[inline]
     fn stream_position(&mut self) -> io::Result<u64> {
         (&mut &self.std).stream_position()

--- a/cap-std/src/fs_utf8/file.rs
+++ b/cap-std/src/fs_utf8/file.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "with_options")]
+#[cfg(with_options)]
 use crate::fs::OpenOptions;
 use crate::fs::{Metadata, Permissions};
-#[cfg(feature = "read_initializer")]
+#[cfg(read_initializer)]
 use std::io::Initializer;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -62,7 +62,7 @@ impl File {
     ///
     /// [`std::fs::File::with_options`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.with_options
     #[inline]
-    #[cfg(feature = "with_options")]
+    #[cfg(with_options)]
     pub fn with_options() -> OpenOptions {
         crate::fs::File::with_options()
     }
@@ -205,13 +205,13 @@ impl Read for File {
         self.cap_std.read_to_string(buf)
     }
 
-    #[cfg(feature = "can_vector")]
+    #[cfg(can_vector)]
     #[inline]
     fn is_read_vectored(&self) -> bool {
         self.cap_std.is_read_vectored()
     }
 
-    #[cfg(feature = "read_initializer")]
+    #[cfg(read_initializer)]
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
         self.cap_std.initializer()
@@ -244,13 +244,13 @@ impl Read for &File {
         (&mut &self.cap_std).read_to_string(buf)
     }
 
-    #[cfg(feature = "can_vector")]
+    #[cfg(can_vector)]
     #[inline]
     fn is_read_vectored(&self) -> bool {
         (&mut &self.cap_std).is_read_vectored()
     }
 
-    #[cfg(feature = "read_initializer")]
+    #[cfg(read_initializer)]
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
         (&mut &self.cap_std).initializer()
@@ -278,13 +278,13 @@ impl Write for File {
         self.cap_std.write_all(buf)
     }
 
-    #[cfg(feature = "can_vector")]
+    #[cfg(can_vector)]
     #[inline]
     fn is_write_vectored(&self) -> bool {
         self.cap_std.is_write_vectored()
     }
 
-    #[cfg(feature = "write_all_vectored")]
+    #[cfg(write_all_vectored)]
     #[inline]
     fn write_all_vectored(&mut self, bufs: &mut [IoSlice]) -> io::Result<()> {
         self.cap_std.write_all_vectored(bufs)
@@ -312,13 +312,13 @@ impl Write for &File {
         (&mut &self.cap_std).write_all(buf)
     }
 
-    #[cfg(feature = "can_vector")]
+    #[cfg(can_vector)]
     #[inline]
     fn is_write_vectored(&self) -> bool {
         (&mut &self.cap_std).is_write_vectored()
     }
 
-    #[cfg(feature = "write_all_vectored")]
+    #[cfg(write_all_vectored)]
     #[inline]
     fn write_all_vectored(&mut self, bufs: &mut [IoSlice]) -> io::Result<()> {
         (&mut &self.cap_std).write_all_vectored(bufs)
@@ -331,13 +331,13 @@ impl Seek for File {
         self.cap_std.seek(pos)
     }
 
-    #[cfg(feature = "seek_convenience")]
+    #[cfg(seek_convenience)]
     #[inline]
     fn stream_len(&mut self) -> io::Result<u64> {
         self.cap_std.stream_len()
     }
 
-    #[cfg(feature = "seek_convenience")]
+    #[cfg(seek_convenience)]
     #[inline]
     fn stream_position(&mut self) -> io::Result<u64> {
         self.cap_std.stream_position()
@@ -350,13 +350,13 @@ impl Seek for &File {
         (&mut &self.cap_std).seek(pos)
     }
 
-    #[cfg(feature = "seek_convenience")]
+    #[cfg(seek_convenience)]
     #[inline]
     fn stream_len(&mut self) -> io::Result<u64> {
         (&mut &self.cap_std).stream_len()
     }
 
-    #[cfg(feature = "seek_convenience")]
+    #[cfg(seek_convenience)]
     #[inline]
     fn stream_position(&mut self) -> io::Result<u64> {
         (&mut &self.cap_std).stream_position()

--- a/cap-std/src/lib.rs
+++ b/cap-std/src/lib.rs
@@ -26,11 +26,11 @@
 
 #![deny(missing_docs)]
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
-#![cfg_attr(feature = "can_vector", feature(can_vector))]
-#![cfg_attr(feature = "read_initializer", feature(read_initializer))]
-#![cfg_attr(feature = "seek_convenience", feature(seek_convenience))]
-#![cfg_attr(feature = "with_options", feature(with_options))]
-#![cfg_attr(feature = "write_all_vectored", feature(write_all_vectored))]
+#![cfg_attr(can_vector, feature(can_vector))]
+#![cfg_attr(read_initializer, feature(read_initializer))]
+#![cfg_attr(seek_convenience, feature(seek_convenience))]
+#![cfg_attr(with_options, feature(with_options))]
+#![cfg_attr(write_all_vectored, feature(write_all_vectored))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/bytecodealliance/cap-std/main/media/cap-std.svg"
 )]

--- a/cap-std/src/net/tcp_stream.rs
+++ b/cap-std/src/net/tcp_stream.rs
@@ -1,5 +1,5 @@
 use crate::net::{Shutdown, SocketAddr};
-#[cfg(feature = "read_initializer")]
+#[cfg(read_initializer)]
 use std::io::Initializer;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -255,13 +255,13 @@ impl Read for TcpStream {
         self.std.read_to_string(buf)
     }
 
-    #[cfg(feature = "can_vector")]
+    #[cfg(can_vector)]
     #[inline]
     fn is_read_vectored(&self) -> bool {
         self.std.is_read_vectored()
     }
 
-    #[cfg(feature = "read_initializer")]
+    #[cfg(read_initializer)]
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
         self.std.initializer()
@@ -294,13 +294,13 @@ impl Read for &TcpStream {
         (&mut &self.std).read_to_string(buf)
     }
 
-    #[cfg(feature = "can_vector")]
+    #[cfg(can_vector)]
     #[inline]
     fn is_read_vectored(&self) -> bool {
         (&mut &self.std).is_read_vectored()
     }
 
-    #[cfg(feature = "read_initializer")]
+    #[cfg(read_initializer)]
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
         (&mut &self.std).initializer()
@@ -328,13 +328,13 @@ impl Write for TcpStream {
         self.std.write_all(buf)
     }
 
-    #[cfg(feature = "can_vector")]
+    #[cfg(can_vector)]
     #[inline]
     fn is_write_vectored(&self) -> bool {
         self.std.is_write_vectored()
     }
 
-    #[cfg(feature = "write_all_vectored")]
+    #[cfg(write_all_vectored)]
     #[inline]
     fn write_all_vectored(&mut self, bufs: &mut [IoSlice]) -> io::Result<()> {
         self.std.write_all_vectored(bufs)
@@ -362,13 +362,13 @@ impl Write for &TcpStream {
         (&mut &self.std).write_all(buf)
     }
 
-    #[cfg(feature = "can_vector")]
+    #[cfg(can_vector)]
     #[inline]
     fn is_write_vectored(&self) -> bool {
         (&mut &self.std).is_write_vectored()
     }
 
-    #[cfg(feature = "write_all_vectored")]
+    #[cfg(write_all_vectored)]
     #[inline]
     fn write_all_vectored(&mut self, bufs: &mut [IoSlice]) -> io::Result<()> {
         (&mut &self.std).write_all_vectored(bufs)

--- a/cap-std/src/os/unix/net/unix_stream.rs
+++ b/cap-std/src/os/unix/net/unix_stream.rs
@@ -1,5 +1,5 @@
 use crate::{net::Shutdown, os::unix::net::SocketAddr};
-#[cfg(feature = "read_initializer")]
+#[cfg(read_initializer)]
 use std::io::Initializer;
 use std::{
     io::{self, IoSlice, IoSliceMut, Read, Write},
@@ -199,13 +199,13 @@ impl Read for UnixStream {
         self.std.read_to_string(buf)
     }
 
-    #[cfg(feature = "can_vector")]
+    #[cfg(can_vector)]
     #[inline]
     fn is_read_vectored(&self) -> bool {
         self.std.is_read_vectored()
     }
 
-    #[cfg(feature = "read_initializer")]
+    #[cfg(read_initializer)]
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
         self.std.initializer()
@@ -238,13 +238,13 @@ impl Read for &UnixStream {
         (&mut &self.std).read_to_string(buf)
     }
 
-    #[cfg(feature = "can_vector")]
+    #[cfg(can_vector)]
     #[inline]
     fn is_read_vectored(&self) -> bool {
         (&mut &self.std).is_read_vectored()
     }
 
-    #[cfg(feature = "read_initializer")]
+    #[cfg(read_initializer)]
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
         (&mut &self.std).initializer()
@@ -272,13 +272,13 @@ impl Write for UnixStream {
         self.std.write_all(buf)
     }
 
-    #[cfg(feature = "can_vector")]
+    #[cfg(can_vector)]
     #[inline]
     fn is_write_vectored(&self) -> bool {
         self.std.is_write_vectored()
     }
 
-    #[cfg(feature = "write_all_vectored")]
+    #[cfg(write_all_vectored)]
     #[inline]
     fn write_all_vectored(&mut self, bufs: &mut [IoSlice]) -> io::Result<()> {
         self.std.write_all_vectored(bufs)
@@ -306,13 +306,13 @@ impl Write for &UnixStream {
         (&mut &self.std).write_all(buf)
     }
 
-    #[cfg(feature = "can_vector")]
+    #[cfg(can_vector)]
     #[inline]
     fn is_write_vectored(&self) -> bool {
         (&mut &self.std).is_write_vectored()
     }
 
-    #[cfg(feature = "write_all_vectored")]
+    #[cfg(write_all_vectored)]
     #[inline]
     fn write_all_vectored(&mut self, bufs: &mut [IoSlice]) -> io::Result<()> {
         (&mut &self.std).write_all_vectored(bufs)


### PR DESCRIPTION
Cargo features are meant to be additive, so switch from using
`cfg(feature = "can_vector")` to using `cfg(can_vector)`, and similar.

While here, enable the windows_security_qos_flags functionality by
default, as it's now available on stable.