### PR TITLE
Test updates

### DIFF
--- a/tests/is-file-read-write.rs
+++ b/tests/is-file-read-write.rs
@@ -1,11 +1,11 @@
 #[macro_use]
 mod sys_common;
 
-use cap_fs_ext::{IsReadWrite, OpenOptions};
+use cap_fs_ext::{IsFileReadWrite, OpenOptions};
 use sys_common::io::tmpdir;
 
 #[test]
-fn basic_is_read_write() {
+fn basic_is_file_read_write() {
     let tmpdir = tmpdir();
 
     let file = check!(tmpdir.open_with(
@@ -16,10 +16,10 @@ fn basic_is_read_write() {
             .write(true)
             .read(true)
     ));
-    assert_eq!(check!(file.is_read_write()), (true, true));
+    assert_eq!(check!(file.is_file_read_write()), (true, true));
 
     let file = check!(tmpdir.open_with("file", OpenOptions::new().append(true).read(true)));
-    assert_eq!(check!(file.is_read_write()), (true, true));
+    assert_eq!(check!(file.is_file_read_write()), (true, true));
 
     let file = check!(tmpdir.open_with(
         "file",
@@ -29,7 +29,7 @@ fn basic_is_read_write() {
             .write(true)
             .read(false)
     ));
-    assert_eq!(check!(file.is_read_write()), (false, true));
+    assert_eq!(check!(file.is_file_read_write()), (false, true));
 
     let file = check!(tmpdir.open_with(
         "file",
@@ -39,5 +39,5 @@ fn basic_is_read_write() {
             .write(false)
             .read(true)
     ));
-    assert_eq!(check!(file.is_read_write()), (true, false));
+    assert_eq!(check!(file.is_file_read_write()), (true, false));
 }


### PR DESCRIPTION
Fix the is-read-write.rs test and port `symlink_hard_link` from Rust's standard library testsuite (which I added in https://github.com/rust-lang/rust/pull/78026).