### PR TITLE
Use ERROR_STOPPED_ON_SYMLINK on Windows for symlink errors.

### DIFF
--- a/cap-primitives/src/windows/fs/open_unchecked.rs
+++ b/cap-primitives/src/windows/fs/open_unchecked.rs
@@ -48,7 +48,7 @@ pub(crate) fn open_unchecked(
                     // them as a distinct error.
                     if metadata.file_type().is_symlink() {
                         return Err(OpenUncheckedError::Symlink(
-                            io::Error::new(io::ErrorKind::Other, "symlink encountered"),
+                            io::Error::from_raw_os_error(winerror::ERROR_STOPPED_ON_SYMLINK as i32),
                             if metadata.file_attributes() & FILE_ATTRIBUTE_DIRECTORY
                                 == FILE_ATTRIBUTE_DIRECTORY
                             {


### PR DESCRIPTION
When `FollowSymlinks::No` and a symlink is encountered, on Windows, use
`ERROR_STOPPED_ON_SYMLINK` as the error code.