### PR TITLE
Explicitly disallow Windows reserved filenames.

### DIFF
--- a/cap-primitives/src/windows/fs/mod.rs
+++ b/cap-primitives/src/windows/fs/mod.rs
@@ -1,5 +1,3 @@
-use crate::fs::manually;
-
 mod copy;
 mod create_dir_unchecked;
 mod dir_entry_inner;
@@ -12,6 +10,7 @@ mod is_file_read_write_impl;
 mod is_same_file;
 mod metadata_ext;
 mod oflags;
+mod open_impl;
 mod open_options_ext;
 mod open_unchecked;
 mod read_dir_inner;
@@ -53,8 +52,8 @@ pub(crate) use file_type_ext::*;
 pub(crate) use hard_link_unchecked::*;
 pub(crate) use is_file_read_write_impl::*;
 pub(crate) use is_same_file::*;
-pub(crate) use manually::open as open_impl;
 pub(crate) use metadata_ext::*;
+pub(crate) use open_impl::open_impl;
 pub(crate) use open_options_ext::*;
 pub(crate) use open_unchecked::*;
 pub(crate) use read_dir_inner::*;

--- a/cap-primitives/src/windows/fs/open_impl.rs
+++ b/cap-primitives/src/windows/fs/open_impl.rs
@@ -1,0 +1,26 @@
+use crate::fs::{manually, OpenOptions};
+use std::{fs, io, path::Path};
+use winapi::shared::winerror::ERROR_FILE_NOT_FOUND;
+
+pub(crate) fn open_impl(
+    start: &fs::File,
+    path: &Path,
+    options: &OpenOptions,
+) -> io::Result<fs::File> {
+    // Windows reserves several special device paths. Disallow opening any
+    // of them.
+    if let Some(stem) = path.file_stem() {
+        if let Some(stemstr) = stem.to_str() {
+            match stemstr.to_uppercase().as_str() {
+                "CON" | "PRN" | "AUX" | "NUL" | "COM0" | "COM1" | "COM2" | "COM3" | "COM4"
+                | "COM5" | "COM6" | "COM7" | "COM8" | "COM9" | "LPT0" | "LPT1" | "LPT2"
+                | "LPT3" | "LPT4" | "LPT5" | "LPT6" | "LPT7" | "LPT8" | "LPT9" => {
+                    return Err(io::Error::from_raw_os_error(ERROR_FILE_NOT_FOUND as i32));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    manually::open(start, path, options)
+}

--- a/tests/windows-open.rs
+++ b/tests/windows-open.rs
@@ -114,3 +114,39 @@ fn windows_open_ambient() {
     check!(tmpdir.rename("aaa", &tmpdir, "xxx"));
     check!(tmpdir.remove_dir("xxx"));
 }
+
+#[test]
+#[cfg(windows)]
+fn windows_open_special() {
+    let tmpdir = tmpdir();
+
+    // Opening any of these should fail.
+    for device in &[
+        "CON", "PRN", "AUX", "NUL", "COM0", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7",
+        "COM8", "COM9", "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8",
+        "LPT9",
+    ] {
+        tmpdir.open(device).unwrap_err();
+        tmpdir.open(&format!(".\\{}", device)).unwrap_err();
+        tmpdir.open(&format!("{}.ext", device)).unwrap_err();
+        tmpdir.open(&format!(".\\{}.ext", device)).unwrap_err();
+
+        let mut options = cap_std::fs::OpenOptions::new();
+        options.write(true);
+        tmpdir.open_with(device, &options).unwrap_err();
+        tmpdir
+            .open_with(&format!(".\\{}", device), &options)
+            .unwrap_err();
+        tmpdir
+            .open_with(&format!("{}.ext", device), &options)
+            .unwrap_err();
+        tmpdir
+            .open_with(&format!(".\\{}.ext", device), &options)
+            .unwrap_err();
+
+        tmpdir.create(device).unwrap_err();
+        tmpdir.create(&format!(".\\{}", device)).unwrap_err();
+        tmpdir.create(&format!("{}.ext", device)).unwrap_err();
+        tmpdir.create(&format!(".\\{}.ext", device)).unwrap_err();
+    }
+}


### PR DESCRIPTION
Check for Windows reserved names like "NUL" explicitly rather than
having the underlying OS check it for us.

Fixes #165.