### PR TITLE
Use the `AmbientAuthority` type instead of `unsafe` to indicate ambient authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,8 @@ There currently are three main ways:
  - Use the [`cap-directories`] crate to create `Dir`s for config, cache and
    other data directories.
  - Use the [`cap-tempfile`] crate to create `Dir`s for temporary directories.
- - Use the `unsafe` [`Dir::open_ambient_dir`] to open a plain path. This
-   function is not sandboxed, and may open any file the host process has
-   access to.
+ - Use [`Dir::open_ambient_dir`] to open a plain path. This function is not
+   sandboxed, and may open any file the host process has access to.
 
 ## Examples
 

--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -11,7 +11,9 @@ use std::{fs, path::PathBuf};
 
 #[bench]
 fn nested_directories_open(b: &mut test::Bencher) {
-    let dir = unsafe { cap_tempfile::tempdir().unwrap() };
+    use cap_tempfile::ambient_authority;
+
+    let dir = cap_tempfile::tempdir(ambient_authority()).unwrap();
 
     let mut path = PathBuf::new();
     for _ in 0..256 {
@@ -41,7 +43,9 @@ fn nested_directories_open_baseline(b: &mut test::Bencher) {
 
 #[bench]
 fn nested_directories_metadata(b: &mut test::Bencher) {
-    let dir = unsafe { cap_tempfile::tempdir().unwrap() };
+    use cap_tempfile::ambient_authority;
+
+    let dir = cap_tempfile::tempdir(ambient_authority()).unwrap();
 
     let mut path = PathBuf::new();
     for _ in 0..256 {
@@ -72,7 +76,9 @@ fn nested_directories_metadata_baseline(b: &mut test::Bencher) {
 
 #[bench]
 fn nested_directories_canonicalize(b: &mut test::Bencher) {
-    let dir = unsafe { cap_tempfile::tempdir().unwrap() };
+    use cap_tempfile::ambient_authority;
+
+    let dir = cap_tempfile::tempdir(ambient_authority()).unwrap();
 
     let mut path = PathBuf::new();
     for _ in 0..256 {
@@ -103,7 +109,9 @@ fn nested_directories_canonicalize_baseline(b: &mut test::Bencher) {
 #[cfg(unix)]
 #[bench]
 fn nested_directories_readlink(b: &mut test::Bencher) {
-    let dir = unsafe { cap_tempfile::tempdir().unwrap() };
+    use cap_tempfile::ambient_authority;
+
+    let dir = cap_tempfile::tempdir(ambient_authority()).unwrap();
 
     let mut path = PathBuf::new();
     for _ in 0..256 {
@@ -143,7 +151,9 @@ fn nested_directories_readlink_baseline(b: &mut test::Bencher) {
 
 #[bench]
 fn curdir(b: &mut test::Bencher) {
-    let dir = unsafe { cap_tempfile::tempdir().unwrap() };
+    use cap_tempfile::ambient_authority;
+
+    let dir = cap_tempfile::tempdir(ambient_authority()).unwrap();
 
     let mut path = PathBuf::new();
     for _ in 0..256 {
@@ -176,7 +186,9 @@ fn curdir_baseline(b: &mut test::Bencher) {
 
 #[bench]
 fn parentdir(b: &mut test::Bencher) {
-    let dir = unsafe { cap_tempfile::tempdir().unwrap() };
+    use cap_tempfile::ambient_authority;
+
+    let dir = cap_tempfile::tempdir(ambient_authority()).unwrap();
 
     let mut path = PathBuf::new();
     for _ in 0..256 {
@@ -219,7 +231,9 @@ fn parentdir_baseline(b: &mut test::Bencher) {
 
 #[bench]
 fn directory_iteration(b: &mut test::Bencher) {
-    let dir = unsafe { cap_tempfile::tempdir().unwrap() };
+    use cap_tempfile::ambient_authority;
+
+    let dir = cap_tempfile::tempdir(ambient_authority()).unwrap();
 
     for i in 0..256 {
         dir.create(i.to_string()).unwrap();
@@ -234,7 +248,9 @@ fn directory_iteration(b: &mut test::Bencher) {
 
 #[bench]
 fn directory_iteration_fast(b: &mut test::Bencher) {
-    let dir = unsafe { cap_tempfile::tempdir().unwrap() };
+    use cap_tempfile::ambient_authority;
+
+    let dir = cap_tempfile::tempdir(ambient_authority()).unwrap();
 
     for i in 0..256 {
         dir.create(i.to_string()).unwrap();
@@ -265,7 +281,9 @@ fn directory_iteration_baseline(b: &mut test::Bencher) {
 #[cfg(unix)]
 #[bench]
 fn symlink_chasing_open(b: &mut test::Bencher) {
-    let dir = unsafe { cap_tempfile::tempdir().unwrap() };
+    use cap_tempfile::ambient_authority;
+
+    let dir = cap_tempfile::tempdir(ambient_authority()).unwrap();
 
     dir.create("0").unwrap();
     for i in 0..32 {
@@ -303,7 +321,9 @@ fn symlink_chasing_open_baseline(b: &mut test::Bencher) {
 #[cfg(unix)]
 #[bench]
 fn symlink_chasing_metadata(b: &mut test::Bencher) {
-    let dir = unsafe { cap_tempfile::tempdir().unwrap() };
+    use cap_tempfile::ambient_authority;
+
+    let dir = cap_tempfile::tempdir(ambient_authority()).unwrap();
 
     dir.create("0").unwrap();
     for i in 0..32 {
@@ -341,7 +361,9 @@ fn symlink_chasing_metadata_baseline(b: &mut test::Bencher) {
 #[cfg(unix)]
 #[bench]
 fn symlink_chasing_canonicalize(b: &mut test::Bencher) {
-    let dir = unsafe { cap_tempfile::tempdir().unwrap() };
+    use cap_tempfile::ambient_authority;
+
+    let dir = cap_tempfile::tempdir(ambient_authority()).unwrap();
 
     dir.create("0").unwrap();
     for i in 0..32 {
@@ -378,7 +400,9 @@ fn symlink_chasing_canonicalize_baseline(b: &mut test::Bencher) {
 
 #[bench]
 fn recursive_create_delete(b: &mut test::Bencher) {
-    let dir = unsafe { cap_tempfile::tempdir().unwrap() };
+    use cap_tempfile::ambient_authority;
+
+    let dir = cap_tempfile::tempdir(ambient_authority()).unwrap();
 
     let mut path = PathBuf::new();
     for depth in 0..256 {
@@ -409,7 +433,9 @@ fn recursive_create_delete_baseline(b: &mut test::Bencher) {
 
 #[bench]
 fn copy_4b(b: &mut test::Bencher) {
-    let dir = unsafe { cap_tempfile::tempdir().unwrap() };
+    use cap_tempfile::ambient_authority;
+
+    let dir = cap_tempfile::tempdir(ambient_authority()).unwrap();
 
     dir.write("file", &vec![1u8; 0x4]).unwrap();
 
@@ -433,7 +459,9 @@ fn copy_4b_baseline(b: &mut test::Bencher) {
 
 #[bench]
 fn copy_4k(b: &mut test::Bencher) {
-    let dir = unsafe { cap_tempfile::tempdir().unwrap() };
+    use cap_tempfile::ambient_authority;
+
+    let dir = cap_tempfile::tempdir(ambient_authority()).unwrap();
 
     dir.write("file", &vec![1u8; 0x1000]).unwrap();
 
@@ -457,7 +485,9 @@ fn copy_4k_baseline(b: &mut test::Bencher) {
 
 #[bench]
 fn copy_4m(b: &mut test::Bencher) {
-    let dir = unsafe { cap_tempfile::tempdir().unwrap() };
+    use cap_tempfile::ambient_authority;
+
+    let dir = cap_tempfile::tempdir(ambient_authority()).unwrap();
 
     dir.write("file", &vec![1u8; 0x400000]).unwrap();
 

--- a/cap-async-std/src/fs/dir_entry.rs
+++ b/cap-async-std/src/fs/dir_entry.rs
@@ -4,6 +4,7 @@ use async_std::io;
 use async_std::os::unix::fs::DirEntryExt;
 #[cfg(target_os = "wasi")]
 use async_std::os::wasi::fs::DirEntryExt;
+use cap_primitives::ambient_authority;
 use std::{ffi::OsString, fmt};
 
 /// Entries returned by the `ReadDir` iterator.
@@ -30,21 +31,21 @@ impl DirEntry {
     #[inline]
     pub fn open(&self) -> io::Result<File> {
         let file = self.inner.open()?.into();
-        Ok(unsafe { File::from_std(file) })
+        Ok(File::from_std(file, ambient_authority()))
     }
 
     /// Open the file with the given options.
     #[inline]
     pub fn open_with(&self, options: &OpenOptions) -> io::Result<File> {
         let file = self.inner.open_with(options)?.into();
-        Ok(unsafe { File::from_std(file) })
+        Ok(File::from_std(file, ambient_authority()))
     }
 
     /// Open the entry as a directory.
     #[inline]
     pub fn open_dir(&self) -> io::Result<Dir> {
         let file = self.inner.open_dir()?.into();
-        Ok(unsafe { Dir::from_std_file(file) })
+        Ok(Dir::from_std_file(file, ambient_authority()))
     }
 
     /// Removes the file from its filesystem.
@@ -97,9 +98,9 @@ impl DirEntryExt for DirEntry {
 
 #[cfg(windows)]
 #[doc(hidden)]
-unsafe impl cap_primitives::fs::_WindowsDirEntryExt for DirEntry {
+impl cap_primitives::fs::_WindowsDirEntryExt for DirEntry {
     #[inline]
-    unsafe fn full_metadata(&self) -> io::Result<Metadata> {
+    fn full_metadata(&self) -> io::Result<Metadata> {
         self.inner.full_metadata()
     }
 }

--- a/cap-async-std/src/fs/file.rs
+++ b/cap-async-std/src/fs/file.rs
@@ -8,7 +8,7 @@ use async_std::{
     io::{self, IoSlice, IoSliceMut, Read, Seek, SeekFrom, Write},
     task::{Context, Poll},
 };
-use cap_primitives::fs::is_file_read_write;
+use cap_primitives::{ambient_authority, fs::is_file_read_write, AmbientAuthority};
 use std::{fmt, pin::Pin};
 use unsafe_io::{AsUnsafeFile, OwnsRaw};
 #[cfg(windows)]
@@ -35,12 +35,12 @@ pub struct File {
 impl File {
     /// Constructs a new instance of `Self` from the given `async_std::fs::File`.
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
     /// `async_std::fs::File` is not sandboxed and may access any path that the host
     /// process has access to.
     #[inline]
-    pub unsafe fn from_std(std: fs::File) -> Self {
+    pub fn from_std(std: fs::File, _: AmbientAuthority) -> Self {
         Self { std }
     }
 
@@ -135,7 +135,7 @@ fn permissions_into_std(
 impl FromRawFd for File {
     #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self::from_std(fs::File::from_raw_fd(fd))
+        Self::from_std(fs::File::from_raw_fd(fd), ambient_authority())
     }
 }
 
@@ -143,7 +143,7 @@ impl FromRawFd for File {
 impl FromRawHandle for File {
     #[inline]
     unsafe fn from_raw_handle(handle: RawHandle) -> Self {
-        Self::from_std(fs::File::from_raw_handle(handle))
+        Self::from_std(fs::File::from_raw_handle(handle), ambient_authority())
     }
 }
 

--- a/cap-async-std/src/fs_utf8/dir.rs
+++ b/cap-async-std/src/fs_utf8/dir.rs
@@ -3,6 +3,7 @@ use crate::{
     fs_utf8::{from_utf8, to_utf8, DirBuilder, File, Metadata, ReadDir},
 };
 use async_std::{fs, io};
+use cap_primitives::{ambient_authority, AmbientAuthority};
 use std::fmt;
 use unsafe_io::OwnsRaw;
 #[cfg(unix)]
@@ -36,13 +37,13 @@ impl Dir {
     /// To prevent race conditions on Windows, the file must be opened without
     /// `FILE_SHARE_DELETE`.
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
     /// `async_std::fs::File` is not sandboxed and may access any path that the host
     /// process has access to.
     #[inline]
-    pub unsafe fn from_std_file(std_file: fs::File) -> Self {
-        Self::from_cap_std(crate::fs::Dir::from_std_file(std_file))
+    pub fn from_std_file(std_file: fs::File, ambient_authority: AmbientAuthority) -> Self {
+        Self::from_cap_std(crate::fs::Dir::from_std_file(std_file, ambient_authority))
     }
 
     /// Constructs a new instance of `Self` from the given `cap_std::fs::Dir`.
@@ -496,14 +497,17 @@ impl Dir {
     /// Constructs a new instance of `Self` by opening the given path as a
     /// directory using the host process' ambient authority.
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
     /// This function is not sandboxed and may access any path that the host
     /// process has access to.
     #[inline]
-    pub unsafe fn open_ambient_dir<P: AsRef<str>>(path: P) -> io::Result<Self> {
+    pub fn open_ambient_dir<P: AsRef<str>>(
+        path: P,
+        ambient_authority: AmbientAuthority,
+    ) -> io::Result<Self> {
         let path = from_utf8(path)?;
-        crate::fs::Dir::open_ambient_dir(path).map(Self::from_cap_std)
+        crate::fs::Dir::open_ambient_dir(path, ambient_authority).map(Self::from_cap_std)
     }
 }
 
@@ -511,7 +515,7 @@ impl Dir {
 impl FromRawFd for Dir {
     #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self::from_std_file(fs::File::from_raw_fd(fd))
+        Self::from_std_file(fs::File::from_raw_fd(fd), ambient_authority())
     }
 }
 
@@ -521,7 +525,7 @@ impl FromRawHandle for Dir {
     /// `FILE_SHARE_DELETE`.
     #[inline]
     unsafe fn from_raw_handle(handle: RawHandle) -> Self {
-        Self::from_std_file(fs::File::from_raw_handle(handle))
+        Self::from_std_file(fs::File::from_raw_handle(handle), ambient_authority())
     }
 }
 

--- a/cap-async-std/src/fs_utf8/dir_entry.rs
+++ b/cap-async-std/src/fs_utf8/dir_entry.rs
@@ -100,9 +100,9 @@ impl DirEntryExt for DirEntry {
 
 #[cfg(windows)]
 #[doc(hidden)]
-unsafe impl cap_primitives::fs::_WindowsDirEntryExt for DirEntry {
+impl cap_primitives::fs::_WindowsDirEntryExt for DirEntry {
     #[inline]
-    unsafe fn full_metadata(&self) -> io::Result<Metadata> {
+    fn full_metadata(&self) -> io::Result<Metadata> {
         self.cap_std.full_metadata()
     }
 }

--- a/cap-async-std/src/fs_utf8/file.rs
+++ b/cap-async-std/src/fs_utf8/file.rs
@@ -8,6 +8,7 @@ use async_std::{
     io::{self, IoSlice, IoSliceMut, Read, Seek, SeekFrom, Write},
     task::{Context, Poll},
 };
+use cap_primitives::{ambient_authority, AmbientAuthority};
 use std::{fmt, pin::Pin};
 use unsafe_io::OwnsRaw;
 #[cfg(windows)]
@@ -34,13 +35,13 @@ pub struct File {
 impl File {
     /// Constructs a new instance of `Self` from the given `async_std::fs::File`.
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
     /// `async_std::fs::File` is not sandboxed and may access any path that the host
     /// process has access to.
     #[inline]
-    pub unsafe fn from_std(std: fs::File) -> Self {
-        Self::from_cap_std(crate::fs::File::from_std(std))
+    pub fn from_std(std: fs::File, ambient_authority: AmbientAuthority) -> Self {
+        Self::from_cap_std(crate::fs::File::from_std(std, ambient_authority))
     }
 
     /// Constructs a new instance of `Self` from the given `cap_std::fs::File`.
@@ -106,7 +107,7 @@ impl File {
 impl FromRawFd for File {
     #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self::from_std(fs::File::from_raw_fd(fd))
+        Self::from_std(fs::File::from_raw_fd(fd), ambient_authority())
     }
 }
 
@@ -114,7 +115,7 @@ impl FromRawFd for File {
 impl FromRawHandle for File {
     #[inline]
     unsafe fn from_raw_handle(handle: RawHandle) -> Self {
-        Self::from_std(fs::File::from_raw_handle(handle))
+        Self::from_std(fs::File::from_raw_handle(handle), ambient_authority())
     }
 }
 

--- a/cap-async-std/src/lib.rs
+++ b/cap-async-std/src/lib.rs
@@ -46,3 +46,4 @@ pub mod time;
 // For now, re-export `path`; see
 // <https://github.com/bytecodealliance/cap-std/issues/88>
 pub use async_std::path;
+pub use cap_primitives::{ambient_authority, AmbientAuthority};

--- a/cap-async-std/src/net/incoming.rs
+++ b/cap-async-std/src/net/incoming.rs
@@ -4,8 +4,8 @@ use async_std::{
     stream::Stream,
     task::{Context, Poll},
 };
-use std::{fmt, pin::Pin};
 use cap_primitives::{ambient_authority, AmbientAuthority};
+use std::{fmt, pin::Pin};
 
 /// An iterator that infinitely `accept`s connections on a [`TcpListener`].
 ///

--- a/cap-async-std/src/net/pool.rs
+++ b/cap-async-std/src/net/pool.rs
@@ -1,6 +1,6 @@
 use crate::net::{TcpListener, TcpStream, ToSocketAddrs, UdpSocket};
 use async_std::{io, net};
-use cap_primitives::{ambient_authority, net::NO_SOCKET_ADDRS};
+use cap_primitives::{ambient_authority, net::NO_SOCKET_ADDRS, AmbientAuthority};
 
 /// A pool of network addresses.
 ///
@@ -21,20 +21,29 @@ impl Pool {
 
     /// Add a range of network addresses with a specific port to the pool.
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
     /// This function allows ambient access to any IP address.
-    pub unsafe fn insert_ip_net(&mut self, ip_net: ipnet::IpNet, port: u16) {
-        self.cap.insert_ip_net(ip_net, port)
+    pub fn insert_ip_net(
+        &mut self,
+        ip_net: ipnet::IpNet,
+        port: u16,
+        ambient_authority: AmbientAuthority,
+    ) {
+        self.cap.insert_ip_net(ip_net, port, ambient_authority)
     }
 
     /// Add a specific [`net::SocketAddr`] to the pool.
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
     /// This function allows ambient access to any IP address.
-    pub unsafe fn insert_socket_addr(&mut self, addr: net::SocketAddr) {
-        self.cap.insert_socket_addr(addr)
+    pub fn insert_socket_addr(
+        &mut self,
+        addr: net::SocketAddr,
+        ambient_authority: AmbientAuthority,
+    ) {
+        self.cap.insert_socket_addr(addr, ambient_authority)
     }
 
     /// Creates a new `TcpListener` which will be bound to the specified

--- a/cap-async-std/src/net/tcp_listener.rs
+++ b/cap-async-std/src/net/tcp_listener.rs
@@ -2,8 +2,8 @@ use crate::net::{Incoming, SocketAddr, TcpStream};
 #[cfg(unix)]
 use async_std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use async_std::{io, net};
-use std::fmt;
 use cap_primitives::{ambient_authority, AmbientAuthority};
+use std::fmt;
 use unsafe_io::OwnsRaw;
 #[cfg(windows)]
 use {

--- a/cap-async-std/src/net/tcp_stream.rs
+++ b/cap-async-std/src/net/tcp_stream.rs
@@ -6,8 +6,8 @@ use async_std::{
     net,
     task::{Context, Poll},
 };
-use std::{fmt, pin::Pin};
 use cap_primitives::{ambient_authority, AmbientAuthority};
+use std::{fmt, pin::Pin};
 use unsafe_io::OwnsRaw;
 #[cfg(windows)]
 use {

--- a/cap-async-std/src/net/tcp_stream.rs
+++ b/cap-async-std/src/net/tcp_stream.rs
@@ -7,6 +7,7 @@ use async_std::{
     task::{Context, Poll},
 };
 use std::{fmt, pin::Pin};
+use cap_primitives::{ambient_authority, AmbientAuthority};
 use unsafe_io::OwnsRaw;
 #[cfg(windows)]
 use {
@@ -31,12 +32,12 @@ pub struct TcpStream {
 impl TcpStream {
     /// Constructs a new instance of `Self` from the given `async_std::net::TcpStream`.
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
     /// `async_std::net::TcpStream` is not sandboxed and may access any address that the host
     /// process has access to.
     #[inline]
-    pub unsafe fn from_std(std: net::TcpStream) -> Self {
+    pub fn from_std(std: net::TcpStream, _: AmbientAuthority) -> Self {
         Self { std }
     }
 
@@ -124,7 +125,7 @@ impl TcpStream {
 impl FromRawFd for TcpStream {
     #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self::from_std(net::TcpStream::from_raw_fd(fd))
+        Self::from_std(net::TcpStream::from_raw_fd(fd), ambient_authority())
     }
 }
 
@@ -132,7 +133,7 @@ impl FromRawFd for TcpStream {
 impl FromRawSocket for TcpStream {
     #[inline]
     unsafe fn from_raw_socket(socket: RawSocket) -> Self {
-        Self::from_std(net::TcpStream::from_raw_socket(socket))
+        Self::from_std(net::TcpStream::from_raw_socket(socket), ambient_authority())
     }
 }
 

--- a/cap-async-std/src/net/udp_socket.rs
+++ b/cap-async-std/src/net/udp_socket.rs
@@ -3,6 +3,7 @@ use crate::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use async_std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use async_std::{io, net};
 use std::fmt;
+use cap_primitives::{ambient_authority, AmbientAuthority};
 use unsafe_io::OwnsRaw;
 #[cfg(windows)]
 use {
@@ -31,12 +32,12 @@ pub struct UdpSocket {
 impl UdpSocket {
     /// Constructs a new instance of `Self` from the given `async_std::net::UdpSocket`.
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
     /// `async_std::net::UdpSocket` is not sandboxed and may access any address that the host
     /// process has access to.
     #[inline]
-    pub unsafe fn from_std(std: net::UdpSocket) -> Self {
+    pub fn from_std(std: net::UdpSocket, _: AmbientAuthority) -> Self {
         Self { std }
     }
 
@@ -220,7 +221,7 @@ impl UdpSocket {
 impl FromRawFd for UdpSocket {
     #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self::from_std(net::UdpSocket::from_raw_fd(fd))
+        Self::from_std(net::UdpSocket::from_raw_fd(fd), ambient_authority())
     }
 }
 
@@ -228,7 +229,7 @@ impl FromRawFd for UdpSocket {
 impl FromRawSocket for UdpSocket {
     #[inline]
     unsafe fn from_raw_socket(socket: RawSocket) -> Self {
-        Self::from_std(net::UdpSocket::from_raw_socket(socket))
+        Self::from_std(net::UdpSocket::from_raw_socket(socket), ambient_authority())
     }
 }
 

--- a/cap-async-std/src/net/udp_socket.rs
+++ b/cap-async-std/src/net/udp_socket.rs
@@ -2,8 +2,8 @@ use crate::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 #[cfg(unix)]
 use async_std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use async_std::{io, net};
-use std::fmt;
 use cap_primitives::{ambient_authority, AmbientAuthority};
+use std::fmt;
 use unsafe_io::OwnsRaw;
 #[cfg(windows)]
 use {

--- a/cap-async-std/src/os/unix/net/incoming.rs
+++ b/cap-async-std/src/os/unix/net/incoming.rs
@@ -5,8 +5,8 @@ use async_std::{
     stream::Stream,
     task::{Context, Poll},
 };
-use std::{fmt, pin::Pin};
 use cap_primitives::{ambient_authority, AmbientAuthority};
+use std::{fmt, pin::Pin};
 
 /// An iterator over incoming connections to a [`UnixListener`].
 ///

--- a/cap-async-std/src/os/unix/net/unix_datagram.rs
+++ b/cap-async-std/src/os/unix/net/unix_datagram.rs
@@ -6,8 +6,8 @@ use async_std::{
         io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
     },
 };
-use std::fmt;
 use cap_primitives::{ambient_authority, AmbientAuthority};
+use std::fmt;
 use unsafe_io::OwnsRaw;
 
 /// A Unix datagram socket.

--- a/cap-async-std/src/os/unix/net/unix_datagram.rs
+++ b/cap-async-std/src/os/unix/net/unix_datagram.rs
@@ -7,6 +7,7 @@ use async_std::{
     },
 };
 use std::fmt;
+use cap_primitives::{ambient_authority, AmbientAuthority};
 use unsafe_io::OwnsRaw;
 
 /// A Unix datagram socket.
@@ -31,12 +32,12 @@ pub struct UnixDatagram {
 impl UnixDatagram {
     /// Constructs a new instance of `Self` from the given `async_std::os::unix::net::UnixDatagram`.
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
     /// `async_std::os::unix::net::UnixDatagram` is not sandboxed and may access any address that
     /// the host process has access to.
     #[inline]
-    pub unsafe fn from_std(std: unix::net::UnixDatagram) -> Self {
+    pub fn from_std(std: unix::net::UnixDatagram, _: AmbientAuthority) -> Self {
         Self { std }
     }
 
@@ -50,7 +51,7 @@ impl UnixDatagram {
     #[inline]
     pub fn unbound() -> io::Result<Self> {
         let unix_datagram = unix::net::UnixDatagram::unbound()?;
-        Ok(unsafe { Self::from_std(unix_datagram) })
+        Ok(Self::from_std(unix_datagram, ambient_authority()))
     }
 
     /// Creates an unnamed pair of connected sockets.
@@ -62,8 +63,12 @@ impl UnixDatagram {
     /// [`async_std::os::unix::net::UnixDatagram::pair`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.pair
     #[inline]
     pub fn pair() -> io::Result<(Self, Self)> {
-        unix::net::UnixDatagram::pair()
-            .map(|(a, b)| unsafe { (Self::from_std(a), Self::from_std(b)) })
+        unix::net::UnixDatagram::pair().map(|(a, b)| {
+            (
+                Self::from_std(a, ambient_authority()),
+                Self::from_std(b, ambient_authority()),
+            )
+        })
     }
 
     // async_std doesn't have `try_clone`.
@@ -144,7 +149,10 @@ impl UnixDatagram {
 impl FromRawFd for UnixDatagram {
     #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self::from_std(unix::net::UnixDatagram::from_raw_fd(fd))
+        Self::from_std(
+            unix::net::UnixDatagram::from_raw_fd(fd),
+            ambient_authority(),
+        )
     }
 }
 

--- a/cap-async-std/src/os/unix/net/unix_listener.rs
+++ b/cap-async-std/src/os/unix/net/unix_listener.rs
@@ -6,8 +6,8 @@ use async_std::{
         io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
     },
 };
-use std::fmt;
 use cap_primitives::{ambient_authority, AmbientAuthority};
+use std::fmt;
 use unsafe_io::OwnsRaw;
 
 /// A structure representing a Unix domain socket server.

--- a/cap-directories/src/lib.rs
+++ b/cap-directories/src/lib.rs
@@ -1,6 +1,7 @@
 //! Capability-oriented standard directories.
 
 #![deny(missing_docs)]
+#![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/bytecodealliance/cap-std/main/media/cap-std.svg"
 )]
@@ -13,6 +14,7 @@ use std::io;
 mod project_dirs;
 mod user_dirs;
 
+pub use cap_std::{ambient_authority, AmbientAuthority};
 pub use project_dirs::ProjectDirs;
 pub use user_dirs::UserDirs;
 

--- a/cap-directories/src/project_dirs.rs
+++ b/cap-directories/src/project_dirs.rs
@@ -1,5 +1,5 @@
 use crate::not_found;
-use cap_std::fs::Dir;
+use cap_std::{ambient_authority, fs::Dir, AmbientAuthority};
 use std::{fs, io};
 
 /// `ProjectDirs` computes the cache, config or data directories for a specific
@@ -25,12 +25,16 @@ impl ProjectDirs {
     ///
     /// This corresponds to [`directories_next::ProjectDirs::from`].
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
-    /// This function is unsafe because it makes use of ambient authority to
-    /// access the project directories, which doesn't uphold the invariant of
-    /// the rest of the API. It is otherwise safe to use.
-    pub unsafe fn from(qualifier: &str, organization: &str, application: &str) -> Option<Self> {
+    /// This function makes use of ambient authority to access the project
+    /// directories.
+    pub fn from(
+        qualifier: &str,
+        organization: &str,
+        application: &str,
+        _: AmbientAuthority,
+    ) -> Option<Self> {
         let inner = directories_next::ProjectDirs::from(qualifier, organization, application)?;
         Some(Self { inner })
     }
@@ -41,7 +45,7 @@ impl ProjectDirs {
     pub fn cache_dir(&self) -> io::Result<Dir> {
         let path = self.inner.cache_dir();
         fs::create_dir_all(path)?;
-        unsafe { Dir::open_ambient_dir(path) }
+        Dir::open_ambient_dir(path, ambient_authority())
     }
 
     /// Returns the project's config directory.
@@ -50,7 +54,7 @@ impl ProjectDirs {
     pub fn config_dir(&self) -> io::Result<Dir> {
         let path = self.inner.config_dir();
         fs::create_dir_all(path)?;
-        unsafe { Dir::open_ambient_dir(path) }
+        Dir::open_ambient_dir(path, ambient_authority())
     }
 
     /// Returns the project's data directory.
@@ -59,7 +63,7 @@ impl ProjectDirs {
     pub fn data_dir(&self) -> io::Result<Dir> {
         let path = self.inner.data_dir();
         fs::create_dir_all(path)?;
-        unsafe { Dir::open_ambient_dir(path) }
+        Dir::open_ambient_dir(path, ambient_authority())
     }
 
     /// Returns the project's local data directory.
@@ -68,7 +72,7 @@ impl ProjectDirs {
     pub fn data_local_dir(&self) -> io::Result<Dir> {
         let path = self.inner.data_local_dir();
         fs::create_dir_all(path)?;
-        unsafe { Dir::open_ambient_dir(path) }
+        Dir::open_ambient_dir(path, ambient_authority())
     }
 
     /// Returns the project's runtime directory.
@@ -77,6 +81,6 @@ impl ProjectDirs {
     pub fn runtime_dir(&self) -> io::Result<Dir> {
         let path = self.inner.runtime_dir().ok_or_else(not_found)?;
         fs::create_dir_all(path)?;
-        unsafe { Dir::open_ambient_dir(path) }
+        Dir::open_ambient_dir(path, ambient_authority())
     }
 }

--- a/cap-directories/src/user_dirs.rs
+++ b/cap-directories/src/user_dirs.rs
@@ -1,5 +1,5 @@
 use crate::not_found;
-use cap_std::fs::Dir;
+use cap_std::{fs::Dir, AmbientAuthority};
 use std::io;
 
 /// `UserDirs` provides paths of user-facing standard directories, following
@@ -31,129 +31,146 @@ impl UserDirs {
     ///
     /// This corresponds to [`directories_next::UserDirs::home_dir`].
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
-    /// This function is unsafe because it makes use of ambient authority to
-    /// access the user directories, which doesn't uphold the invariant of
-    /// the rest of the API. It is otherwise safe to use.
-    pub unsafe fn home_dir(&self) -> io::Result<Dir> {
-        Dir::open_ambient_dir(self.inner.home_dir())
+    /// This function makes use of ambient authority to access the user
+    /// directories.
+    pub fn home_dir(&self, ambient_authority: AmbientAuthority) -> io::Result<Dir> {
+        Dir::open_ambient_dir(self.inner.home_dir(), ambient_authority)
     }
 
     /// Returns the user's audio directory.
     ///
     /// This corresponds to [`directories_next::UserDirs::audio_dir`].
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
-    /// This function is unsafe because it makes use of ambient authority to
-    /// access the user directories, which doesn't uphold the invariant of
-    /// the rest of the API. It is otherwise safe to use.
-    pub unsafe fn audio_dir(&self) -> io::Result<Dir> {
-        Dir::open_ambient_dir(self.inner.audio_dir().ok_or_else(not_found)?)
+    /// This function makes use of ambient authority to access the user
+    /// directories.
+    pub fn audio_dir(&self, ambient_authority: AmbientAuthority) -> io::Result<Dir> {
+        Dir::open_ambient_dir(
+            self.inner.audio_dir().ok_or_else(not_found)?,
+            ambient_authority,
+        )
     }
 
     /// Returns the user's desktop directory.
     ///
     /// This corresponds to [`directories_next::UserDirs::desktop_dir`].
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
-    /// This function is unsafe because it makes use of ambient authority to
-    /// access the user directories, which doesn't uphold the invariant of
-    /// the rest of the API. It is otherwise safe to use.
-    pub unsafe fn desktop_dir(&self) -> io::Result<Dir> {
-        Dir::open_ambient_dir(self.inner.desktop_dir().ok_or_else(not_found)?)
+    /// This function makes use of ambient authority to access the user
+    /// directories.
+    pub fn desktop_dir(&self, ambient_authority: AmbientAuthority) -> io::Result<Dir> {
+        Dir::open_ambient_dir(
+            self.inner.desktop_dir().ok_or_else(not_found)?,
+            ambient_authority,
+        )
     }
 
     /// Returns the user's document directory.
     ///
     /// This corresponds to [`directories_next::UserDirs::document_dir`].
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
-    /// This function is unsafe because it makes use of ambient authority to
-    /// access the user directories, which doesn't uphold the invariant of
-    /// the rest of the API. It is otherwise safe to use.
-    pub unsafe fn document_dir(&self) -> io::Result<Dir> {
-        Dir::open_ambient_dir(self.inner.document_dir().ok_or_else(not_found)?)
+    /// This function makes use of ambient authority to access the user
+    /// directories.
+    pub fn document_dir(&self, ambient_authority: AmbientAuthority) -> io::Result<Dir> {
+        Dir::open_ambient_dir(
+            self.inner.document_dir().ok_or_else(not_found)?,
+            ambient_authority,
+        )
     }
 
     /// Returns the user's download directory.
     ///
     /// This corresponds to [`directories_next::UserDirs::download_dir`].
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
-    /// This function is unsafe because it makes use of ambient authority to
-    /// access the user directories, which doesn't uphold the invariant of
-    /// the rest of the API. It is otherwise safe to use.
-    pub unsafe fn download_dir(&self) -> io::Result<Dir> {
-        Dir::open_ambient_dir(self.inner.download_dir().ok_or_else(not_found)?)
+    /// This function makes use of ambient authority to access the user
+    /// directories.
+    pub fn download_dir(&self, ambient_authority: AmbientAuthority) -> io::Result<Dir> {
+        Dir::open_ambient_dir(
+            self.inner.download_dir().ok_or_else(not_found)?,
+            ambient_authority,
+        )
     }
 
     /// Returns the user's font directory.
     ///
     /// This corresponds to [`directories_next::UserDirs::font_dir`].
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
-    /// This function is unsafe because it makes use of ambient authority to
-    /// access the user directories, which doesn't uphold the invariant of
-    /// the rest of the API. It is otherwise safe to use.
-    pub unsafe fn font_dir(&self) -> io::Result<Dir> {
-        Dir::open_ambient_dir(self.inner.font_dir().ok_or_else(not_found)?)
+    /// This function makes use of ambient authority to access the user
+    /// directories.
+    pub fn font_dir(&self, ambient_authority: AmbientAuthority) -> io::Result<Dir> {
+        Dir::open_ambient_dir(
+            self.inner.font_dir().ok_or_else(not_found)?,
+            ambient_authority,
+        )
     }
 
     /// Returns the user's picture directory.
     ///
     /// This corresponds to [`directories_next::UserDirs::picture_dir`].
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
-    /// This function is unsafe because it makes use of ambient authority to
-    /// access the user directories, which doesn't uphold the invariant of
-    /// the rest of the API. It is otherwise safe to use.
-    pub unsafe fn picture_dir(&self) -> io::Result<Dir> {
-        Dir::open_ambient_dir(self.inner.picture_dir().ok_or_else(not_found)?)
+    /// This function makes use of ambient authority to access the user
+    /// directories.
+    pub fn picture_dir(&self, ambient_authority: AmbientAuthority) -> io::Result<Dir> {
+        Dir::open_ambient_dir(
+            self.inner.picture_dir().ok_or_else(not_found)?,
+            ambient_authority,
+        )
     }
 
     /// Returns the user's public directory.
     ///
     /// This corresponds to [`directories_next::UserDirs::public_dir`].
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
-    /// This function is unsafe because it makes use of ambient authority to
-    /// access the user directories, which doesn't uphold the invariant of
-    /// the rest of the API. It is otherwise safe to use.
-    pub unsafe fn public_dir(&self) -> io::Result<Dir> {
-        Dir::open_ambient_dir(self.inner.public_dir().ok_or_else(not_found)?)
+    /// This function makes use of ambient authority to access the user
+    /// directories.
+    pub fn public_dir(&self, ambient_authority: AmbientAuthority) -> io::Result<Dir> {
+        Dir::open_ambient_dir(
+            self.inner.public_dir().ok_or_else(not_found)?,
+            ambient_authority,
+        )
     }
 
     /// Returns the user's template directory.
     ///
     /// This corresponds to [`directories_next::UserDirs::template_dir`].
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
-    /// This function is unsafe because it makes use of ambient authority to
-    /// access the user directories, which doesn't uphold the invariant of
-    /// the rest of the API. It is otherwise safe to use.
-    pub unsafe fn template_dir(&self) -> io::Result<Dir> {
-        Dir::open_ambient_dir(self.inner.template_dir().ok_or_else(not_found)?)
+    /// This function makes use of ambient authority to access the user
+    /// directories.
+    pub fn template_dir(&self, ambient_authority: AmbientAuthority) -> io::Result<Dir> {
+        Dir::open_ambient_dir(
+            self.inner.template_dir().ok_or_else(not_found)?,
+            ambient_authority,
+        )
     }
 
     /// Returns the user's video directory.
     ///
     /// This corresponds to [`directories_next::UserDirs::video_dir`].
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
-    /// This function is unsafe because it makes use of ambient authority to
-    /// access the user directories, which doesn't uphold the invariant of
-    /// the rest of the API. It is otherwise safe to use.
-    pub unsafe fn video_dir(&self) -> io::Result<Dir> {
-        Dir::open_ambient_dir(self.inner.video_dir().ok_or_else(not_found)?)
+    /// This function makes use of ambient authority to access the user
+    /// directories.
+    pub fn video_dir(&self, ambient_authority: AmbientAuthority) -> io::Result<Dir> {
+        Dir::open_ambient_dir(
+            self.inner.video_dir().ok_or_else(not_found)?,
+            ambient_authority,
+        )
     }
 }

--- a/cap-fs-ext/src/dir_entry_ext.rs
+++ b/cap-fs-ext/src/dir_entry_ext.rs
@@ -35,7 +35,7 @@ impl DirEntryExt for cap_std::fs::DirEntry {
 impl DirEntryExt for cap_std::fs::DirEntry {
     #[inline]
     fn full_metadata(&self) -> io::Result<Metadata> {
-        unsafe { _WindowsDirEntryExt::full_metadata(self) }
+        _WindowsDirEntryExt::full_metadata(self)
     }
 }
 
@@ -51,7 +51,7 @@ impl DirEntryExt for cap_async_std::fs::DirEntry {
 impl DirEntryExt for cap_async_std::fs::DirEntry {
     #[inline]
     fn full_metadata(&self) -> io::Result<Metadata> {
-        unsafe { _WindowsDirEntryExt::full_metadata(self) }
+        _WindowsDirEntryExt::full_metadata(self)
     }
 }
 
@@ -67,7 +67,7 @@ impl DirEntryExt for cap_std::fs_utf8::DirEntry {
 impl DirEntryExt for cap_std::fs_utf8::DirEntry {
     #[inline]
     fn full_metadata(&self) -> io::Result<Metadata> {
-        unsafe { _WindowsDirEntryExt::full_metadata(self) }
+        _WindowsDirEntryExt::full_metadata(self)
     }
 }
 
@@ -83,6 +83,6 @@ impl DirEntryExt for cap_async_std::fs_utf8::DirEntry {
 impl DirEntryExt for cap_async_std::fs_utf8::DirEntry {
     #[inline]
     fn full_metadata(&self) -> io::Result<Metadata> {
-        unsafe { _WindowsDirEntryExt::full_metadata(self) }
+        _WindowsDirEntryExt::full_metadata(self)
     }
 }

--- a/cap-fs-ext/src/file_type_ext.rs
+++ b/cap-fs-ext/src/file_type_ext.rs
@@ -90,21 +90,21 @@ impl FileTypeExt for cap_primitives::fs::FileType {
 impl FileTypeExt for cap_primitives::fs::FileType {
     #[inline]
     fn is_block_device(&self) -> bool {
-        unsafe { _WindowsFileTypeExt::is_block_device(self) }
+        _WindowsFileTypeExt::is_block_device(self)
     }
 
     #[inline]
     fn is_char_device(&self) -> bool {
-        unsafe { _WindowsFileTypeExt::is_char_device(self) }
+        _WindowsFileTypeExt::is_char_device(self)
     }
 
     #[inline]
     fn is_fifo(&self) -> bool {
-        unsafe { _WindowsFileTypeExt::is_fifo(self) }
+        _WindowsFileTypeExt::is_fifo(self)
     }
 
     #[inline]
     fn is_socket(&self) -> bool {
-        unsafe { _WindowsFileTypeExt::is_socket(self) }
+        _WindowsFileTypeExt::is_socket(self)
     }
 }

--- a/cap-fs-ext/src/lib.rs
+++ b/cap-fs-ext/src/lib.rs
@@ -1,6 +1,7 @@
 //! Extension traits for `Dir`
 
 #![deny(missing_docs)]
+#![forbid(unsafe_code)]
 #![cfg_attr(all(windows, windows_by_handle), feature(windows_by_handle))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/bytecodealliance/cap-std/main/media/cap-std.svg"
@@ -31,3 +32,5 @@ pub use reopen::Reopen;
 
 /// Re-export these to allow them to be used with `Reuse`.
 pub use cap_primitives::fs::{FollowSymlinks, Metadata, OpenOptions};
+
+pub use cap_primitives::{ambient_authority, AmbientAuthority};

--- a/cap-fs-ext/src/metadata_ext.rs
+++ b/cap-fs-ext/src/metadata_ext.rs
@@ -92,27 +92,21 @@ impl MetadataExt for cap_primitives::fs::Metadata {
 #[cfg(all(windows, any(feature = "std", feature = "async_std")))]
 impl MetadataExt for cap_primitives::fs::Metadata {
     fn dev(&self) -> u64 {
-        unsafe {
-            _WindowsByHandle::volume_serial_number(self)
-                .expect("`dev` depends on a Metadata constructed from an open `File`")
-                .into()
-        }
+        _WindowsByHandle::volume_serial_number(self)
+            .expect("`dev` depends on a Metadata constructed from an open `File`")
+            .into()
     }
 
     #[inline]
     fn ino(&self) -> u64 {
-        unsafe {
-            _WindowsByHandle::file_index(self)
-                .expect("`ino` depends on a Metadata constructed from an open `File`")
-        }
+        _WindowsByHandle::file_index(self)
+            .expect("`ino` depends on a Metadata constructed from an open `File`")
     }
 
     #[inline]
     fn nlink(&self) -> u64 {
-        unsafe {
-            _WindowsByHandle::number_of_links(self)
-                .expect("`nlink` depends on a Metadata constructed from an open `File`")
-                .into()
-        }
+        _WindowsByHandle::number_of_links(self)
+            .expect("`nlink` depends on a Metadata constructed from an open `File`")
+            .into()
     }
 }

--- a/cap-fs-ext/src/open_options_follow_ext.rs
+++ b/cap-fs-ext/src/open_options_follow_ext.rs
@@ -19,6 +19,6 @@ impl OpenOptionsFollowExt for cap_primitives::fs::OpenOptions {
         // `follow` functionality is implemented within `cap_primitives`; we're
         // just exposing it here since `OpenOptions` is re-exported by
         // `cap_std` etc. and `follow` isn't in `std`.
-        unsafe { self._cap_fs_ext_follow(follow) }
+        self._cap_fs_ext_follow(follow)
     }
 }

--- a/cap-fs-ext/src/open_options_maybe_dir_ext.rs
+++ b/cap-fs-ext/src/open_options_maybe_dir_ext.rs
@@ -15,6 +15,6 @@ impl OpenOptionsMaybeDirExt for cap_primitives::fs::OpenOptions {
         // `maybe_dir` functionality is implemented within `cap_primitives`;
         // we're just exposing it here since `OpenOptions` is re-exported by
         // `cap_std` etc. and `maybe_dir` isn't in `std`.
-        unsafe { self._cap_fs_ext_maybe_dir(maybe_dir) }
+        self._cap_fs_ext_maybe_dir(maybe_dir)
     }
 }

--- a/cap-fs-ext/src/reopen.rs
+++ b/cap-fs-ext/src/reopen.rs
@@ -1,4 +1,7 @@
-use cap_primitives::fs::{reopen, OpenOptions};
+use cap_primitives::{
+    ambient_authority,
+    fs::{reopen, OpenOptions},
+};
 use std::io;
 #[cfg(any(feature = "std", feature = "async_std"))]
 use unsafe_io::AsUnsafeFile;
@@ -40,7 +43,7 @@ impl Reopen for cap_std::fs::File {
     #[inline]
     fn reopen(&self, options: &OpenOptions) -> io::Result<Self> {
         let file = reopen(&AsUnsafeFile::as_file_view(self), options)?;
-        Ok(unsafe { Self::from_std(file) })
+        Ok(Self::from_std(file, ambient_authority()))
     }
 }
 
@@ -49,7 +52,7 @@ impl Reopen for cap_std::fs_utf8::File {
     #[inline]
     fn reopen(&self, options: &OpenOptions) -> io::Result<Self> {
         let file = reopen(&self.as_file_view(), options)?;
-        Ok(unsafe { Self::from_std(file) })
+        Ok(Self::from_std(file, ambient_authority()))
     }
 }
 
@@ -68,7 +71,7 @@ impl Reopen for cap_async_std::fs::File {
     fn reopen(&self, options: &OpenOptions) -> io::Result<Self> {
         let file = reopen(&self.as_file_view(), options)?;
         let std = async_std::fs::File::from_filelike(file);
-        Ok(unsafe { Self::from_std(std) })
+        Ok(Self::from_std(std, ambient_authority()))
     }
 }
 
@@ -78,6 +81,6 @@ impl Reopen for cap_async_std::fs_utf8::File {
     fn reopen(&self, options: &OpenOptions) -> io::Result<Self> {
         let file = reopen(&self.as_file_view(), options)?;
         let std = async_std::fs::File::from_filelike(file);
-        Ok(unsafe { Self::from_std(std) })
+        Ok(Self::from_std(std, ambient_authority()))
     }
 }

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2018"
 rustc_version = "0.3.0"
 
 [dependencies]
+ambient-authority = "0.0.0"
 arbitrary = { version = "1.0.0", optional = true, features = ["derive"] }
 ipnet = "2.3.0"
 maybe-owned = "0.3.4"

--- a/cap-primitives/src/fs/dir_entry.rs
+++ b/cap-primitives/src/fs/dir_entry.rs
@@ -120,12 +120,10 @@ impl fmt::Debug for DirEntry {
 /// Extension trait to allow `full_metadata` etc. to be exposed by
 /// the `cap-fs-ext` crate.
 ///
-/// # Safety
-///
 /// This is hidden from the main API since this functionality isn't present in `std`.
 /// Use `cap_fs_ext::DirEntryExt` instead of calling this directly.
 #[cfg(windows)]
 #[doc(hidden)]
-pub unsafe trait _WindowsDirEntryExt {
-    unsafe fn full_metadata(&self) -> io::Result<Metadata>;
+pub trait _WindowsDirEntryExt {
+    fn full_metadata(&self) -> io::Result<Metadata>;
 }

--- a/cap-primitives/src/fs/file_type.rs
+++ b/cap-primitives/src/fs/file_type.rs
@@ -146,15 +146,13 @@ impl std::os::windows::fs::FileTypeExt for FileType {
 /// Extension trait to allow `is_block_device` etc. to be exposed by
 /// the `cap-fs-ext` crate.
 ///
-/// # Safety
-///
 /// This is hidden from the main API since this functionality isn't present in `std`.
 /// Use `cap_fs_ext::FileTypeExt` instead of calling this directly.
 #[cfg(windows)]
 #[doc(hidden)]
-pub unsafe trait _WindowsFileTypeExt {
-    unsafe fn is_block_device(&self) -> bool;
-    unsafe fn is_char_device(&self) -> bool;
-    unsafe fn is_fifo(&self) -> bool;
-    unsafe fn is_socket(&self) -> bool;
+pub trait _WindowsFileTypeExt {
+    fn is_block_device(&self) -> bool;
+    fn is_char_device(&self) -> bool;
+    fn is_fifo(&self) -> bool;
+    fn is_socket(&self) -> bool;
 }

--- a/cap-primitives/src/fs/metadata.rs
+++ b/cap-primitives/src/fs/metadata.rs
@@ -389,15 +389,13 @@ impl std::os::windows::fs::MetadataExt for Metadata {
 /// Extension trait to allow `volume_serial_number` etc. to be exposed by
 /// the `cap-fs-ext` crate.
 ///
-/// # Safety
-///
 /// This is hidden from the main API since this functionality isn't present in `std`.
 /// Use `cap_fs_ext::MetadataExt` instead of calling this directly.
 #[cfg(windows)]
 #[doc(hidden)]
-pub unsafe trait _WindowsByHandle {
-    unsafe fn file_attributes(&self) -> u32;
-    unsafe fn volume_serial_number(&self) -> Option<u32>;
-    unsafe fn number_of_links(&self) -> Option<u32>;
-    unsafe fn file_index(&self) -> Option<u64>;
+pub trait _WindowsByHandle {
+    fn file_attributes(&self) -> u32;
+    fn volume_serial_number(&self) -> Option<u32>;
+    fn number_of_links(&self) -> Option<u32>;
+    fn file_index(&self) -> Option<u64>;
 }

--- a/cap-primitives/src/fs/mod.rs
+++ b/cap-primitives/src/fs/mod.rs
@@ -103,8 +103,10 @@ fn map_result<T: Clone>(result: &std::io::Result<T>) -> Result<T, (std::io::Erro
 /// Test that `file_path` works on a few miscellaneous directory paths.
 #[test]
 fn dir_paths() {
+    use crate::ambient_authority;
+
     for path in &[std::env::current_dir().unwrap(), std::env::temp_dir()] {
-        let dir = unsafe { open_ambient_dir(&path).unwrap() };
+        let dir = open_ambient_dir(&path, ambient_authority()).unwrap();
         assert_eq!(
             file_path(&dir)
                 .as_ref()

--- a/cap-primitives/src/fs/open_dir.rs
+++ b/cap-primitives/src/fs/open_dir.rs
@@ -4,6 +4,7 @@
 #[allow(unused_imports)]
 use crate::fs::open_unchecked;
 use crate::fs::{dir_options, open, open_ambient_dir_impl, readdir_options, FollowSymlinks};
+use ambient_authority::AmbientAuthority;
 use std::{fs, io, path::Path};
 
 /// Open a directory by performing an `openat`-like operation,
@@ -48,11 +49,11 @@ pub(crate) fn open_dir_for_reading_unchecked(
 /// Open a directory named by a bare path, using the host process' ambient
 /// authority.
 ///
-/// # Safety
+/// # Ambient Authority
 ///
 /// This function is not sandboxed and may trivially access any path that the
 /// host process has access to.
 #[inline]
-pub unsafe fn open_ambient_dir(path: &Path) -> io::Result<fs::File> {
-    open_ambient_dir_impl(path)
+pub fn open_ambient_dir(path: &Path, ambient_authority: AmbientAuthority) -> io::Result<fs::File> {
+    open_ambient_dir_impl(path, ambient_authority)
 }

--- a/cap-primitives/src/fs/open_options.rs
+++ b/cap-primitives/src/fs/open_options.rs
@@ -142,25 +142,21 @@ impl OpenOptions {
 
     /// Wrapper to allow `follow` to be exposed by the `cap-fs-ext` crate.
     ///
-    /// # Safety
-    ///
     /// This is hidden from the main API since this functionality isn't present in `std`.
     /// Use `cap_fs_ext::OpenOptionsFollowExt` instead of calling this directly.
     #[doc(hidden)]
     #[inline]
-    pub unsafe fn _cap_fs_ext_follow(&mut self, follow: FollowSymlinks) -> &mut Self {
+    pub fn _cap_fs_ext_follow(&mut self, follow: FollowSymlinks) -> &mut Self {
         self.follow(follow)
     }
 
     /// Wrapper to allow `maybe_dir` to be exposed by the `cap-fs-ext` crate.
     ///
-    /// # Safety
-    ///
     /// This is hidden from the main API since this functionality isn't present in `std`.
     /// Use `cap_fs_ext::OpenOptionsMaybeDirExt` instead of calling this directly.
     #[doc(hidden)]
     #[inline]
-    pub unsafe fn _cap_fs_ext_maybe_dir(&mut self, maybe_dir: bool) -> &mut Self {
+    pub fn _cap_fs_ext_maybe_dir(&mut self, maybe_dir: bool) -> &mut Self {
         self.maybe_dir(maybe_dir)
     }
 }

--- a/cap-primitives/src/lib.rs
+++ b/cap-primitives/src/lib.rs
@@ -1,6 +1,7 @@
 //! Capability-oriented primitives.
 
 #![deny(missing_docs)]
+#![forbid(unsafe_code)]
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(all(windows, windows_by_handle), feature(windows_by_handle))]
 #![cfg_attr(all(windows, windows_file_type_ext), feature(windows_file_type_ext))]
@@ -19,3 +20,5 @@ mod windows;
 pub mod fs;
 pub mod net;
 pub mod time;
+
+pub use ambient_authority::{ambient_authority, AmbientAuthority};

--- a/cap-primitives/src/net/pool.rs
+++ b/cap-primitives/src/net/pool.rs
@@ -1,3 +1,4 @@
+use ambient_authority::AmbientAuthority;
 use ipnet::IpNet;
 use std::{io, net};
 
@@ -47,10 +48,10 @@ impl Pool {
 
     /// Add a range of network addresses with a specific port to the pool.
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
     /// This function allows ambient access to any IP address.
-    pub unsafe fn insert_ip_net(&mut self, ip_net: ipnet::IpNet, port: u16) {
+    pub fn insert_ip_net(&mut self, ip_net: ipnet::IpNet, port: u16, _: AmbientAuthority) {
         self.grants.push(IpGrant {
             set: AddrSet::Net(ip_net),
             port,
@@ -59,10 +60,10 @@ impl Pool {
 
     /// Add a specific [`net::SocketAddr`] to the pool.
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
     /// This function allows ambient access to any IP address.
-    pub unsafe fn insert_socket_addr(&mut self, addr: net::SocketAddr) {
+    pub fn insert_socket_addr(&mut self, addr: net::SocketAddr, _: AmbientAuthority) {
         self.grants.push(IpGrant {
             set: AddrSet::Net(addr.ip().into()),
             port: addr.port(),

--- a/cap-primitives/src/posish/fs/dir_utils.rs
+++ b/cap-primitives/src/posish/fs/dir_utils.rs
@@ -1,4 +1,5 @@
 use crate::fs::OpenOptions;
+use ambient_authority::AmbientAuthority;
 use posish::fs::OFlags;
 #[cfg(unix)]
 use std::os::unix::{ffi::OsStrExt, fs::OpenOptionsExt};
@@ -91,11 +92,11 @@ pub(crate) fn canonicalize_options() -> OpenOptions {
 /// Open a directory named by a bare path, using the host process' ambient
 /// authority.
 ///
-/// # Safety
+/// # Ambient Authority
 ///
 /// This function is not sandboxed and may trivially access any path that the
 /// host process has access to.
-pub(crate) unsafe fn open_ambient_dir_impl(path: &Path) -> io::Result<fs::File> {
+pub(crate) fn open_ambient_dir_impl(path: &Path, _: AmbientAuthority) -> io::Result<fs::File> {
     // This is for `std::fs`, so we don't have `dir_required`, so set
     // `O_DIRECTORY` manually.
     let flags = OFlags::DIRECTORY | target_o_path();

--- a/cap-primitives/src/time/monotonic_clock.rs
+++ b/cap-primitives/src/time/monotonic_clock.rs
@@ -1,4 +1,5 @@
 use crate::time::{Duration, Instant};
+use ambient_authority::AmbientAuthority;
 use std::time;
 
 /// A reference to a monotonically nondecreasing clock.
@@ -12,11 +13,11 @@ pub struct MonotonicClock(());
 impl MonotonicClock {
     /// Constructs a new instance of `Self`.
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
-    /// This is unsafe because access to clocks is an ambient authority.
+    /// This uses ambient authority to accesses clocks.
     #[inline]
-    pub const unsafe fn new() -> Self {
+    pub const fn new(_: AmbientAuthority) -> Self {
         Self(())
     }
 

--- a/cap-primitives/src/time/system_clock.rs
+++ b/cap-primitives/src/time/system_clock.rs
@@ -1,4 +1,5 @@
 use crate::time::{Duration, SystemTime, SystemTimeError};
+use ambient_authority::AmbientAuthority;
 use std::time;
 
 /// A reference to a system clock, useful for talking to external entities like
@@ -21,11 +22,11 @@ impl SystemClock {
 
     /// Constructs a new instance of `Self`.
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
-    /// This is unsafe because access to clocks is an ambient authority.
+    /// This uses ambient authority to accesses clocks.
     #[inline]
-    pub const unsafe fn new() -> Self {
+    pub const fn new(_: AmbientAuthority) -> Self {
         Self(())
     }
 

--- a/cap-primitives/src/windows/fs/dir_entry_inner.rs
+++ b/cap-primitives/src/windows/fs/dir_entry_inner.rs
@@ -1,7 +1,10 @@
 use super::open_options_to_std;
-use crate::fs::{
-    open, open_ambient_dir, FileType, FileTypeExt, FollowSymlinks, Metadata, OpenOptions, ReadDir,
-    ReadDirInner,
+use crate::{
+    ambient_authority,
+    fs::{
+        open, open_ambient_dir, FileType, FileTypeExt, FollowSymlinks, Metadata, OpenOptions,
+        ReadDir, ReadDirInner,
+    },
 };
 use std::{ffi::OsString, fmt, fs, io, os::windows::fs::OpenOptionsExt};
 use winapi::um::winbase::{FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT};
@@ -25,14 +28,14 @@ impl DirEntryInner {
                 }
                 Ok(file)
             }
-            FollowSymlinks::Yes => unsafe {
+            FollowSymlinks::Yes => {
                 let path = self.std.path();
                 open(
-                    &open_ambient_dir(path.parent().unwrap())?,
+                    &open_ambient_dir(path.parent().unwrap(), ambient_authority())?,
                     path.file_name().unwrap().as_ref(),
                     options,
                 )
-            },
+            }
         }
     }
 
@@ -104,9 +107,9 @@ impl fmt::Debug for DirEntryInner {
 }
 
 #[doc(hidden)]
-unsafe impl crate::fs::_WindowsDirEntryExt for crate::fs::DirEntry {
+impl crate::fs::_WindowsDirEntryExt for crate::fs::DirEntry {
     #[inline]
-    unsafe fn full_metadata(&self) -> io::Result<Metadata> {
+    fn full_metadata(&self) -> io::Result<Metadata> {
         DirEntryInner::full_metadata(&self.inner)
     }
 }

--- a/cap-primitives/src/windows/fs/dir_utils.rs
+++ b/cap-primitives/src/windows/fs/dir_utils.rs
@@ -1,4 +1,7 @@
-use crate::fs::{errors, OpenOptions};
+use crate::{
+    fs::{errors, OpenOptions},
+    AmbientAuthority,
+};
 use std::{
     ffi::OsString,
     fs, io,
@@ -89,11 +92,11 @@ pub(crate) fn canonicalize_options() -> OpenOptions {
 /// Open a directory named by a bare path, using the host process' ambient
 /// authority.
 ///
-/// # Safety
+/// # Ambient Authority
 ///
 /// This function is not sandboxed and may trivially access any path that the
 /// host process has access to.
-pub(crate) unsafe fn open_ambient_dir_impl(path: &Path) -> io::Result<fs::File> {
+pub(crate) fn open_ambient_dir_impl(path: &Path, _: AmbientAuthority) -> io::Result<fs::File> {
     // Set `FILE_FLAG_BACKUP_SEMANTICS` so that we can open directories. Unset
     // `FILE_SHARE_DELETE` so that directories can't be renamed or deleted
     // underneath us, since we use paths to implement many directory operations.

--- a/cap-primitives/src/windows/fs/file_type_ext.rs
+++ b/cap-primitives/src/windows/fs/file_type_ext.rs
@@ -97,24 +97,24 @@ impl FileTypeExt {
 }
 
 #[doc(hidden)]
-unsafe impl crate::fs::_WindowsFileTypeExt for crate::fs::FileType {
+impl crate::fs::_WindowsFileTypeExt for crate::fs::FileType {
     #[inline]
-    unsafe fn is_block_device(&self) -> bool {
+    fn is_block_device(&self) -> bool {
         false
     }
 
     #[inline]
-    unsafe fn is_char_device(&self) -> bool {
+    fn is_char_device(&self) -> bool {
         *self == FileType::ext(FileTypeExt::CharacterDevice)
     }
 
     #[inline]
-    unsafe fn is_fifo(&self) -> bool {
+    fn is_fifo(&self) -> bool {
         *self == FileType::ext(FileTypeExt::Fifo)
     }
 
     #[inline]
-    unsafe fn is_socket(&self) -> bool {
+    fn is_socket(&self) -> bool {
         false
     }
 }

--- a/cap-primitives/src/windows/fs/metadata_ext.rs
+++ b/cap-primitives/src/windows/fs/metadata_ext.rs
@@ -182,24 +182,24 @@ impl std::os::windows::fs::MetadataExt for MetadataExt {
 }
 
 #[doc(hidden)]
-unsafe impl crate::fs::_WindowsByHandle for crate::fs::Metadata {
+impl crate::fs::_WindowsByHandle for crate::fs::Metadata {
     #[inline]
-    unsafe fn file_attributes(&self) -> u32 {
+    fn file_attributes(&self) -> u32 {
         self.ext.file_attributes
     }
 
     #[inline]
-    unsafe fn volume_serial_number(&self) -> Option<u32> {
+    fn volume_serial_number(&self) -> Option<u32> {
         self.ext.volume_serial_number
     }
 
     #[inline]
-    unsafe fn number_of_links(&self) -> Option<u32> {
+    fn number_of_links(&self) -> Option<u32> {
         self.ext.number_of_links
     }
 
     #[inline]
-    unsafe fn file_index(&self) -> Option<u64> {
+    fn file_index(&self) -> Option<u64> {
         self.ext.file_index
     }
 }

--- a/cap-rand/Cargo.toml
+++ b/cap-rand/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/bytecodealliance/cap-std"
 edition = "2018"
 
 [dependencies]
+ambient-authority = "0.0.0"
 rand = "0.8.1"
 
 [features]

--- a/cap-rand/src/lib.rs
+++ b/cap-rand/src/lib.rs
@@ -21,6 +21,7 @@
 //! [`CapRng`]: crate::rngs::CapRng
 
 #![deny(missing_docs)]
+#![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/bytecodealliance/cap-std/main/media/cap-std.svg"
 )]
@@ -28,6 +29,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/bytecodealliance/cap-std/main/media/cap-std.ico"
 )]
 
+pub use ambient_authority::{ambient_authority, AmbientAuthority};
 pub use rand::{distributions, seq, CryptoRng, Error, Fill, Rng, RngCore, SeedableRng};
 
 /// Convenience re-export of common members.
@@ -49,6 +51,8 @@ pub mod prelude {
 ///
 /// This corresponds to [`rand::rngs`].
 pub mod rngs {
+    use super::AmbientAuthority;
+
     pub use rand::rngs::{adapter, mock, StdRng};
 
     #[cfg(feature = "small_rng")]
@@ -58,21 +62,20 @@ pub mod rngs {
     /// operating system.
     ///
     /// This corresponds to [`rand::rngs::OsRng`], except instead of
-    /// implementing `Default` it has an unsafe `default` function since
-    /// accessing the operating system requires ambient authority.
+    /// implementing `Default` it has an ambient-authority `default` function
+    /// to access the operating system.
     #[derive(Clone, Copy, Debug)]
     pub struct OsRng(());
 
     impl OsRng {
         /// Returns an `OsRng` instance.
         ///
-        /// # Safety
+        /// # Ambient Authority
         ///
-        /// This function is unsafe because it makes use of ambient authority
-        /// to access the platform entropy source, which doesn't uphold the
-        /// invariant of the rest of the API. It is otherwise safe to use.
+        /// This function makes use of ambient authority to access the platform
+        /// entropy source.
         #[inline]
-        pub const unsafe fn default() -> Self {
+        pub const fn default(_: AmbientAuthority) -> Self {
             Self(())
         }
     }
@@ -114,14 +117,13 @@ pub mod rngs {
     impl CapRng {
         /// A convenience alias for calling `thread_rng`.
         ///
-        /// # Safety
+        /// # Ambient Authority
         ///
-        /// This function is unsafe because it makes use of ambient authority
-        /// to access the platform entropy source, which doesn't uphold the
-        /// invariant of the rest of the API. It is otherwise safe to use.
+        /// This function makes use of ambient authority to access the platform
+        /// entropy source.
         #[inline]
-        pub unsafe fn default() -> Self {
-            crate::thread_rng()
+        pub fn default(ambient_authority: AmbientAuthority) -> Self {
+            crate::thread_rng(ambient_authority)
         }
     }
 
@@ -155,13 +157,12 @@ pub mod rngs {
 ///
 /// This corresponds to [`rand::thread_rng`].
 ///
-/// # Safety
+/// # Ambient Authority
 ///
-/// This function is unsafe because it makes use of ambient authority to
-/// access the platform entropy source, which doesn't uphold the invariant
-/// of the rest of the API. It is otherwise safe to use.
+/// This function makes use of ambient authority to access the platform entropy
+/// source.
 #[inline]
-pub unsafe fn thread_rng() -> rngs::CapRng {
+pub fn thread_rng(_: AmbientAuthority) -> rngs::CapRng {
     rngs::CapRng {
         inner: rand::thread_rng(),
     }
@@ -171,13 +172,12 @@ pub unsafe fn thread_rng() -> rngs::CapRng {
 ///
 /// This corresponds to [`rand::random`].
 ///
-/// # Safety
+/// # Ambient Authority
 ///
-/// This function is unsafe because it makes use of ambient authority to
-/// access the platform entropy source, which doesn't uphold the invariant
-/// of the rest of the API. It is otherwise safe to use.
+/// This function makes use of ambient authority to access the platform entropy
+/// source.
 #[inline]
-pub unsafe fn random<T>() -> T
+pub fn random<T>(_: AmbientAuthority) -> T
 where
     crate::distributions::Standard: crate::distributions::Distribution<T>,
 {

--- a/cap-std/src/fs/dir_entry.rs
+++ b/cap-std/src/fs/dir_entry.rs
@@ -1,4 +1,5 @@
 use crate::fs::{Dir, File, FileType, Metadata, OpenOptions};
+use cap_primitives::ambient_authority;
 #[cfg(not(windows))]
 use posish::fs::DirEntryExt;
 use std::{ffi::OsString, fmt, io};
@@ -27,21 +28,21 @@ impl DirEntry {
     #[inline]
     pub fn open(&self) -> io::Result<File> {
         let file = self.inner.open()?;
-        Ok(unsafe { File::from_std(file) })
+        Ok(File::from_std(file, ambient_authority()))
     }
 
     /// Open the file with the given options.
     #[inline]
     pub fn open_with(&self, options: &OpenOptions) -> io::Result<File> {
         let file = self.inner.open_with(options)?;
-        Ok(unsafe { File::from_std(file) })
+        Ok(File::from_std(file, ambient_authority()))
     }
 
     /// Open the entry as a directory.
     #[inline]
     pub fn open_dir(&self) -> io::Result<Dir> {
         let dir = self.inner.open_dir()?;
-        Ok(unsafe { Dir::from_std_file(dir) })
+        Ok(Dir::from_std_file(dir, ambient_authority()))
     }
 
     /// Removes the file from its filesystem.
@@ -92,9 +93,9 @@ impl DirEntryExt for DirEntry {
 
 #[cfg(windows)]
 #[doc(hidden)]
-unsafe impl cap_primitives::fs::_WindowsDirEntryExt for DirEntry {
+impl cap_primitives::fs::_WindowsDirEntryExt for DirEntry {
     #[inline]
-    unsafe fn full_metadata(&self) -> io::Result<Metadata> {
+    fn full_metadata(&self) -> io::Result<Metadata> {
         cap_primitives::fs::_WindowsDirEntryExt::full_metadata(&self.inner)
     }
 }

--- a/cap-std/src/fs_utf8/dir_entry.rs
+++ b/cap-std/src/fs_utf8/dir_entry.rs
@@ -100,9 +100,9 @@ impl DirEntryExt for DirEntry {
 
 #[cfg(windows)]
 #[doc(hidden)]
-unsafe impl cap_primitives::fs::_WindowsDirEntryExt for DirEntry {
+impl cap_primitives::fs::_WindowsDirEntryExt for DirEntry {
     #[inline]
-    unsafe fn full_metadata(&self) -> io::Result<Metadata> {
+    fn full_metadata(&self) -> io::Result<Metadata> {
         self.cap_std.full_metadata()
     }
 }

--- a/cap-std/src/fs_utf8/file.rs
+++ b/cap-std/src/fs_utf8/file.rs
@@ -1,6 +1,7 @@
 #[cfg(with_options)]
 use crate::fs::OpenOptions;
 use crate::fs::{Metadata, Permissions};
+use cap_primitives::{ambient_authority, AmbientAuthority};
 #[cfg(target_os = "wasi")]
 use std::path::Path;
 use std::{
@@ -35,13 +36,13 @@ pub struct File {
 impl File {
     /// Constructs a new instance of `Self` from the given [`std::fs::File`].
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
     /// [`std::fs::File`] is not sandboxed and may access any path that the
     /// host process has access to.
     #[inline]
-    pub unsafe fn from_std(std: fs::File) -> Self {
-        Self::from_cap_std(crate::fs::File::from_std(std))
+    pub fn from_std(std: fs::File, ambient_authority: AmbientAuthority) -> Self {
+        Self::from_cap_std(crate::fs::File::from_std(std, ambient_authority))
     }
 
     /// Constructs a new instance of `Self` from the given `cap_std::fs::File`.
@@ -121,7 +122,7 @@ impl File {
 impl FromRawFd for File {
     #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self::from_std(fs::File::from_raw_fd(fd))
+        Self::from_std(fs::File::from_raw_fd(fd), ambient_authority())
     }
 }
 
@@ -129,7 +130,7 @@ impl FromRawFd for File {
 impl FromRawHandle for File {
     #[inline]
     unsafe fn from_raw_handle(handle: RawHandle) -> Self {
-        Self::from_std(fs::File::from_raw_handle(handle))
+        Self::from_std(fs::File::from_raw_handle(handle), ambient_authority())
     }
 }
 

--- a/cap-std/src/lib.rs
+++ b/cap-std/src/lib.rs
@@ -45,4 +45,5 @@ pub mod os;
 pub mod time;
 // For now, re-export `path`; see
 // <https://github.com/bytecodealliance/cap-std/issues/88>
+pub use cap_primitives::{ambient_authority, AmbientAuthority};
 pub use std::path;

--- a/cap-std/src/net/incoming.rs
+++ b/cap-std/src/net/incoming.rs
@@ -1,4 +1,5 @@
 use crate::net::TcpStream;
+use cap_primitives::{ambient_authority, AmbientAuthority};
 use std::{fmt, io, net};
 
 /// An iterator that infinitely `accept`s connections on a [`TcpListener`].
@@ -13,12 +14,12 @@ pub struct Incoming<'a> {
 impl<'a> Incoming<'a> {
     /// Constructs a new instance of `Self` from the given `std::net::Incoming`.
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
     /// `std::net::Incoming` is not sandboxed and may access any address that the host
     /// process has access to.
     #[inline]
-    pub unsafe fn from_std(std: net::Incoming<'a>) -> Self {
+    pub fn from_std(std: net::Incoming<'a>, _: AmbientAuthority) -> Self {
         Self { std }
     }
 }
@@ -30,7 +31,7 @@ impl<'a> Iterator for Incoming<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.std.next().map(|result| {
             let tcp_stream = result?;
-            Ok(unsafe { TcpStream::from_std(tcp_stream) })
+            Ok(TcpStream::from_std(tcp_stream, ambient_authority()))
         })
     }
 

--- a/cap-std/src/net/pool.rs
+++ b/cap-std/src/net/pool.rs
@@ -1,5 +1,5 @@
 use crate::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs, UdpSocket};
-use cap_primitives::{ambient_authority, net::NO_SOCKET_ADDRS};
+use cap_primitives::{ambient_authority, net::NO_SOCKET_ADDRS, AmbientAuthority};
 use std::{io, net, time::Duration};
 
 /// A pool of network addresses.
@@ -21,20 +21,29 @@ impl Pool {
 
     /// Add a range of network addresses with a specific port to the pool.
     ///
-    /// # Safety
+    /// # AmbientAuthority
     ///
     /// This function allows ambient access to any IP address.
-    pub unsafe fn insert_ip_net(&mut self, ip_net: ipnet::IpNet, port: u16) {
-        self.cap.insert_ip_net(ip_net, port)
+    pub fn insert_ip_net(
+        &mut self,
+        ip_net: ipnet::IpNet,
+        port: u16,
+        ambient_authority: AmbientAuthority,
+    ) {
+        self.cap.insert_ip_net(ip_net, port, ambient_authority)
     }
 
     /// Add a specific [`net::SocketAddr`] to the pool.
     ///
-    /// # Safety
+    /// # AmbientAuthority
     ///
     /// This function allows ambient access to any IP address.
-    pub unsafe fn insert_socket_addr(&mut self, addr: net::SocketAddr) {
-        self.cap.insert_socket_addr(addr)
+    pub fn insert_socket_addr(
+        &mut self,
+        addr: net::SocketAddr,
+        ambient_authority: AmbientAuthority,
+    ) {
+        self.cap.insert_socket_addr(addr, ambient_authority)
     }
 
     /// Creates a new `TcpListener` which will be bound to the specified address.

--- a/cap-std/src/net/tcp_stream.rs
+++ b/cap-std/src/net/tcp_stream.rs
@@ -1,4 +1,5 @@
 use crate::net::{Shutdown, SocketAddr};
+use cap_primitives::{ambient_authority, AmbientAuthority};
 use std::{
     fmt,
     io::{self, IoSlice, IoSliceMut, Read, Write},
@@ -31,12 +32,12 @@ pub struct TcpStream {
 impl TcpStream {
     /// Constructs a new instance of `Self` from the given `std::net::TcpStream`.
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
     /// `std::net::TcpStream` is not sandboxed and may access any address that the host
     /// process has access to.
     #[inline]
-    pub unsafe fn from_std(std: net::TcpStream) -> Self {
+    pub fn from_std(std: net::TcpStream, _: AmbientAuthority) -> Self {
         Self { std }
     }
 
@@ -70,7 +71,7 @@ impl TcpStream {
     #[inline]
     pub fn try_clone(&self) -> io::Result<Self> {
         let tcp_stream = self.std.try_clone()?;
-        Ok(unsafe { Self::from_std(tcp_stream) })
+        Ok(Self::from_std(tcp_stream, ambient_authority()))
     }
 
     /// Sets the read timeout to the timeout specified.
@@ -167,7 +168,7 @@ impl TcpStream {
 impl FromRawFd for TcpStream {
     #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self::from_std(net::TcpStream::from_raw_fd(fd))
+        Self::from_std(net::TcpStream::from_raw_fd(fd), ambient_authority())
     }
 }
 
@@ -175,7 +176,7 @@ impl FromRawFd for TcpStream {
 impl FromRawSocket for TcpStream {
     #[inline]
     unsafe fn from_raw_socket(socket: RawSocket) -> Self {
-        Self::from_std(net::TcpStream::from_raw_socket(socket))
+        Self::from_std(net::TcpStream::from_raw_socket(socket), ambient_authority())
     }
 }
 

--- a/cap-std/src/net/udp_socket.rs
+++ b/cap-std/src/net/udp_socket.rs
@@ -1,4 +1,5 @@
 use crate::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use cap_primitives::{ambient_authority, AmbientAuthority};
 use std::{fmt, io, net, time::Duration};
 #[cfg(not(windows))]
 use unsafe_io::os::posish::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -30,12 +31,12 @@ pub struct UdpSocket {
 impl UdpSocket {
     /// Constructs a new instance of `Self` from the given `std::net::UdpSocket`.
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
     /// `std::net::UdpSocket` is not sandboxed and may access any address that the host
     /// process has access to.
     #[inline]
-    pub unsafe fn from_std(std: net::UdpSocket) -> Self {
+    pub fn from_std(std: net::UdpSocket, _: AmbientAuthority) -> Self {
         Self { std }
     }
 
@@ -77,7 +78,7 @@ impl UdpSocket {
     #[inline]
     pub fn try_clone(&self) -> io::Result<Self> {
         let udp_socket = self.std.try_clone()?;
-        Ok(unsafe { Self::from_std(udp_socket) })
+        Ok(Self::from_std(udp_socket, ambient_authority()))
     }
 
     /// Sets the read timeout to the timeout specified.
@@ -275,7 +276,7 @@ impl UdpSocket {
 impl FromRawFd for UdpSocket {
     #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self::from_std(net::UdpSocket::from_raw_fd(fd))
+        Self::from_std(net::UdpSocket::from_raw_fd(fd), ambient_authority())
     }
 }
 
@@ -283,7 +284,7 @@ impl FromRawFd for UdpSocket {
 impl FromRawSocket for UdpSocket {
     #[inline]
     unsafe fn from_raw_socket(socket: RawSocket) -> Self {
-        Self::from_std(net::UdpSocket::from_raw_socket(socket))
+        Self::from_std(net::UdpSocket::from_raw_socket(socket), ambient_authority())
     }
 }
 

--- a/cap-tempfile/src/lib.rs
+++ b/cap-tempfile/src/lib.rs
@@ -1,6 +1,7 @@
 //! Capability-oriented temporary directories.
 
 #![deny(missing_docs)]
+#![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/bytecodealliance/cap-std/main/media/cap-std.svg"
 )]
@@ -12,6 +13,8 @@ use cap_std::fs::Dir;
 use std::{env, fmt, fs, io, mem, ops::Deref};
 #[cfg(not(target_os = "emscripten"))]
 use uuid::Uuid;
+
+pub use cap_std::{ambient_authority, AmbientAuthority};
 
 /// A directory in a filesystem that is automatically deleted when it goes out
 /// of scope.
@@ -34,18 +37,17 @@ impl TempDir {
     ///
     /// [`tempfile::TempDir::new`]: https://docs.rs/tempfile/latest/tempfile/struct.TempDir.html#method.new
     ///
-    /// # Safety
+    /// # Ambient Authority
     ///
-    /// This function is unsafe because it makes use of ambient authority to
-    /// access temporary directories, which doesn't uphold the invariant of
-    /// the rest of the API. It is otherwise safe to use.
-    pub unsafe fn new() -> io::Result<Self> {
+    /// This function makes use of ambient authority to access temporary
+    /// directories.
+    pub fn new(ambient_authority: AmbientAuthority) -> io::Result<Self> {
         let system_tmp = env::temp_dir();
         for _ in 0..Self::num_iterations() {
             let name = system_tmp.join(&Self::new_name());
             match fs::create_dir(&name) {
                 Ok(()) => {
-                    let dir = match Dir::open_ambient_dir(&name) {
+                    let dir = match Dir::open_ambient_dir(&name, ambient_authority) {
                         Ok(dir) => dir,
                         Err(e) => {
                             fs::remove_dir(name).ok();
@@ -152,13 +154,12 @@ impl fmt::Debug for TempDir {
 ///
 /// [`tempfile::tempdir`]: https://docs.rs/tempfile/latest/tempfile/fn.tempdir.html
 ///
-/// # Safety
+/// # Ambient Authority
 ///
-/// This function is unsafe because it makes use of ambient authority to
-/// access temporary directories, which doesn't uphold the invariant of
-/// the rest of the API. It is otherwise safe to use.
-pub unsafe fn tempdir() -> io::Result<TempDir> {
-    TempDir::new()
+/// This function makes use of ambient authority to access temporary
+/// directories.
+pub fn tempdir(ambient_authority: AmbientAuthority) -> io::Result<TempDir> {
+    TempDir::new(ambient_authority)
 }
 
 /// Create a new temporary directory.
@@ -172,33 +173,43 @@ pub fn tempdir_in(dir: &Dir) -> io::Result<TempDir> {
 
 #[test]
 fn drop_tempdir() {
-    let t = unsafe { tempdir().unwrap() };
+    use crate::ambient_authority;
+
+    let t = tempdir(ambient_authority()).unwrap();
     drop(t)
 }
 
 #[test]
 fn close_tempdir() {
-    let t = unsafe { tempdir().unwrap() };
+    use crate::ambient_authority;
+
+    let t = tempdir(ambient_authority()).unwrap();
     t.close().unwrap();
 }
 
 #[test]
 fn drop_tempdir_in() {
-    let dir = unsafe { Dir::open_ambient_dir(env::temp_dir()).unwrap() };
+    use crate::ambient_authority;
+
+    let dir = Dir::open_ambient_dir(env::temp_dir(), ambient_authority()).unwrap();
     let t = tempdir_in(&dir).unwrap();
     drop(t);
 }
 
 #[test]
 fn close_tempdir_in() {
-    let dir = unsafe { Dir::open_ambient_dir(env::temp_dir()).unwrap() };
+    use crate::ambient_authority;
+
+    let dir = Dir::open_ambient_dir(env::temp_dir(), ambient_authority()).unwrap();
     let t = tempdir_in(&dir).unwrap();
     t.close().unwrap();
 }
 
 #[test]
 fn close_outer() {
-    let t = unsafe { tempdir().unwrap() };
+    use crate::ambient_authority;
+
+    let t = tempdir(ambient_authority()).unwrap();
     let _s = tempdir_in(&t).unwrap();
     #[cfg(windows)]
     assert_eq!(
@@ -211,7 +222,9 @@ fn close_outer() {
 
 #[test]
 fn close_inner() {
-    let t = unsafe { tempdir().unwrap() };
+    use crate::ambient_authority;
+
+    let t = tempdir(ambient_authority()).unwrap();
     let s = tempdir_in(&t).unwrap();
     s.close().unwrap();
 }

--- a/cap-time-ext/src/lib.rs
+++ b/cap-time-ext/src/lib.rs
@@ -1,6 +1,7 @@
 //! Extension traits for `SystemClock` and `MonotonicClock`
 
 #![deny(missing_docs)]
+#![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/bytecodealliance/cap-std/main/media/cap-std.svg"
 )]

--- a/examples/async_std_fs_misc.rs
+++ b/examples/async_std_fs_misc.rs
@@ -2,7 +2,10 @@
 // adapted to use this crate instead.
 
 use async_std::{io, io::prelude::*};
-use cap_async_std::fs::{Dir, OpenOptions};
+use cap_async_std::{
+    ambient_authority,
+    fs::{Dir, OpenOptions},
+};
 //use async_std::os::unix;
 use std::path::Path;
 
@@ -33,7 +36,7 @@ fn touch(dir: &mut Dir, path: &Path) -> io::Result<()> {
 
 #[async_std::main]
 async fn main() {
-    let mut cwd = unsafe { Dir::open_ambient_dir(".") }.expect("!");
+    let mut cwd = Dir::open_ambient_dir(".", ambient_authority()).expect("!");
 
     println!("`mkdir a`");
 

--- a/examples/kv-cli.rs
+++ b/examples/kv-cli.rs
@@ -5,7 +5,7 @@
 //! scheme the filesystem uses, but it makes a simple illustration of the
 //! `cap-std` API.
 
-use cap_directories::ProjectDirs;
+use cap_directories::{ambient_authority, ProjectDirs};
 use std::{env::args, path::PathBuf, str};
 
 fn main() -> anyhow::Result<()> {
@@ -19,13 +19,12 @@ fn main() -> anyhow::Result<()> {
     }
 
     // Obtain the `data_dir` for this program.
-    let project_dirs = unsafe {
-        ProjectDirs::from(
-            "com.example",
-            "Example Organization",
-            "Cap-std Key-Value CLI Example",
-        )
-    }
+    let project_dirs = ProjectDirs::from(
+        "com.example",
+        "Example Organization",
+        "Cap-std Key-Value CLI Example",
+        ambient_authority(),
+    )
     .ok_or_else(no_project_dirs)?;
     let mut data_dir = project_dirs.data_dir()?;
 

--- a/examples/std_fs_misc.rs
+++ b/examples/std_fs_misc.rs
@@ -1,7 +1,10 @@
 // Copied from https://doc.rust-lang.org/rust-by-example/std_misc/fs.html and
 // adapted to use this crate instead.
 
-use cap_std::fs::{Dir, OpenOptions};
+use cap_std::{
+    ambient_authority,
+    fs::{Dir, OpenOptions},
+};
 use std::{io, io::prelude::*};
 //use std::os::unix;
 use std::path::Path;
@@ -32,7 +35,7 @@ fn touch(dir: &mut Dir, path: &Path) -> io::Result<()> {
 }
 
 fn main() {
-    let mut cwd = unsafe { Dir::open_ambient_dir(".") }.expect("!");
+    let mut cwd = Dir::open_ambient_dir(".", ambient_authority()).expect("!");
 
     println!("`mkdir a`");
 

--- a/fuzz/fuzz_targets/cap-primitives.rs
+++ b/fuzz/fuzz_targets/cap-primitives.rs
@@ -4,7 +4,10 @@
 extern crate libfuzzer_sys;
 
 use arbitrary::Arbitrary;
-use cap_primitives::fs::{open_ambient_dir, DirOptions, FollowSymlinks, OpenOptions};
+use cap_primitives::{
+    ambient_authority,
+    fs::{open_ambient_dir, DirOptions, FollowSymlinks, OpenOptions},
+};
 use std::{fs, path::PathBuf};
 use tempfile::tempdir;
 
@@ -206,7 +209,7 @@ fuzz_target!(|plan: Plan| {
     let tmp = tempdir().unwrap();
     fs::create_dir(tmp.path().join("dir")).unwrap();
 
-    let dir = unsafe { open_ambient_dir(&tmp.path().join("dir")).unwrap() };
+    let dir = open_ambient_dir(&tmp.path().join("dir"), ambient_authority()).unwrap();
 
     let mut files = (0..8).map(|_| dir.try_clone().unwrap()).collect::<Vec<_>>();
 

--- a/tests/dir-ext.rs
+++ b/tests/dir-ext.rs
@@ -1,13 +1,13 @@
 mod sys_common;
 
 use cap_fs_ext::DirExt;
-use cap_tempfile::TempDir;
+use cap_tempfile::{ambient_authority, TempDir};
 
 use sys_common::symlink_supported;
 
 #[test]
 fn remove_file() {
-    let tempdir = unsafe { TempDir::new() }.expect("create tempdir");
+    let tempdir = TempDir::new(ambient_authority()).expect("create tempdir");
     let file = tempdir.create("file").expect("create file to delete");
     drop(file);
     tempdir.remove_file_or_symlink("file").expect("delete file");
@@ -20,7 +20,7 @@ fn remove_symlink_to_file() {
         return;
     }
 
-    let tempdir = unsafe { TempDir::new() }.expect("create tempdir");
+    let tempdir = TempDir::new(ambient_authority()).expect("create tempdir");
     let target = tempdir.create("target").expect("create target file");
     drop(target);
     tempdir.symlink("target", "link").expect("create symlink");
@@ -38,7 +38,7 @@ fn remove_symlink_to_dir() {
         return;
     }
 
-    let tempdir = unsafe { TempDir::new() }.expect("create tempdir");
+    let tempdir = TempDir::new(ambient_authority()).expect("create tempdir");
     let target = tempdir.create_dir("target").expect("create target dir");
     drop(target);
     tempdir.symlink("target", "link").expect("create symlink");
@@ -52,7 +52,7 @@ fn remove_symlink_to_dir() {
 
 #[test]
 fn do_not_remove_dir() {
-    let tempdir = unsafe { TempDir::new() }.expect("create tempdir");
+    let tempdir = TempDir::new(ambient_authority()).expect("create tempdir");
     let subdir = tempdir.create_dir("subdir").expect("create dir");
     drop(subdir);
     assert!(tempdir.exists("subdir"), "subdir created");

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -8,7 +8,10 @@ mod sys_common;
 
 use std::io::prelude::*;
 
-use cap_std::fs::{self, Dir, OpenOptions};
+use cap_std::{
+    ambient_authority,
+    fs::{self, Dir, OpenOptions},
+};
 #[cfg(not(racy_asserts))] // racy asserts are racy
 use std::thread;
 use std::{
@@ -849,7 +852,7 @@ fn symlink_noexist() {
 fn read_link() {
     if cfg!(windows) {
         // directory symlink
-        let root = unsafe { Dir::open_ambient_dir(r"C:\").unwrap() };
+        let root = Dir::open_ambient_dir(r"C:\", ambient_authority()).unwrap();
         error_contains!(
             root.read_link(r"Users\All Users"),
             "a path led outside of the filesystem"

--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -281,7 +281,7 @@ fn follow_dotdot_symlink() {
 
 #[test]
 fn follow_dotdot_symlink_ambient() {
-    use cap_std::fs::Dir;
+    use cap_std::{ambient_authority, fs::Dir};
     #[cfg(unix)]
     use std::os::unix::fs::symlink as symlink_dir;
     #[cfg(windows)]
@@ -298,33 +298,52 @@ fn follow_dotdot_symlink_ambient() {
     check!(symlink_dir("../../..", dir.path().join("a/b/e")));
     check!(symlink_dir("../../../..", dir.path().join("a/b/f")));
 
-    unsafe {
-        check!(Dir::open_ambient_dir(dir.path().join("a/b/c")));
-        assert!(check!(std::fs::metadata(dir.path().join("a/b/c"))).is_dir());
+    check!(Dir::open_ambient_dir(
+        dir.path().join("a/b/c"),
+        ambient_authority()
+    ));
+    assert!(check!(std::fs::metadata(dir.path().join("a/b/c"))).is_dir());
 
-        #[cfg(windows)]
-        {
-            error!(Dir::open_ambient_dir(dir.path().join("a/b/d")), 123);
-            error!(std::fs::metadata(dir.path().join("a/b/d")), 123);
+    #[cfg(windows)]
+    {
+        error!(
+            Dir::open_ambient_dir(dir.path().join("a/b/d"), ambient_authority()),
+            123
+        );
+        error!(std::fs::metadata(dir.path().join("a/b/d")), 123);
 
-            error!(Dir::open_ambient_dir(dir.path().join("a/b/e")), 123);
-            error!(std::fs::metadata(dir.path().join("a/b/e")), 123);
+        error!(
+            Dir::open_ambient_dir(dir.path().join("a/b/e"), ambient_authority()),
+            123
+        );
+        error!(std::fs::metadata(dir.path().join("a/b/e")), 123);
 
-            error!(Dir::open_ambient_dir(dir.path().join("a/b/f")), 123);
-            error!(std::fs::metadata(dir.path().join("a/b/f")), 123);
-        }
+        error!(
+            Dir::open_ambient_dir(dir.path().join("a/b/f"), ambient_authority()),
+            123
+        );
+        error!(std::fs::metadata(dir.path().join("a/b/f")), 123);
+    }
 
-        #[cfg(not(windows))]
-        {
-            check!(Dir::open_ambient_dir(dir.path().join("a/b/d")));
-            assert!(check!(std::fs::metadata(dir.path().join("a/b/d"))).is_dir());
+    #[cfg(not(windows))]
+    {
+        check!(Dir::open_ambient_dir(
+            dir.path().join("a/b/d"),
+            ambient_authority()
+        ));
+        assert!(check!(std::fs::metadata(dir.path().join("a/b/d"))).is_dir());
 
-            check!(Dir::open_ambient_dir(dir.path().join("a/b/e")));
-            assert!(check!(std::fs::metadata(dir.path().join("a/b/e"))).is_dir());
+        check!(Dir::open_ambient_dir(
+            dir.path().join("a/b/e"),
+            ambient_authority()
+        ));
+        assert!(check!(std::fs::metadata(dir.path().join("a/b/e"))).is_dir());
 
-            check!(Dir::open_ambient_dir(dir.path().join("a/b/f")));
-            assert!(check!(std::fs::metadata(dir.path().join("a/b/f"))).is_dir());
-        }
+        check!(Dir::open_ambient_dir(
+            dir.path().join("a/b/f"),
+            ambient_authority()
+        ));
+        assert!(check!(std::fs::metadata(dir.path().join("a/b/f"))).is_dir());
     }
 }
 
@@ -486,7 +505,7 @@ fn file_with_trailing_slashdot() {
 #[cfg(windows)]
 #[test]
 fn file_with_trailing_slashdot_ambient() {
-    use cap_std::fs::Dir;
+    use cap_std::{ambient_authority, fs::Dir};
     let dir = tempfile::tempdir().unwrap();
     check!(std::fs::File::create(dir.path().join("file")));
     check!(std::fs::File::open(dir.path().join("file")));
@@ -498,17 +517,36 @@ fn file_with_trailing_slashdot_ambient() {
     assert!(std::fs::File::open(dir.path().join("file/")).is_err());
     assert!(std::fs::File::open(dir.path().join("file\\.\\")).is_err());
     assert!(std::fs::File::open(dir.path().join("file/./")).is_err());
-    unsafe {
-        check!(Dir::open_ambient_dir(dir.path().join("file/..")));
-        check!(Dir::open_ambient_dir(dir.path().join("file\\.\\..")));
-        check!(Dir::open_ambient_dir(dir.path().join("file/./..")));
-        check!(Dir::open_ambient_dir(dir.path().join("file\\..\\.")));
-        check!(Dir::open_ambient_dir(dir.path().join("file/../.")));
-        check!(Dir::open_ambient_dir(dir.path().join("file\\..\\")));
-        check!(Dir::open_ambient_dir(dir.path().join("file/../")));
-        assert!(Dir::open_ambient_dir(dir.path().join("file\\...")).is_err());
-        assert!(Dir::open_ambient_dir(dir.path().join("file/...")).is_err());
-    }
+    check!(Dir::open_ambient_dir(
+        dir.path().join("file/.."),
+        ambient_authority()
+    ));
+    check!(Dir::open_ambient_dir(
+        dir.path().join("file\\.\\.."),
+        ambient_authority()
+    ));
+    check!(Dir::open_ambient_dir(
+        dir.path().join("file/./.."),
+        ambient_authority()
+    ));
+    check!(Dir::open_ambient_dir(
+        dir.path().join("file\\..\\."),
+        ambient_authority()
+    ));
+    check!(Dir::open_ambient_dir(
+        dir.path().join("file/../."),
+        ambient_authority()
+    ));
+    check!(Dir::open_ambient_dir(
+        dir.path().join("file\\..\\"),
+        ambient_authority()
+    ));
+    check!(Dir::open_ambient_dir(
+        dir.path().join("file/../"),
+        ambient_authority()
+    ));
+    assert!(Dir::open_ambient_dir(dir.path().join("file\\..."), ambient_authority()).is_err());
+    assert!(Dir::open_ambient_dir(dir.path().join("file/..."), ambient_authority()).is_err());
 }
 
 #[cfg(all(unix, not(any(target_os = "ios", target_os = "macos"))))]

--- a/tests/net-udp.rs
+++ b/tests/net-udp.rs
@@ -4,7 +4,7 @@
 mod net;
 mod sys_common;
 
-use cap_std::net::*;
+use cap_std::{ambient_authority, net::*};
 use net::{next_test_ip4, next_test_ip6};
 use std::{io::ErrorKind, sync::mpsc::channel};
 //use sys_common::AsInner;
@@ -30,9 +30,7 @@ macro_rules! t {
 #[test]
 fn bind_error() {
     let mut pool = Pool::new();
-    unsafe {
-        pool.insert_socket_addr("1.1.1.1:9999".parse().unwrap());
-    }
+    pool.insert_socket_addr("1.1.1.1:9999".parse().unwrap(), ambient_authority());
 
     match pool.bind_udp_socket("1.1.1.1:9999") {
         Ok(..) => panic!(),
@@ -44,13 +42,9 @@ fn bind_error() {
 fn socket_smoke_test_ip4() {
     each_ip(&mut |server_ip, client_ip| {
         let mut client_pool = Pool::new();
-        unsafe {
-            client_pool.insert_socket_addr(client_ip);
-        }
+        client_pool.insert_socket_addr(client_ip, ambient_authority());
         let mut server_pool = Pool::new();
-        unsafe {
-            server_pool.insert_socket_addr(server_ip);
-        }
+        server_pool.insert_socket_addr(server_ip, ambient_authority());
 
         let (tx1, rx1) = channel();
         let (tx2, rx2) = channel();
@@ -78,9 +72,7 @@ fn socket_smoke_test_ip4() {
 fn socket_name() {
     each_ip(&mut |addr, _| {
         let mut pool = Pool::new();
-        unsafe {
-            pool.insert_socket_addr(addr);
-        }
+        pool.insert_socket_addr(addr, ambient_authority());
 
         let server = t!(pool.bind_udp_socket(&addr));
         assert_eq!(addr, t!(server.local_addr()));
@@ -91,13 +83,9 @@ fn socket_name() {
 fn socket_peer() {
     each_ip(&mut |addr1, addr2| {
         let mut pool1 = Pool::new();
-        unsafe {
-            pool1.insert_socket_addr(addr1);
-        }
+        pool1.insert_socket_addr(addr1, ambient_authority());
         let mut pool2 = Pool::new();
-        unsafe {
-            pool2.insert_socket_addr(addr2);
-        }
+        pool2.insert_socket_addr(addr2, ambient_authority());
 
         let server = t!(pool1.bind_udp_socket(&addr1));
         assert_eq!(
@@ -113,13 +101,9 @@ fn socket_peer() {
 fn udp_clone_smoke() {
     each_ip(&mut |addr1, addr2| {
         let mut pool1 = Pool::new();
-        unsafe {
-            pool1.insert_socket_addr(addr1);
-        }
+        pool1.insert_socket_addr(addr1, ambient_authority());
         let mut pool2 = Pool::new();
-        unsafe {
-            pool2.insert_socket_addr(addr2);
-        }
+        pool2.insert_socket_addr(addr2, ambient_authority());
 
         let sock1 = t!(pool1.bind_udp_socket(&addr1));
         let sock2 = t!(pool2.bind_udp_socket(&addr2));
@@ -152,13 +136,9 @@ fn udp_clone_smoke() {
 fn udp_clone_two_read() {
     each_ip(&mut |addr1, addr2| {
         let mut pool1 = Pool::new();
-        unsafe {
-            pool1.insert_socket_addr(addr1);
-        }
+        pool1.insert_socket_addr(addr1, ambient_authority());
         let mut pool2 = Pool::new();
-        unsafe {
-            pool2.insert_socket_addr(addr2);
-        }
+        pool2.insert_socket_addr(addr2, ambient_authority());
 
         let sock1 = t!(pool1.bind_udp_socket(&addr1));
         let sock2 = t!(pool2.bind_udp_socket(&addr2));
@@ -193,13 +173,9 @@ fn udp_clone_two_read() {
 fn udp_clone_two_write() {
     each_ip(&mut |addr1, addr2| {
         let mut pool1 = Pool::new();
-        unsafe {
-            pool1.insert_socket_addr(addr1);
-        }
+        pool1.insert_socket_addr(addr1, ambient_authority());
         let mut pool2 = Pool::new();
-        unsafe {
-            pool2.insert_socket_addr(addr2);
-        }
+        pool2.insert_socket_addr(addr2, ambient_authority());
 
         let sock1 = t!(pool1.bind_udp_socket(&addr1));
         let sock2 = t!(pool2.bind_udp_socket(&addr2));
@@ -242,9 +218,7 @@ fn debug() {
     let socket_addr = next_test_ip4();
 
     let mut pool = Pool::new();
-    unsafe { pool.insert_socket_addr(socket_addr); }
 
-    let udpsock = t!(pool.bind_udp_socket(&socket_addr));
     let udpsock_inner = udpsock.0.socket().as_inner();
     let compare = format!("UdpSocket {{ addr: {:?}, {}: {:?} }}", socket_addr, name, udpsock_inner);
     assert_eq!(format!("{:?}", udpsock), compare);
@@ -263,9 +237,7 @@ fn timeouts() {
     let addr = next_test_ip4();
 
     let mut pool = Pool::new();
-    unsafe {
-        pool.insert_socket_addr(addr);
-    }
+    pool.insert_socket_addr(addr, ambient_authority());
 
     let stream = t!(pool.bind_udp_socket(&addr));
     let dur = Duration::new(15410, 0);
@@ -292,9 +264,7 @@ fn test_read_timeout() {
     let addr = next_test_ip4();
 
     let mut pool = Pool::new();
-    unsafe {
-        pool.insert_socket_addr(addr);
-    }
+    pool.insert_socket_addr(addr, ambient_authority());
 
     let stream = t!(pool.bind_udp_socket(&addr));
     t!(stream.set_read_timeout(Some(Duration::from_millis(1000))));
@@ -325,9 +295,7 @@ fn test_read_with_timeout() {
     let addr = next_test_ip4();
 
     let mut pool = Pool::new();
-    unsafe {
-        pool.insert_socket_addr(addr);
-    }
+    pool.insert_socket_addr(addr, ambient_authority());
 
     let stream = t!(pool.bind_udp_socket(&addr));
     t!(stream.set_read_timeout(Some(Duration::from_millis(1000))));
@@ -364,9 +332,7 @@ fn test_timeout_zero_duration() {
     let addr = next_test_ip4();
 
     let mut pool = Pool::new();
-    unsafe {
-        pool.insert_socket_addr(addr);
-    }
+    pool.insert_socket_addr(addr, ambient_authority());
 
     let socket = t!(pool.bind_udp_socket(&addr));
 
@@ -384,9 +350,7 @@ fn connect_send_recv() {
     let addr = next_test_ip4();
 
     let mut pool = Pool::new();
-    unsafe {
-        pool.insert_socket_addr(addr);
-    }
+    pool.insert_socket_addr(addr, ambient_authority());
 
     let socket = t!(pool.bind_udp_socket(&addr));
     t!(pool.connect_udp_socket(&socket, addr));
@@ -402,9 +366,7 @@ fn connect_send_recv() {
 fn connect_send_peek_recv() {
     each_ip(&mut |addr, _| {
         let mut pool = Pool::new();
-        unsafe {
-            pool.insert_socket_addr(addr);
-        }
+        pool.insert_socket_addr(addr, ambient_authority());
 
         let socket = t!(pool.bind_udp_socket(&addr));
         t!(pool.connect_udp_socket(&socket, addr));
@@ -429,9 +391,7 @@ fn connect_send_peek_recv() {
 fn peek_from() {
     each_ip(&mut |addr, _| {
         let mut pool = Pool::new();
-        unsafe {
-            pool.insert_socket_addr(addr);
-        }
+        pool.insert_socket_addr(addr, ambient_authority());
 
         let socket = t!(pool.bind_udp_socket(&addr));
         t!(pool.send_to_udp_socket_addr(&socket, b"hello world", &addr));
@@ -457,9 +417,7 @@ fn ttl() {
     let addr = next_test_ip4();
 
     let mut pool = Pool::new();
-    unsafe {
-        pool.insert_socket_addr(addr);
-    }
+    pool.insert_socket_addr(addr, ambient_authority());
 
     let stream = t!(pool.bind_udp_socket(&addr));
 
@@ -471,9 +429,7 @@ fn ttl() {
 fn set_nonblocking() {
     each_ip(&mut |addr, _| {
         let mut pool = Pool::new();
-        unsafe {
-            pool.insert_socket_addr(addr);
-        }
+        pool.insert_socket_addr(addr, ambient_authority());
 
         let socket = t!(pool.bind_udp_socket(&addr));
 

--- a/tests/readdir.rs
+++ b/tests/readdir.rs
@@ -1,4 +1,7 @@
-use cap_std::fs::{Dir, DirEntry};
+use cap_std::{
+    ambient_authority,
+    fs::{Dir, DirEntry},
+};
 use std::{collections::HashMap, path::Path};
 
 #[test]
@@ -36,7 +39,7 @@ fn test_dir_entries() {
 #[test]
 fn test_reread_entries() {
     let tmpdir = tempfile::tempdir().expect("construct tempdir");
-    let dir = unsafe { Dir::open_ambient_dir(tmpdir.path()).unwrap() };
+    let dir = Dir::open_ambient_dir(tmpdir.path(), ambient_authority()).unwrap();
 
     let entries = read_entries(&dir);
     assert_eq!(entries.len(), 0, "empty dir");
@@ -67,7 +70,7 @@ fn test_reread_entries() {
 }
 
 fn dir_entries(path: &Path) -> HashMap<String, DirEntry> {
-    let dir = unsafe { Dir::open_ambient_dir(path).unwrap() };
+    let dir = Dir::open_ambient_dir(path, ambient_authority()).unwrap();
     read_entries(&dir)
 }
 

--- a/tests/root.rs
+++ b/tests/root.rs
@@ -1,12 +1,12 @@
 #[macro_use]
 mod sys_common;
 
-use cap_std::fs::Dir;
+use cap_std::{ambient_authority, fs::Dir};
 use std::{fs, path::Component};
 
 #[test]
 fn open_root() {
-    let root = unsafe { Dir::open_ambient_dir(Component::RootDir.as_os_str()) }
+    let root = Dir::open_ambient_dir(Component::RootDir.as_os_str(), ambient_authority())
         .expect("expect to be able to open the root directory");
     error_contains!(
         root.read_dir(Component::ParentDir.as_os_str()),
@@ -19,7 +19,7 @@ fn open_root() {
 #[test]
 fn remove_root() {
     let _observed = {
-        let root = unsafe { Dir::open_ambient_dir(Component::RootDir.as_os_str()) }
+        let root = Dir::open_ambient_dir(Component::RootDir.as_os_str(), ambient_authority())
             .expect("expect to be able to open the root directory");
         root.remove_open_dir().unwrap_err()
     };

--- a/tests/sys_common/io.rs
+++ b/tests/sys_common/io.rs
@@ -4,7 +4,10 @@ pub use cap_tempfile::TempDir;
 
 #[allow(unused)]
 pub fn tmpdir() -> TempDir {
-    // It's ok to wrap this in an unsafe block, rather than an unsafe function,
-    // because this function is only used by tests.
-    unsafe { tempdir() }.expect("expected to be able to create a temporary directory")
+    use cap_tempfile::ambient_authority;
+
+    // It's ok to call `ambient_authority()` here, rather than take an
+    // `AmbientAuthority` argument, because this function is only used
+    // by tests.
+    tempdir(ambient_authority()).expect("expected to be able to create a temporary directory")
 }

--- a/tests/time.rs
+++ b/tests/time.rs
@@ -1,7 +1,10 @@
 // This file is derived from Rust's library/std/src/time/tests.rs at revision
 // 108e90ca78f052c0c1c49c42a22c85620be19712.
 
-use cap_std::time::{Duration, MonotonicClock, SystemClock};
+use cap_std::{
+    ambient_authority,
+    time::{Duration, MonotonicClock, SystemClock},
+};
 
 macro_rules! assert_almost_eq {
     ($a:expr, $b:expr) => {{
@@ -20,7 +23,7 @@ macro_rules! assert_almost_eq {
 
 #[test]
 fn instant_monotonic() {
-    let clock = unsafe { MonotonicClock::new() };
+    let clock = MonotonicClock::new(ambient_authority());
     let a = clock.now();
     let b = clock.now();
     assert!(b >= a);
@@ -28,14 +31,14 @@ fn instant_monotonic() {
 
 #[test]
 fn instant_elapsed() {
-    let clock = unsafe { MonotonicClock::new() };
+    let clock = MonotonicClock::new(ambient_authority());
     let a = clock.now();
     clock.elapsed(a);
 }
 
 #[test]
 fn instant_math() {
-    let clock = unsafe { MonotonicClock::new() };
+    let clock = MonotonicClock::new(ambient_authority());
     let a = clock.now();
     let b = clock.now();
     println!("a: {:?}", a);
@@ -68,7 +71,7 @@ fn instant_math() {
 
 #[test]
 fn instant_math_is_associative() {
-    let clock = unsafe { MonotonicClock::new() };
+    let clock = MonotonicClock::new(ambient_authority());
     let now = clock.now();
     let offset = Duration::from_millis(5);
     // Changing the order of instant math shouldn't change the results,
@@ -79,14 +82,14 @@ fn instant_math_is_associative() {
 #[test]
 #[should_panic]
 fn instant_duration_since_panic() {
-    let clock = unsafe { MonotonicClock::new() };
+    let clock = MonotonicClock::new(ambient_authority());
     let a = clock.now();
     (a - Duration::new(1, 0)).duration_since(a);
 }
 
 #[test]
 fn instant_checked_duration_since_nopanic() {
-    let clock = unsafe { MonotonicClock::new() };
+    let clock = MonotonicClock::new(ambient_authority());
     let now = clock.now();
     let earlier = now - Duration::new(1, 0);
     let later = now + Duration::new(1, 0);
@@ -97,7 +100,7 @@ fn instant_checked_duration_since_nopanic() {
 
 #[test]
 fn instant_saturating_duration_since_nopanic() {
-    let clock = unsafe { MonotonicClock::new() };
+    let clock = MonotonicClock::new(ambient_authority());
     let a = clock.now();
     let ret = (a - Duration::new(1, 0)).saturating_duration_since(a);
     assert_eq!(ret, Duration::new(0, 0));
@@ -105,7 +108,7 @@ fn instant_saturating_duration_since_nopanic() {
 
 #[test]
 fn system_time_math() {
-    let clock = unsafe { SystemClock::new() };
+    let clock = SystemClock::new(ambient_authority());
     let a = clock.now();
     let b = clock.now();
     match b.duration_since(a) {
@@ -156,14 +159,14 @@ fn system_time_math() {
 
 #[test]
 fn system_time_elapsed() {
-    let clock = unsafe { SystemClock::new() };
+    let clock = SystemClock::new(ambient_authority());
     let a = clock.now();
     drop(clock.elapsed(a));
 }
 
 #[test]
 fn since_epoch() {
-    let clock = unsafe { SystemClock::new() };
+    let clock = SystemClock::new(ambient_authority());
     let ts = clock.now();
     let a = ts
         .duration_since(SystemClock::UNIX_EPOCH + Duration::new(1, 0))

--- a/tests/windows-open.rs
+++ b/tests/windows-open.rs
@@ -97,12 +97,20 @@ fn windows_open_tricky() {
 #[test]
 #[cfg(windows)]
 fn windows_open_ambient() {
+    use cap_std::{ambient_authority, fs::Dir};
+
     let ambient_dir = tempfile::tempdir().unwrap();
 
-    let tmpdir = check!(unsafe { cap_std::fs::Dir::open_ambient_dir(ambient_dir.path()) });
+    let tmpdir = check!(Dir::open_ambient_dir(
+        ambient_dir.path(),
+        ambient_authority()
+    ));
     check!(tmpdir.create_dir("aaa"));
 
-    let dir = check!(unsafe { cap_std::fs::Dir::open_ambient_dir(ambient_dir.path().join("aaa")) });
+    let dir = check!(Dir::open_ambient_dir(
+        ambient_dir.path().join("aaa"),
+        ambient_authority()
+    ));
 
     // Attempts to remove or rename the open directory should fail.
     tmpdir.remove_dir("aaa").unwrap_err();

--- a/tests/windows_symlinks.rs
+++ b/tests/windows_symlinks.rs
@@ -38,6 +38,7 @@ fn windows_symlinks() {
 
 #[test]
 fn windows_symlinks_ambient() {
+    use cap_std::{ambient_authority, fs::Dir};
     use std::{
         fs,
         os::windows::fs::{symlink_dir, symlink_file},
@@ -68,11 +69,11 @@ fn windows_symlinks_ambient() {
     let (_maj, _min, build) = nt_version::get();
     if (build & 0xffff) > 17134 {
         assert!(
-            unsafe { cap_std::fs::Dir::open_ambient_dir(dir.path().join("dir_symlink_file")) }
+            Dir::open_ambient_dir(dir.path().join("dir_symlink_file"), ambient_authority())
                 .is_err()
         );
         assert!(
-            unsafe { cap_std::fs::Dir::open_ambient_dir(dir.path().join("file_symlink_dir")) }
+            Dir::open_ambient_dir(dir.path().join("file_symlink_dir"), ambient_authority())
                 .is_err()
         );
         assert!(fs::metadata(dir.path().join("dir_symlink_file")).is_err());


### PR DESCRIPTION
Use the ambient-authority crate instead of `unsafe`.
    
Use the newly-created ambient-authority crate to indicate functions
which have ambient authority, rather than using `unsafe`.

Fixes #141.
