### PR TITLE
Open directories for `Dir` with `O_PATH` when available.

### DIFF
--- a/cap-async-std/src/fs/dir.rs
+++ b/cap-async-std/src/fs/dir.rs
@@ -6,12 +6,12 @@ use async_std::os::wasi::{
 };
 use async_std::{
     fs, io,
-    path::{Component, Path, PathBuf},
+    path::{Path, PathBuf},
 };
 use cap_primitives::fs::{
-    canonicalize, copy, create_dir, hard_link, open, open_ambient_dir, open_dir, read_dir,
-    read_link, remove_dir, remove_dir_all, remove_file, remove_open_dir, remove_open_dir_all,
-    rename, set_permissions, stat, DirOptions, FollowSymlinks, Permissions,
+    canonicalize, copy, create_dir, hard_link, open, open_ambient_dir, open_dir, read_base_dir,
+    read_dir, read_link, remove_dir, remove_dir_all, remove_file, remove_open_dir,
+    remove_open_dir_all, rename, set_permissions, stat, DirOptions, FollowSymlinks, Permissions,
 };
 use std::fmt;
 #[cfg(unix)]
@@ -269,7 +269,8 @@ impl Dir {
     /// Returns an iterator over the entries within `self`.
     #[inline]
     pub fn entries(&self) -> io::Result<ReadDir> {
-        self.read_dir(Component::CurDir)
+        let file = unsafe { as_sync(&self.std_file) };
+        read_base_dir(&file).map(|inner| ReadDir { inner })
     }
 
     /// Returns an iterator over the entries within a directory.

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -19,7 +19,7 @@ ipnet = "2.3.0"
 fs-set-times = "0.2.2"
 
 [target.'cfg(not(windows))'.dependencies]
-posish = "0.5.2"
+posish = "0.5.3"
 libc = "0.2.81"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/cap-primitives/src/fs/open_dir.rs
+++ b/cap-primitives/src/fs/open_dir.rs
@@ -3,7 +3,7 @@
 
 #[allow(unused_imports)]
 use crate::fs::open_unchecked;
-use crate::fs::{dir_options, dir_path_options, open, open_ambient_dir_impl};
+use crate::fs::{dir_options, dir_path_options, open, open_ambient_dir_impl, readdir_options};
 use std::{fs, io, path::Path};
 
 /// Open a directory by performing an `openat`-like operation,
@@ -14,11 +14,29 @@ pub fn open_dir(start: &fs::File, path: &Path) -> io::Result<fs::File> {
     open(start, path, &dir_options())
 }
 
+/// Like `open_dir`, but additionally request the ability to read the directory
+/// entries.
+#[inline]
+pub fn open_dir_for_reading(start: &fs::File, path: &Path) -> io::Result<fs::File> {
+    open(start, path, &readdir_options())
+}
+
 /// Open a directory by performing an unsandboxed `openat`-like operation.
 #[inline]
 #[allow(dead_code)]
 pub(crate) fn open_dir_unchecked(start: &fs::File, path: &Path) -> io::Result<fs::File> {
     open_unchecked(start, path, &dir_options()).map_err(Into::into)
+}
+
+/// Like `open_dir_unchecked`, but additionally request the ability to read the
+/// directory entries.
+#[inline]
+#[allow(dead_code)]
+pub(crate) fn open_dir_for_reading_unchecked(
+    start: &fs::File,
+    path: &Path,
+) -> io::Result<fs::File> {
+    open_unchecked(start, path, &readdir_options()).map_err(Into::into)
 }
 
 /// Open a directory named by a bare path, using the host process' ambient

--- a/cap-primitives/src/fs/read_dir.rs
+++ b/cap-primitives/src/fs/read_dir.rs
@@ -11,6 +11,15 @@ pub fn read_dir(start: &fs::File, path: &Path) -> io::Result<ReadDir> {
     })
 }
 
+/// Like `read_dir` but operates on the base directory itself, rather than
+/// on a path based on it.
+#[inline]
+pub fn read_base_dir(start: &fs::File) -> io::Result<ReadDir> {
+    Ok(ReadDir {
+        inner: ReadDirInner::read_base_dir(start)?,
+    })
+}
+
 /// Like `read_dir`, but doesn't perform sandboxing.
 #[inline]
 pub(crate) fn read_dir_unchecked(start: &fs::File, path: &Path) -> io::Result<ReadDir> {

--- a/cap-primitives/src/posish/fs/dir_utils.rs
+++ b/cap-primitives/src/posish/fs/dir_utils.rs
@@ -104,18 +104,24 @@ pub(crate) unsafe fn open_ambient_dir_impl(path: &Path) -> io::Result<fs::File> 
 }
 
 const fn target_o_path() -> OFlags {
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "redox",))]
+    #[cfg(any(
+        target_os = "android",
+        target_os = "emscripten",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "redox",
+    ))]
     {
         OFlags::PATH
     }
 
     #[cfg(any(
-        target_os = "netbsd",
-        target_os = "macos",
-        target_os = "ios",
+        target_os = "dragonfly",
         target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
         target_os = "openbsd",
