### PR TITLE
Have `full_metadata` fail rather than falling back to partial results.

### DIFF
--- a/cap-fs-ext/src/dir_entry_ext.rs
+++ b/cap-fs-ext/src/dir_entry_ext.rs
@@ -7,6 +7,11 @@ use std::io;
 pub trait DirEntryExt {
     /// Return the full metadata, which on Windows includes the optional
     /// values.
+    ///
+    /// If the full metadata cannot be computed, this fails rather than
+    /// falling back to partial metadata, even when that might not fail.
+    /// If partial metadata is desired, `std::fs::DirEntry::metadata` can
+    /// be used.
     fn full_metadata(&self) -> io::Result<Metadata>;
 }
 

--- a/cap-primitives/src/windows/fs/dir_entry_inner.rs
+++ b/cap-primitives/src/windows/fs/dir_entry_inner.rs
@@ -50,10 +50,8 @@ impl DirEntryInner {
         opts.access_mode(0);
         opts.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS);
         opts.follow(FollowSymlinks::No);
-        match self.open(&opts) {
-            Ok(opened) => Metadata::from_file(&opened),
-            Err(_) => self.metadata(),
-        }
+        let opened = self.open(&opts)?;
+        Metadata::from_file(&opened)
     }
 
     #[inline]


### PR DESCRIPTION
`full_metadata` requires some additional system calls which may fail
even when plain `metadata` may succeed. Have `full_metadata` fail rather
than implicitly calling `metadata` so that it always either returns full
results or fails.