### PR TITLE
Build fix for s390x platform

### DIFF
--- a/cap-primitives/src/posish/linux/fs/procfs.rs
+++ b/cap-primitives/src/posish/linux/fs/procfs.rs
@@ -30,8 +30,10 @@ const PROC_ROOT_INO: u64 = 1;
 ///
 /// This is defined in the `libc` crate for linux-gnu but not for
 /// linux-musl, so we define it ourselves.
-#[cfg(not(any(target_env = "musl", target_os = "android")))]
+#[cfg(not(any(target_env = "musl", target_os = "android", target_arch = "s390x")))]
 const PROC_SUPER_MAGIC: libc::__fsword_t = 0x0000_9fa0;
+#[cfg(all(target_arch = "s390x", not(target_env = "musl")))]
+const PROC_SUPER_MAGIC: libc::c_uint = 0x0000_9fa0;
 #[cfg(any(target_env = "musl", target_os = "android"))]
 const PROC_SUPER_MAGIC: libc::c_ulong = 0x0000_9fa0;
 
@@ -181,11 +183,13 @@ fn proc_self_fd() -> io::Result<&'static fs::File> {
     #[allow(clippy::useless_conversion)]
     static PROC_SELF_FD: Lazy<io::Result<fs::File>> = Lazy::new(|| {
         // When libc does have this constant, check that our copy has the same value.
-        #[cfg(not(any(target_env = "musl", target_os = "android")))]
+        #[cfg(not(any(target_env = "musl", target_os = "android", target_arch = "s390x")))]
         assert_eq!(
             PROC_SUPER_MAGIC,
             libc::__fsword_t::from(libc::PROC_SUPER_MAGIC)
         );
+        #[cfg(all(target_arch = "s390x", not(target_env = "musl")))]
+        assert_eq!(PROC_SUPER_MAGIC, libc::c_uint::from(libc::PROC_SUPER_MAGIC));
         #[cfg(target_os = "android")]
         assert_eq!(PROC_SUPER_MAGIC as libc::c_long, libc::PROC_SUPER_MAGIC);
 


### PR DESCRIPTION
On s390x, PROC_SUPER_MAGIC (like all superblock magic numbers)
must have type libc::c_uint instead of libc::__fsword_t.

This is done correctly in the libc crate, but not in the local copy
of PROC_SUPER_MAGIC in cap-primitives/src/posish/linux/fs/procfs.rs,
causing a build failure on s390x.

Fix by duplicating the libc logic here as well.