-        target_os = "dragonfly"
     ))]
     {
         OFlags::empty()

--- a/cap-primitives/src/winx/fs/dir_utils.rs
+++ b/cap-primitives/src/winx/fs/dir_utils.rs
@@ -78,6 +78,13 @@ pub(crate) fn dir_options() -> OpenOptions {
         .clone()
 }
 
+/// Like `dir_options`, but additionally request the ability to read the
+/// directory entries.
+pub(crate) fn readdir_options() -> OpenOptions {
+    // Windows doesn't appear to make this distinction.
+    dir_options()
+}
+
 /// Return an `OpenOptions` for canonicalizing paths.
 pub(crate) fn canonicalize_options() -> OpenOptions {
     OpenOptions::new()

--- a/cap-primitives/src/winx/fs/read_dir_inner.rs
+++ b/cap-primitives/src/winx/fs/read_dir_inner.rs
@@ -15,6 +15,10 @@ impl ReadDirInner {
         Self::new_unchecked(&dir, Component::CurDir.as_os_str().as_ref())
     }
 
+    pub(crate) fn read_base_dir(start: &fs::File) -> io::Result<Self> {
+        Self::new_unchecked(&start, Component::CurDir.as_os_str().as_ref())
+    }
+
     pub(crate) fn new_unchecked(start: &fs::File, path: &Path) -> io::Result<Self> {
         let full_path = concatenate_or_return_absolute(start, path)?;
         Ok(Self {

--- a/cap-std/src/fs/dir.rs
+++ b/cap-std/src/fs/dir.rs
@@ -1,8 +1,8 @@
 use crate::fs::{DirBuilder, File, Metadata, OpenOptions, ReadDir};
 use cap_primitives::fs::{
-    canonicalize, copy, create_dir, hard_link, open, open_ambient_dir, open_dir, read_dir,
-    read_link, remove_dir, remove_dir_all, remove_file, remove_open_dir, remove_open_dir_all,
-    rename, set_permissions, stat, DirOptions, FollowSymlinks, Permissions,
+    canonicalize, copy, create_dir, hard_link, open, open_ambient_dir, open_dir, read_base_dir,
+    read_dir, read_link, remove_dir, remove_dir_all, remove_file, remove_open_dir,
+    remove_open_dir_all, rename, set_permissions, stat, DirOptions, FollowSymlinks, Permissions,
 };
 #[cfg(target_os = "wasi")]
 use std::os::wasi::{
@@ -12,7 +12,7 @@ use std::os::wasi::{
 use std::{
     fmt, fs,
     io::{self, Read, Write},
-    path::{Component, Path, PathBuf},
+    path::{Path, PathBuf},
 };
 #[cfg(unix)]
 use {
@@ -268,7 +268,7 @@ impl Dir {
     /// Returns an iterator over the entries within `self`.
     #[inline]
     pub fn entries(&self) -> io::Result<ReadDir> {
-        self.read_dir(Component::CurDir)
+        read_base_dir(&self.std_file).map(|inner| ReadDir { inner })
     }
 
     /// Returns an iterator over the entries within a directory.

--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -414,6 +414,26 @@ fn dir_searchable_unreadable() {
         .is_err());
 }
 
+/// Test opening a directory with no permissions.
+#[test]
+fn dir_unsearchable_unreadable() {
+    use cap_std::fs::DirBuilder;
+    use std::os::unix::fs::DirBuilderExt;
+
+    let tmpdir = tmpdir();
+
+    let mut options = DirBuilder::new();
+    options.mode(0o000);
+    check!(tmpdir.create_dir_with("dir", &options));
+
+    // Platforms with `O_PATH` can open a directory with no permissions.
+    if cfg!(any(target_os = "linux", target_os = "android", target_os = "redox")) {
+        check!(tmpdir.open_dir("dir"));
+    } else {
+        assert!(tmpdir.open_dir("dir").is_err());
+    }
+}
+
 /// This test is the same as `symlink_hard_link` but uses `std::fs`'
 /// ambient API instead of `cap_std`. The purpose of this test is to
 /// confirm fundamentally OS-specific behaviors.

--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -427,7 +427,11 @@ fn dir_unsearchable_unreadable() {
     check!(tmpdir.create_dir_with("dir", &options));
 
     // Platforms with `O_PATH` can open a directory with no permissions.
-    if cfg!(any(target_os = "linux", target_os = "android", target_os = "redox")) {
+    if cfg!(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "redox"
+    )) {
         check!(tmpdir.open_dir("dir"));
     } else {
         assert!(tmpdir.open_dir("dir").is_err());

--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -415,6 +415,7 @@ fn dir_searchable_unreadable() {
 }
 
 /// Test opening a directory with no permissions.
+#[cfg(unix)]
 #[test]
 fn dir_unsearchable_unreadable() {
     use cap_std::fs::DirBuilder;


### PR DESCRIPTION
Make `Dir::open` and friends use `O_PATH` on Linux and other platforms
that support it.