### PR TITLE
DirExt::remove_file_or_symlink no longer deletes empty directory

### DIFF
--- a/cap-fs-ext/Cargo.toml
+++ b/cap-fs-ext/Cargo.toml
@@ -31,5 +31,11 @@ std = ["cap-std"]
 async_std = ["cap-async-std", "async-std"]
 async_std_fs_utf8 = ["cap-async-std/fs_utf8"]
 
+[target.'cfg(windows)'.dependencies]
+winapi = "0.3.9"
+
+[dev-dependencies]
+cap-tempfile = { path = "../cap-tempfile" }
+
 [badges]
 maintenance = { status = "actively-developed" }

--- a/cap-fs-ext/src/dir_ext.rs
+++ b/cap-fs-ext/src/dir_ext.rs
@@ -439,7 +439,7 @@ impl DirExt for cap_async_std::fs::Dir {
         // This operation may race, because it checks the metadata before deleting
         // the symlink. We tried to do this atomically by ReOpenFile with DELETE_ON_CLOSE but could
         // not get it to work.
-        fn delete_symlink_to_dir(dir: &cap_std::fs::Dir, path: &str) -> io::Result<()> {
+        fn delete_symlink_to_dir(dir: &cap_std::fs::Dir, path: &Path) -> io::Result<()> {
             use crate::{FollowSymlinks, OpenOptionsFollowExt};
             use cap_std::fs::OpenOptions;
             use std::os::windows::fs::OpenOptionsExt;
@@ -699,7 +699,7 @@ impl DirExtUtf8 for cap_async_std::fs_utf8::Dir {
         // This operation may race, because it checks the metadata before deleting
         // the symlink. We tried to do this atomically by ReOpenFile with DELETE_ON_CLOSE but could
         // not get it to work.
-        fn delete_symlink_to_dir(dir: &cap_std_async::fs_utf8::Dir, path: &str) -> io::Result<()> {
+        fn delete_symlink_to_dir(dir: &cap_async_std::fs_utf8::Dir, path: &str) -> io::Result<()> {
             use crate::{FollowSymlinks, OpenOptionsFollowExt};
             use cap_std::fs::OpenOptions;
             use std::os::windows::fs::OpenOptionsExt;

--- a/cap-fs-ext/src/dir_ext.rs
+++ b/cap-fs-ext/src/dir_ext.rs
@@ -439,7 +439,7 @@ impl DirExt for cap_async_std::fs::Dir {
         // This operation may race, because it checks the metadata before deleting
         // the symlink. We tried to do this atomically by ReOpenFile with DELETE_ON_CLOSE but could
         // not get it to work.
-        fn delete_symlink_to_dir(dir: &cap_std::fs::Dir, path: &Path) -> io::Result<()> {
+        fn delete_symlink_to_dir(dir: &cap_async_std::fs::Dir, path: &Path) -> io::Result<()> {
             use crate::{FollowSymlinks, OpenOptionsFollowExt};
             use cap_std::fs::OpenOptions;
             use std::os::windows::fs::OpenOptionsExt;


### PR DESCRIPTION
(except in the case of a race, which is pretty contrived)