### PR TITLE
Add a `maybe_dir` extension trait for `OpenOptions`.

### DIFF
--- a/cap-fs-ext/src/lib.rs
+++ b/cap-fs-ext/src/lib.rs
@@ -14,6 +14,7 @@ mod file_type_ext;
 mod is_file_read_write;
 mod metadata_ext;
 mod open_options_follow_ext;
+mod open_options_maybe_dir_ext;
 mod reopen;
 
 #[cfg(all(any(feature = "std", feature = "async_std"), feature = "fs_utf8"))]
@@ -22,8 +23,9 @@ pub use dir_ext::{DirExt, SystemTimeSpec};
 pub use file_type_ext::FileTypeExt;
 pub use is_file_read_write::IsFileReadWrite;
 pub use metadata_ext::MetadataExt;
-pub use open_options_follow_ext::{FollowSymlinks, OpenOptionsFollowExt};
+pub use open_options_follow_ext::OpenOptionsFollowExt;
+pub use open_options_maybe_dir_ext::OpenOptionsMaybeDirExt;
 pub use reopen::Reopen;
 
 /// Re-export this to allow it to be used with `Reuse`.
-pub use cap_primitives::fs::OpenOptions;
+pub use cap_primitives::fs::{FollowSymlinks, OpenOptions};

--- a/cap-fs-ext/src/open_options_follow_ext.rs
+++ b/cap-fs-ext/src/open_options_follow_ext.rs
@@ -1,4 +1,4 @@
-pub use cap_primitives::fs::FollowSymlinks;
+use crate::FollowSymlinks;
 
 /// Extension trait for `cap_primitives::fs::OpenOptions` which adds
 /// `follow`, a function for controlling whether a symlink in the last

--- a/cap-fs-ext/src/open_options_maybe_dir_ext.rs
+++ b/cap-fs-ext/src/open_options_maybe_dir_ext.rs
@@ -1,0 +1,20 @@
+/// Extension trait for `cap_primitives::fs::OpenOptions` which adds
+/// `maybe_dir`, a function for controlling whether an open should
+/// attempt to succeed on a directory. On Posix-ish platforms, opening
+/// a directory always succeeds, but on Windows, opening a directory
+/// needs this option.
+pub trait OpenOptionsMaybeDirExt {
+    /// Sets the option for disabling an error that might be generated
+    /// by the opened object being a directory.
+    fn maybe_dir(&mut self, maybe_dir: bool) -> &mut Self;
+}
+
+impl OpenOptionsMaybeDirExt for cap_primitives::fs::OpenOptions {
+    #[inline]
+    fn maybe_dir(&mut self, maybe_dir: bool) -> &mut Self {
+        // `maybe_dir` functionality is implemented within `cap_primitives`; we're
+        // just exposing it here since `OpenOptions` is re-exported by `cap_std`
+        // etc. and `maybe_dir` isn't in `std`.
+        unsafe { self._cap_fs_ext_maybe_dir(maybe_dir) }
+    }
+}

--- a/cap-primitives/src/fs/open_options.rs
+++ b/cap-primitives/src/fs/open_options.rs
@@ -25,6 +25,7 @@ pub struct OpenOptions {
     pub(crate) create: bool,
     pub(crate) create_new: bool,
     pub(crate) dir_required: bool,
+    pub(crate) maybe_dir: bool,
     pub(crate) readdir_required: bool,
     pub(crate) follow: FollowSymlinks,
 
@@ -49,6 +50,7 @@ impl OpenOptions {
             create: false,
             create_new: false,
             dir_required: false,
+            maybe_dir: false,
             readdir_required: false,
             follow: FollowSymlinks::Yes,
 
@@ -137,6 +139,13 @@ impl OpenOptions {
         self
     }
 
+    /// Sets the option to disable an error if the opened object is a directory.
+    #[inline]
+    pub(crate) fn maybe_dir(&mut self, maybe_dir: bool) -> &mut Self {
+        self.maybe_dir = maybe_dir;
+        self
+    }
+
     /// Sets the option to request the ability to read directory entries.
     #[inline]
     pub(crate) fn readdir_required(&mut self, readdir_required: bool) -> &mut Self {
@@ -154,6 +163,18 @@ impl OpenOptions {
     #[inline]
     pub unsafe fn _cap_fs_ext_follow(&mut self, follow: FollowSymlinks) -> &mut Self {
         self.follow(follow)
+    }
+
+    /// Wrapper to allow `maybe_dir` to be exposed by the `cap-fs-ext` crate.
+    ///
+    /// # Safety
+    ///
+    /// This is hidden from the main API since this functionality isn't present in `std`.
+    /// Use `cap_fs_ext::OpenOptionsMaybeDirExt` instead of calling this directly.
+    #[doc(hidden)]
+    #[inline]
+    pub unsafe fn _cap_fs_ext_maybe_dir(&mut self, maybe_dir: bool) -> &mut Self {
+        self.maybe_dir(maybe_dir)
     }
 }
 
@@ -249,6 +270,7 @@ impl arbitrary::Arbitrary for OpenOptions {
             .create(<bool as Arbitrary>::arbitrary(u)?)
             .create_new(<bool as Arbitrary>::arbitrary(u)?)
             .dir_required(<bool as Arbitrary>::arbitrary(u)?)
+            .maybe_dir(<bool as Arbitrary>::arbitrary(u)?)
             .readdir_required(<bool as Arbitrary>::arbitrary(u)?)
             .follow(<FollowSymlinks as Arbitrary>::arbitrary(u)?)
             .clone())

--- a/cap-primitives/src/windows/fs/oflags.rs
+++ b/cap-primitives/src/windows/fs/oflags.rs
@@ -9,7 +9,7 @@ pub(in super::super) fn open_options_to_std(opts: &OpenOptions) -> (fs::OpenOpti
     let mut trunc = opts.truncate;
     let mut manually_trunc = false;
 
-    let custom_flags = match opts.follow {
+    let mut custom_flags = match opts.follow {
         FollowSymlinks::Yes => opts.ext.custom_flags,
         FollowSymlinks::No => {
             if trunc && !opts.create_new && !opts.append && opts.write {
@@ -21,6 +21,9 @@ pub(in super::super) fn open_options_to_std(opts: &OpenOptions) -> (fs::OpenOpti
             opts.ext.custom_flags | Flags::FILE_FLAG_OPEN_REPARSE_POINT.bits()
         }
     };
+    if opts.maybe_dir {
+        custom_flags |= Flags::FILE_FLAG_BACKUP_SEMANTICS.bits();
+    }
     let mut std_opts = fs::OpenOptions::new();
     std_opts
         .read(opts.read)

--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -752,3 +752,22 @@ fn readdir_write() {
             .is_err());
     }
 }
+
+#[test]
+fn maybe_dir() {
+    use cap_fs_ext::OpenOptionsMaybeDirExt;
+
+    let tmpdir = tmpdir();
+    check!(tmpdir.create_dir("dir"));
+
+    // Opening directories works on non-Windows platforms.
+    #[cfg(not(windows))]
+    check!(tmpdir.open("dir"));
+
+    // Opening directories fails on Windows.
+    #[cfg(windows)]
+    assert!(tmpdir.open("dir").is_err());
+
+    // Opening directories works on all platforms with `maybe_dir`.
+    check!(tmpdir.open_with("dir", OpenOptions::new().read(true).maybe_dir(true)));
+}


### PR DESCRIPTION
On Windows, a special flag is needed to open directories. This supports
setting that flag, to allow opening directories on Windows.