### PR TITLE
Update to winx 0.23.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ libc = "0.2.81"
 # for testing here.
 nt_version = "0.1.3"
 winapi = "0.3.9"
-winx = "0.22.0"
+winx = "0.23.0"
 
 [features]
 default = []

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -37,7 +37,7 @@ errno = "0.2.7"
 errno = "0.2.7"
 
 [target.'cfg(windows)'.dependencies]
-winx = "0.22.0"
+winx = "0.23.0"
 winapi = { version = "0.3.9", features = [
     "ioapiset",
     "winioctl"

--- a/cap-primitives/src/windows/fs/dir_utils.rs
+++ b/cap-primitives/src/windows/fs/dir_utils.rs
@@ -9,8 +9,8 @@ use std::{
     },
     path::{Path, PathBuf},
 };
+use winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS;
 use winapi::um::winnt;
-use winx::file::Flags;
 
 /// Rust's `Path` implicitly strips redundant slashes, however they aren't
 /// redundant in one case: at the end of a path they indicate that a path is
@@ -68,7 +68,7 @@ pub(crate) fn dir_options() -> OpenOptions {
     OpenOptions::new()
         .read(true)
         .dir_required(true)
-        .custom_flags(Flags::FILE_FLAG_BACKUP_SEMANTICS.bits())
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
         .share_mode(winnt::FILE_SHARE_READ | winnt::FILE_SHARE_WRITE)
         .clone()
 }
@@ -83,7 +83,7 @@ pub(crate) fn readdir_options() -> OpenOptions {
 pub(crate) fn canonicalize_options() -> OpenOptions {
     OpenOptions::new()
         .read(true)
-        .custom_flags(Flags::FILE_FLAG_BACKUP_SEMANTICS.bits())
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
         .clone()
 }
 
@@ -100,7 +100,7 @@ pub(crate) unsafe fn open_ambient_dir_impl(path: &Path) -> io::Result<fs::File> 
     // underneath us, since we use paths to implement many directory operations.
     let dir = fs::OpenOptions::new()
         .read(true)
-        .custom_flags(Flags::FILE_FLAG_BACKUP_SEMANTICS.bits())
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
         .share_mode(winnt::FILE_SHARE_READ | winnt::FILE_SHARE_WRITE)
         .open(&path)?;
 

--- a/cap-primitives/src/windows/fs/oflags.rs
+++ b/cap-primitives/src/windows/fs/oflags.rs
@@ -1,6 +1,6 @@
 use crate::fs::{FollowSymlinks, OpenOptions};
 use std::{fs, os::windows::fs::OpenOptionsExt};
-use winx::file::Flags;
+use winapi::um::winbase::{FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT};
 
 /// Translate the given `cap_std` into `std` options. Also return a bool
 /// indicating that the `trunc` flag was requested but could not be set,
@@ -18,11 +18,11 @@ pub(in super::super) fn open_options_to_std(opts: &OpenOptions) -> (fs::OpenOpti
                 manually_trunc = true;
                 trunc = false;
             }
-            opts.ext.custom_flags | Flags::FILE_FLAG_OPEN_REPARSE_POINT.bits()
+            opts.ext.custom_flags | FILE_FLAG_OPEN_REPARSE_POINT
         }
     };
     if opts.maybe_dir {
-        custom_flags |= Flags::FILE_FLAG_BACKUP_SEMANTICS.bits();
+        custom_flags |= FILE_FLAG_BACKUP_SEMANTICS;
     }
     let mut std_opts = fs::OpenOptions::new();
     std_opts

--- a/cap-time-ext/Cargo.toml
+++ b/cap-time-ext/Cargo.toml
@@ -22,7 +22,7 @@ posish = "0.5.2"
 
 [target.'cfg(windows)'.dependencies]
 once_cell = "1.5.2"
-winx = "0.22.0"
+winx = "0.23.0"
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
Use `winapi_util::file::information` in place of `winx::file::get_fileinfo`,
which is simpler, except for needing to convert the types, which we need
to do because we're ultimately using these values in the
[windows `MetadataExt` trait] which uses `u32`. I submitted
BurntSushi/winapi-util#7 to propose changing the types upstream.

[windows `MetadataExt` trait]: https://doc.rust-lang.org/stable/std/os/windows/fs/trait.MetadataExt.html