### PR TITLE
 Make `remove_file_or_symlink_dir` non-racy.

### DIFF
--- a/cap-fs-ext/src/dir_ext.rs
+++ b/cap-fs-ext/src/dir_ext.rs
@@ -298,57 +298,6 @@ impl DirExt for cap_std::fs::Dir {
     }
 }
 
-#[cfg(all(test, feature = "std"))]
-mod std_remove_file_or_symlink_tests {
-    use super::DirExt;
-    use cap_tempfile::TempDir;
-    #[test]
-    fn remove_file() {
-        let tempdir = unsafe { TempDir::new() }.expect("create tempdir");
-        let file = tempdir.create("file").expect("create file to delete");
-        drop(file);
-        tempdir.remove_file_or_symlink("file").expect("delete file");
-        assert!(!tempdir.exists("file"), "deletion worked");
-    }
-    #[test]
-    fn remove_symlink_to_file() {
-        let tempdir = unsafe { TempDir::new() }.expect("create tempdir");
-        let target = tempdir.create("target").expect("create target file");
-        drop(target);
-        tempdir.symlink("target", "link").expect("create symlink");
-        assert!(tempdir.exists("link"), "link exists");
-        tempdir
-            .remove_file_or_symlink("link")
-            .expect("delete symlink");
-        assert!(!tempdir.exists("link"), "link deleted");
-        assert!(tempdir.exists("target"), "target not deleted");
-    }
-    #[test]
-    fn remove_symlink_to_dir() {
-        let tempdir = unsafe { TempDir::new() }.expect("create tempdir");
-        let target = tempdir.create_dir("target").expect("create target dir");
-        drop(target);
-        tempdir.symlink("target", "link").expect("create symlink");
-        assert!(tempdir.exists("link"), "link exists");
-        tempdir
-            .remove_file_or_symlink("link")
-            .expect("delete symlink");
-        assert!(!tempdir.exists("link"), "link deleted");
-        assert!(tempdir.exists("target"), "target not deleted");
-    }
-    #[test]
-    fn do_not_remove_dir() {
-        let tempdir = unsafe { TempDir::new() }.expect("create tempdir");
-        let subdir = tempdir.create_dir("subdir").expect("create dir");
-        drop(subdir);
-        assert!(tempdir.exists("subdir"), "subdir created");
-        tempdir
-            .remove_file_or_symlink("subdir")
-            .expect_err("should not delete empty directory");
-        assert!(tempdir.exists("subdir"), "subdir not deleted");
-    }
-}
-
 #[cfg(feature = "async_std")]
 impl DirExt for cap_async_std::fs::Dir {
     #[inline]

--- a/cap-primitives/src/fs/metadata.rs
+++ b/cap-primitives/src/fs/metadata.rs
@@ -396,6 +396,7 @@ impl std::os::windows::fs::MetadataExt for Metadata {
 #[cfg(windows)]
 #[doc(hidden)]
 pub unsafe trait _WindowsByHandle {
+    unsafe fn file_attributes(&self) -> u32;
     unsafe fn volume_serial_number(&self) -> Option<u32>;
     unsafe fn number_of_links(&self) -> Option<u32>;
     unsafe fn file_index(&self) -> Option<u64>;

--- a/cap-primitives/src/windows/fs/metadata_ext.rs
+++ b/cap-primitives/src/windows/fs/metadata_ext.rs
@@ -183,6 +183,11 @@ impl std::os::windows::fs::MetadataExt for MetadataExt {
 #[doc(hidden)]
 unsafe impl crate::fs::_WindowsByHandle for crate::fs::Metadata {
     #[inline]
+    unsafe fn file_attributes(&self) -> u32 {
+        self.ext.file_attributes
+    }
+
+    #[inline]
     unsafe fn volume_serial_number(&self) -> Option<u32> {
         self.ext.volume_serial_number
     }

--- a/tests/dir-ext.rs
+++ b/tests/dir-ext.rs
@@ -1,61 +1,63 @@
+mod sys_common;
+
 use cap_fs_ext::DirExt;
 use cap_tempfile::TempDir;
 
-use sys_common::{io::tmpdir, symlink_supported};
+use sys_common::symlink_supported;
 
-    #[test]
-    fn remove_file() {
-        let tempdir = unsafe { TempDir::new() }.expect("create tempdir");
-        let file = tempdir.create("file").expect("create file to delete");
-        drop(file);
-        tempdir.remove_file_or_symlink("file").expect("delete file");
-        assert!(!tempdir.exists("file"), "deletion worked");
+#[test]
+fn remove_file() {
+    let tempdir = unsafe { TempDir::new() }.expect("create tempdir");
+    let file = tempdir.create("file").expect("create file to delete");
+    drop(file);
+    tempdir.remove_file_or_symlink("file").expect("delete file");
+    assert!(!tempdir.exists("file"), "deletion worked");
+}
+
+#[test]
+fn remove_symlink_to_file() {
+    if !symlink_supported() {
+        return;
     }
 
-    #[test]
-    fn remove_symlink_to_file() {
-        if !symlink_supported() {
-            return;
-        }
+    let tempdir = unsafe { TempDir::new() }.expect("create tempdir");
+    let target = tempdir.create("target").expect("create target file");
+    drop(target);
+    tempdir.symlink("target", "link").expect("create symlink");
+    assert!(tempdir.exists("link"), "link exists");
+    tempdir
+        .remove_file_or_symlink("link")
+        .expect("delete symlink");
+    assert!(!tempdir.exists("link"), "link deleted");
+    assert!(tempdir.exists("target"), "target not deleted");
+}
 
-        let tempdir = unsafe { TempDir::new() }.expect("create tempdir");
-        let target = tempdir.create("target").expect("create target file");
-        drop(target);
-        tempdir.symlink("target", "link").expect("create symlink");
-        assert!(tempdir.exists("link"), "link exists");
-        tempdir
-            .remove_file_or_symlink("link")
-            .expect("delete symlink");
-        assert!(!tempdir.exists("link"), "link deleted");
-        assert!(tempdir.exists("target"), "target not deleted");
+#[test]
+fn remove_symlink_to_dir() {
+    if !symlink_supported() {
+        return;
     }
 
-    #[test]
-    fn remove_symlink_to_dir() {
-        if !symlink_supported() {
-            return;
-        }
+    let tempdir = unsafe { TempDir::new() }.expect("create tempdir");
+    let target = tempdir.create_dir("target").expect("create target dir");
+    drop(target);
+    tempdir.symlink("target", "link").expect("create symlink");
+    assert!(tempdir.exists("link"), "link exists");
+    tempdir
+        .remove_file_or_symlink("link")
+        .expect("delete symlink");
+    assert!(!tempdir.exists("link"), "link deleted");
+    assert!(tempdir.exists("target"), "target not deleted");
+}
 
-        let tempdir = unsafe { TempDir::new() }.expect("create tempdir");
-        let target = tempdir.create_dir("target").expect("create target dir");
-        drop(target);
-        tempdir.symlink("target", "link").expect("create symlink");
-        assert!(tempdir.exists("link"), "link exists");
-        tempdir
-            .remove_file_or_symlink("link")
-            .expect("delete symlink");
-        assert!(!tempdir.exists("link"), "link deleted");
-        assert!(tempdir.exists("target"), "target not deleted");
-    }
-
-    #[test]
-    fn do_not_remove_dir() {
-        let tempdir = unsafe { TempDir::new() }.expect("create tempdir");
-        let subdir = tempdir.create_dir("subdir").expect("create dir");
-        drop(subdir);
-        assert!(tempdir.exists("subdir"), "subdir created");
-        tempdir
-            .remove_file_or_symlink("subdir")
-            .expect_err("should not delete empty directory");
-        assert!(tempdir.exists("subdir"), "subdir not deleted");
-    }
+#[test]
+fn do_not_remove_dir() {
+    let tempdir = unsafe { TempDir::new() }.expect("create tempdir");
+    let subdir = tempdir.create_dir("subdir").expect("create dir");
+    drop(subdir);
+    assert!(tempdir.exists("subdir"), "subdir created");
+    tempdir
+        .remove_file_or_symlink("subdir")
+        .expect_err("should not delete empty directory");
+    assert!(tempdir.exists("subdir"), "subdir not deleted");
+}

--- a/tests/dir-ext.rs
+++ b/tests/dir-ext.rs
@@ -1,0 +1,61 @@
+use cap_fs_ext::DirExt;
+use cap_tempfile::TempDir;
+
+use sys_common::{io::tmpdir, symlink_supported};
+
+    #[test]
+    fn remove_file() {
+        let tempdir = unsafe { TempDir::new() }.expect("create tempdir");
+        let file = tempdir.create("file").expect("create file to delete");
+        drop(file);
+        tempdir.remove_file_or_symlink("file").expect("delete file");
+        assert!(!tempdir.exists("file"), "deletion worked");
+    }
+
+    #[test]
+    fn remove_symlink_to_file() {
+        if !symlink_supported() {
+            return;
+        }
+
+        let tempdir = unsafe { TempDir::new() }.expect("create tempdir");
+        let target = tempdir.create("target").expect("create target file");
+        drop(target);
+        tempdir.symlink("target", "link").expect("create symlink");
+        assert!(tempdir.exists("link"), "link exists");
+        tempdir
+            .remove_file_or_symlink("link")
+            .expect("delete symlink");
+        assert!(!tempdir.exists("link"), "link deleted");
+        assert!(tempdir.exists("target"), "target not deleted");
+    }
+
+    #[test]
+    fn remove_symlink_to_dir() {
+        if !symlink_supported() {
+            return;
+        }
+
+        let tempdir = unsafe { TempDir::new() }.expect("create tempdir");
+        let target = tempdir.create_dir("target").expect("create target dir");
+        drop(target);
+        tempdir.symlink("target", "link").expect("create symlink");
+        assert!(tempdir.exists("link"), "link exists");
+        tempdir
+            .remove_file_or_symlink("link")
+            .expect("delete symlink");
+        assert!(!tempdir.exists("link"), "link deleted");
+        assert!(tempdir.exists("target"), "target not deleted");
+    }
+
+    #[test]
+    fn do_not_remove_dir() {
+        let tempdir = unsafe { TempDir::new() }.expect("create tempdir");
+        let subdir = tempdir.create_dir("subdir").expect("create dir");
+        drop(subdir);
+        assert!(tempdir.exists("subdir"), "subdir created");
+        tempdir
+            .remove_file_or_symlink("subdir")
+            .expect_err("should not delete empty directory");
+        assert!(tempdir.exists("subdir"), "subdir not deleted");
+    }


### PR DESCRIPTION
On Windows, `remove_file` doesn't remove the file until the last handle
is closed, so hold the handle open while we check the symlink's type to
avoid race conditions.