### PR TITLE
Networking support

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,12 @@ and `green`.
 
 ## What about networking?
 
-This library contains a few sketches of how to apply similar ideas to
-networking, but it's very incomplete at this time. If you're interested in this
-area, let's talk about what this might become!
+cap-std also contains a simple capability-oriented version of `std::net`, with
+a [`Pool`] type that represents a pool of network addresses and ports that can
+be accessed, which serves an analogous role to [`Dir`]. It's usable for basic
+use cases, though it's not yet very sophisticated.
+
+[`Pool`]: https://docs.rs/cap-std/latest/cap_std/net/struct.Pool.html
 
 ## What is `cap_std::fs_utf8`?
 

--- a/cap-async-std/Cargo.toml
+++ b/cap-async-std/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2018"
 arf-strings = { version = "0.3.0", optional = true }
 async-std = { version = "1.9.0", features = ["attributes"] }
 cap-primitives = { path = "../cap-primitives", version = "^0.13.11-alpha.0"}
+ipnet = "2.3.0"
 unsafe-io = { version = "0.6.0", features = ["async-std"] }
 
 [target.'cfg(not(windows))'.dependencies]

--- a/cap-async-std/src/lib.rs
+++ b/cap-async-std/src/lib.rs
@@ -6,22 +6,22 @@
 //! objects which can be passed around between different parts of a
 //! program.
 //!
-//! Two notable features are the [`Dir`] and [`Catalog`] types:
+//! Two notable features are the [`Dir`] and [`Pool`] types:
 //!  - `Dir` represents an open directory in a filesystem. Instead of
 //!    opening files by absolute paths or paths relative to the current
 //!    working directory, files are opened via paths relative to a
 //!    `Dir`. The concepts of a process-wide "current working directory"
 //!    and a single global filesystem namespace are de-emphasized.
-//!  - `Catalog` represents a set of network addresses. Instead of
+//!  - `Pool` represents a set of network addresses. Instead of
 //!    allowing applications to request access to any address and then
 //!    applying process-wide filtering rules, filtering rules are
-//!    built into catalogs which may be passed through the program.
+//!    built into pools which may be passed through the program.
 //!
 //! On WASI, use of this library closely reflects the underlying system
 //! API, so it avoids compatibility layers.
 //!
 //! [`Dir`]: fs::Dir
-//! [`Catalog`]: net::Catalog
+//! [`Pool`]: net::Pool
 
 #![deny(missing_docs)]
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]

--- a/cap-async-std/src/net/incoming.rs
+++ b/cap-async-std/src/net/incoming.rs
@@ -4,7 +4,7 @@ use async_std::{
     stream::Stream,
     task::{Context, Poll},
 };
-use std::pin::Pin;
+use std::{fmt, pin::Pin};
 
 /// An iterator that infinitely `accept`s connections on a [`TcpListener`].
 ///
@@ -47,4 +47,8 @@ impl<'a> Stream for Incoming<'a> {
     }
 }
 
-// TODO: impl Debug for Incoming
+impl<'a> fmt::Debug for Incoming<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.std.fmt(f)
+    }
+}

--- a/cap-async-std/src/net/mod.rs
+++ b/cap-async-std/src/net/mod.rs
@@ -5,18 +5,18 @@
 //! This corresponds to [`async_std::net`].
 //!
 //! Instead of [`async_std::net`]'s constructor methods which take an address to
-//! connect to, this crates has methods on [`Catalog`] which operate on addresses
-//! which must be present in the catalog.
+//! connect to, this crates has methods on [`Pool`] which operate on addresses
+//! which must be present in the pool.
 //!
-//! [`Catalog`]: struct.Catalog.html
+//! [`Pool`]: struct.Pool.html
 
-mod catalog;
+mod pool;
 mod incoming;
 mod tcp_listener;
 mod tcp_stream;
 mod udp_socket;
 
-pub use catalog::*;
+pub use pool::*;
 pub use incoming::*;
 pub use tcp_listener::*;
 pub use tcp_stream::*;

--- a/cap-async-std/src/net/mod.rs
+++ b/cap-async-std/src/net/mod.rs
@@ -1,7 +1,5 @@
 //! A capability-oriented network API modeled after `async_std::net`.
 //!
-//! XXX: The interfaces in this module are not yet implemented.
-//!
 //! This corresponds to [`async_std::net`].
 //!
 //! Instead of [`async_std::net`]'s constructor methods which take an address to

--- a/cap-async-std/src/net/mod.rs
+++ b/cap-async-std/src/net/mod.rs
@@ -10,14 +10,14 @@
 //!
 //! [`Pool`]: struct.Pool.html
 
-mod pool;
 mod incoming;
+mod pool;
 mod tcp_listener;
 mod tcp_stream;
 mod udp_socket;
 
-pub use pool::*;
 pub use incoming::*;
+pub use pool::*;
 pub use tcp_listener::*;
 pub use tcp_stream::*;
 pub use udp_socket::*;

--- a/cap-async-std/src/net/pool.rs
+++ b/cap-async-std/src/net/pool.rs
@@ -4,8 +4,6 @@ use crate::net::{TcpListener, TcpStream, ToSocketAddrs, UdpSocket};
 use async_std::{io, net};
 use cap_primitives::net::NO_SOCKET_ADDRS;
 
-// FIXME: lots more to do here
-
 #[derive(Clone)]
 pub struct Pool {
     cap: cap_primitives::net::Pool,

--- a/cap-async-std/src/net/pool.rs
+++ b/cap-async-std/src/net/pool.rs
@@ -1,9 +1,11 @@
-#![allow(missing_docs)] // TODO: add docs
-
 use crate::net::{TcpListener, TcpStream, ToSocketAddrs, UdpSocket};
 use async_std::{io, net};
 use cap_primitives::net::NO_SOCKET_ADDRS;
 
+/// A pool of network addresses.
+///
+/// This does not directly correspond to anything in `std`, however its methods
+/// correspond to the several functions in [`std::net`].
 #[derive(Clone)]
 pub struct Pool {
     cap: cap_primitives::net::Pool,
@@ -17,6 +19,8 @@ impl Pool {
         }
     }
 
+    /// Add a range of network addresses with a specific port to the pool.
+    ///
     /// # Safety
     ///
     /// This function allows ambient access to any IP address.
@@ -24,6 +28,8 @@ impl Pool {
         self.cap.insert_ip_net(ip_net, port)
     }
 
+    /// Add a specific [`net::SocketAddr`] to the pool.
+    ///
     /// # Safety
     ///
     /// This function allows ambient access to any IP address.
@@ -31,6 +37,10 @@ impl Pool {
         self.cap.insert_socket_addr(addr)
     }
 
+    /// Creates a new `TcpListener` which will be bound to the specified
+    /// address.
+    ///
+    /// This corresponds to [`async_std::net::TcpListener::bind`].
     #[inline]
     pub async fn bind_tcp_listener<A: ToSocketAddrs>(&self, addr: A) -> io::Result<TcpListener> {
         let addrs = addr.to_socket_addrs().await?;
@@ -50,6 +60,9 @@ impl Pool {
         }
     }
 
+    /// Creates a new TCP stream connected to the specified address.
+    ///
+    /// This corresponds to [`async_std::net::TcpStream::connect`].
     #[inline]
     pub async fn connect_tcp_stream<A: ToSocketAddrs>(&self, addr: A) -> io::Result<TcpStream> {
         let addrs = addr.to_socket_addrs().await?;
@@ -71,6 +84,9 @@ impl Pool {
 
     // async_std doesn't have `connect_timeout`.
 
+    /// Creates a UDP socket from the given address.
+    ///
+    /// This corresponds to [`async_std::net::UdpSocket::bind`].
     #[inline]
     pub async fn bind_udp_socket<A: ToSocketAddrs>(&self, addr: A) -> io::Result<UdpSocket> {
         let addrs = addr.to_socket_addrs().await?;
@@ -89,6 +105,9 @@ impl Pool {
         }
     }
 
+    /// Sends data on the socket to the given address.
+    ///
+    /// This corresponds to [`async_std::net::UdpSocket::send_to`].
     #[inline]
     pub async fn send_to_udp_socket_addr<A: ToSocketAddrs>(
         &self,
@@ -107,6 +126,9 @@ impl Pool {
         udp_socket.std.send_to(buf, addr).await
     }
 
+    /// Connects the UDP socket to a remote address.
+    ///
+    /// This corresponds to [`async_std::net::UdpSocket::connect`].
     #[inline]
     pub async fn connect_udp_socket<A: ToSocketAddrs>(
         &self,

--- a/cap-async-std/src/net/pool.rs
+++ b/cap-async-std/src/net/pool.rs
@@ -1,119 +1,111 @@
 #![allow(missing_docs)] // TODO: add docs
 
-use crate::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs, UdpSocket};
+use crate::net::{TcpListener, TcpStream, ToSocketAddrs, UdpSocket};
+use async_std::{io, net};
 use cap_primitives::net::NO_SOCKET_ADDRS;
-use std::{io, net, time::Duration};
 
 // FIXME: lots more to do here
 
-pub struct Catalog {
-    cap: cap_primitives::net::Catalog,
+pub struct Pool {
+    cap: cap_primitives::net::Pool,
 }
 
-impl Catalog {
+impl Pool {
     #[inline]
-    pub fn bind_tcp_listener<A: ToSocketAddrs>(&self, addr: A) -> io::Result<TcpListener> {
-        let addrs = addr.to_socket_addrs()?;
+    pub async fn bind_tcp_listener<A: ToSocketAddrs>(&self, addr: A) -> io::Result<TcpListener> {
+        let addrs = addr.to_socket_addrs().await?;
 
         let mut last_err = None;
         for addr in addrs {
             self.cap.check_addr(&addr)?;
             // TODO: when compiling for WASI, use WASI-specific methods instead
-            match net::TcpListener::bind(addr) {
+            match net::TcpListener::bind(addr).await {
                 Ok(tcp_listener) => return Ok(unsafe { TcpListener::from_std(tcp_listener) }),
                 Err(e) => last_err = Some(e),
             }
         }
         match last_err {
             Some(e) => Err(e),
-            None => Err(net::TcpListener::bind(NO_SOCKET_ADDRS).unwrap_err()),
+            None => Err(net::TcpListener::bind(NO_SOCKET_ADDRS).await.unwrap_err()),
         }
     }
 
     #[inline]
-    pub fn connect_tcp_stream<A: ToSocketAddrs>(&self, addr: A) -> io::Result<TcpStream> {
-        let addrs = addr.to_socket_addrs()?;
+    pub async fn connect_tcp_stream<A: ToSocketAddrs>(&self, addr: A) -> io::Result<TcpStream> {
+        let addrs = addr.to_socket_addrs().await?;
 
         let mut last_err = None;
         for addr in addrs {
             self.cap.check_addr(&addr)?;
             // TODO: when compiling for WASI, use WASI-specific methods instead
-            match net::TcpStream::connect(addr) {
+            match net::TcpStream::connect(addr).await {
                 Ok(tcp_stream) => return Ok(unsafe { TcpStream::from_std(tcp_stream) }),
                 Err(e) => last_err = Some(e),
             }
         }
         match last_err {
             Some(e) => Err(e),
-            None => Err(net::TcpStream::connect(NO_SOCKET_ADDRS).unwrap_err()),
+            None => Err(net::TcpStream::connect(NO_SOCKET_ADDRS).await.unwrap_err()),
         }
     }
 
-    #[inline]
-    pub fn connect_timeout_tcp_stream(
-        &self,
-        addr: &SocketAddr,
-        timeout: Duration,
-    ) -> io::Result<TcpStream> {
-        self.cap.check_addr(addr)?;
-        let tcp_stream = net::TcpStream::connect_timeout(addr, timeout)?;
-        Ok(unsafe { TcpStream::from_std(tcp_stream) })
-    }
+    // async_std doesn't have `connect_timeout`.
 
     #[inline]
-    pub fn bind_udp_socket<A: ToSocketAddrs>(&self, addr: A) -> io::Result<UdpSocket> {
-        let addrs = addr.to_socket_addrs()?;
+    pub async fn bind_udp_socket<A: ToSocketAddrs>(&self, addr: A) -> io::Result<UdpSocket> {
+        let addrs = addr.to_socket_addrs().await?;
 
         let mut last_err = None;
         for addr in addrs {
             self.cap.check_addr(&addr)?;
-            match net::UdpSocket::bind(addr) {
+            match net::UdpSocket::bind(addr).await {
                 Ok(udp_socket) => return Ok(unsafe { UdpSocket::from_std(udp_socket) }),
                 Err(e) => last_err = Some(e),
             }
         }
         match last_err {
             Some(e) => Err(e),
-            None => Err(net::UdpSocket::bind(NO_SOCKET_ADDRS).unwrap_err()),
+            None => Err(net::UdpSocket::bind(NO_SOCKET_ADDRS).await.unwrap_err()),
         }
     }
 
     #[inline]
-    pub fn send_to_udp_socket_addr<A: ToSocketAddrs>(
+    pub async fn send_to_udp_socket_addr<A: ToSocketAddrs>(
         &self,
         udp_socket: &UdpSocket,
         buf: &[u8],
         addr: A,
     ) -> io::Result<usize> {
-        let mut addrs = addr.to_socket_addrs()?;
+        let mut addrs = addr.to_socket_addrs().await?;
 
         // `UdpSocket::send_to` only sends to the first address.
-        let addr = addrs
-            .next()
-            .ok_or_else(|| net::UdpSocket::bind(NO_SOCKET_ADDRS).unwrap_err())?;
+        let addr = match addrs.next() {
+            None => return Err(net::UdpSocket::bind(NO_SOCKET_ADDRS).await.unwrap_err()),
+            Some(addr) => addr,
+        };
         self.cap.check_addr(&addr)?;
-        udp_socket.std.send_to(buf, addr)
+        udp_socket.std.send_to(buf, addr).await
     }
 
     #[inline]
-    pub fn connect_udp_socket<A: ToSocketAddrs>(
+    pub async fn connect_udp_socket<A: ToSocketAddrs>(
         &self,
         udp_socket: &UdpSocket,
         addr: A,
     ) -> io::Result<()> {
-        let addrs = addr.to_socket_addrs()?;
+        let addrs = addr.to_socket_addrs().await?;
 
         let mut last_err = None;
         for addr in addrs {
             self.cap.check_addr(&addr)?;
-            match udp_socket.std.connect(addr) {
+            match udp_socket.std.connect(addr).await {
                 Ok(()) => return Ok(()),
                 Err(e) => last_err = Some(e),
             }
         }
         match last_err {
             Some(e) => Err(e),
-            None => Err(net::UdpSocket::bind(NO_SOCKET_ADDRS).unwrap_err()),
+            None => Err(net::UdpSocket::bind(NO_SOCKET_ADDRS).await.unwrap_err()),
         }
     }
 }

--- a/cap-async-std/src/net/pool.rs
+++ b/cap-async-std/src/net/pool.rs
@@ -11,6 +11,27 @@ pub struct Pool {
 }
 
 impl Pool {
+    /// Construct a new empty pool.
+    pub fn new() -> Self {
+        Self {
+            cap: cap_primitives::net::Pool::new(),
+        }
+    }
+
+    /// # Safety
+    ///
+    /// This function allows ambient access to any IP address.
+    pub unsafe fn insert_ip_net(&mut self, ip_net: ipnet::IpNet, port: u16) {
+        self.cap.insert_ip_net(ip_net, port)
+    }
+
+    /// # Safety
+    ///
+    /// This function allows ambient access to any IP address.
+    pub unsafe fn insert_socket_addr(&mut self, addr: net::SocketAddr) {
+        self.cap.insert_socket_addr(addr)
+    }
+
     #[inline]
     pub async fn bind_tcp_listener<A: ToSocketAddrs>(&self, addr: A) -> io::Result<TcpListener> {
         let addrs = addr.to_socket_addrs().await?;

--- a/cap-async-std/src/net/pool.rs
+++ b/cap-async-std/src/net/pool.rs
@@ -6,6 +6,7 @@ use cap_primitives::net::NO_SOCKET_ADDRS;
 
 // FIXME: lots more to do here
 
+#[derive(Clone)]
 pub struct Pool {
     cap: cap_primitives::net::Pool,
 }

--- a/cap-async-std/src/net/tcp_listener.rs
+++ b/cap-async-std/src/net/tcp_listener.rs
@@ -2,6 +2,7 @@ use crate::net::{Incoming, SocketAddr, TcpStream};
 #[cfg(unix)]
 use async_std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use async_std::{io, net};
+use std::fmt;
 use unsafe_io::OwnsRaw;
 #[cfg(windows)]
 use {
@@ -141,4 +142,8 @@ impl IntoRawHandleOrSocket for TcpListener {
 /// Safety: `TcpListener` wraps a `net::TcpListener` which owns its handle.
 unsafe impl OwnsRaw for TcpListener {}
 
-// TODO: impl Debug for TcpListener
+impl fmt::Debug for TcpListener {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.std.fmt(f)
+    }
+}

--- a/cap-async-std/src/net/tcp_listener.rs
+++ b/cap-async-std/src/net/tcp_listener.rs
@@ -14,11 +14,11 @@ use {
 /// This corresponds to [`async_std::net::TcpListener`].
 ///
 /// Note that this `TcpListener` has no `bind` method. To bind it to a socket
-/// address, you must first obtain a [`Catalog`] permitting the address, and
-/// then call [`Catalog::bind_tcp_listener`].
+/// address, you must first obtain a [`Pool`] permitting the address, and
+/// then call [`Pool::bind_tcp_listener`].
 ///
-/// [`Catalog`]: struct.Catalog.html
-/// [`Catalog::bind_tcp_listener`]: struct.Catalog.html#method.bind_tcp_listener
+/// [`Pool`]: struct.Pool.html
+/// [`Pool::bind_tcp_listener`]: struct.Pool.html#method.bind_tcp_listener
 pub struct TcpListener {
     std: net::TcpListener,
 }

--- a/cap-async-std/src/net/tcp_stream.rs
+++ b/cap-async-std/src/net/tcp_stream.rs
@@ -6,7 +6,7 @@ use async_std::{
     net,
     task::{Context, Poll},
 };
-use std::pin::Pin;
+use std::{fmt, pin::Pin};
 use unsafe_io::OwnsRaw;
 #[cfg(windows)]
 use {
@@ -291,4 +291,8 @@ impl Write for &TcpStream {
     // async_std doesn't have `write_all_vectored`.
 }
 
-// TODO: impl Debug for TcpStream
+impl fmt::Debug for TcpStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.std.fmt(f)
+    }
+}

--- a/cap-async-std/src/net/tcp_stream.rs
+++ b/cap-async-std/src/net/tcp_stream.rs
@@ -40,6 +40,14 @@ impl TcpStream {
         Self { std }
     }
 
+    /// Returns the remote address that this stream is connected to.
+    ///
+    /// This corresponds to [`async_std::net::TcpStream::peer_addr`].
+    #[inline]
+    pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+        self.std.peer_addr()
+    }
+
     /// Returns the local socket address of this listener.
     ///
     /// This corresponds to [`async_std::net::TcpStream::local_addr`].

--- a/cap-async-std/src/net/tcp_stream.rs
+++ b/cap-async-std/src/net/tcp_stream.rs
@@ -19,11 +19,11 @@ use {
 /// This corresponds to [`async_std::net::TcpStream`].
 ///
 /// Note that this `TcpStream` has no `connect` method. To create a `TcpStream`,
-/// you must first obtain a [`Catalog`] permitting the address, and then call
-/// [`Catalog::connect_tcp_stream`].
+/// you must first obtain a [`Pool`] permitting the address, and then call
+/// [`Pool::connect_tcp_stream`].
 ///
-/// [`Catalog`]: struct.Catalog.html
-/// [`Catalog::connect_tcp_stream`]: struct.Catalog.html#method.connect_tcp_stream
+/// [`Pool`]: struct.Pool.html
+/// [`Pool::connect_tcp_stream`]: struct.Pool.html#method.connect_tcp_stream
 pub struct TcpStream {
     std: net::TcpStream,
 }

--- a/cap-async-std/src/net/udp_socket.rs
+++ b/cap-async-std/src/net/udp_socket.rs
@@ -15,14 +15,14 @@ use {
 ///
 /// Note that this `UdpSocket` has no `bind`, `connect`, or `send_to` methods. To
 /// create a `UdpSocket` bound to an address or to send a message to an address,
-/// you must first obtain a [`Catalog`] permitting the address, and then call
-/// [`Catalog::bind_udp_socket`], or [`Catalog::connect_udp_socket`], or
-/// [`Catalog::send_to_udp_socket_addr`].
+/// you must first obtain a [`Pool`] permitting the address, and then call
+/// [`Pool::bind_udp_socket`], or [`Pool::connect_udp_socket`], or
+/// [`Pool::send_to_udp_socket_addr`].
 ///
-/// [`Catalog`]: struct.Catalog.html
-/// [`Catalog::bind_udp_socket`]: struct.Catalog.html#method.bind_udp_socket
-/// [`Catalog::connect_udp_socket`]: struct.Catalog.html#method.connect_udp_socket
-/// [`Catalog::send_to_udp_socket_addr`]: struct.Catalog.html#method.send_to_udp_socket_addr
+/// [`Pool`]: struct.Pool.html
+/// [`Pool::bind_udp_socket`]: struct.Pool.html#method.bind_udp_socket
+/// [`Pool::connect_udp_socket`]: struct.Pool.html#method.connect_udp_socket
+/// [`Pool::send_to_udp_socket_addr`]: struct.Pool.html#method.send_to_udp_socket_addr
 pub struct UdpSocket {
     pub(crate) std: net::UdpSocket,
 }

--- a/cap-async-std/src/net/udp_socket.rs
+++ b/cap-async-std/src/net/udp_socket.rs
@@ -2,6 +2,7 @@ use crate::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 #[cfg(unix)]
 use async_std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use async_std::{io, net};
+use std::fmt;
 use unsafe_io::OwnsRaw;
 #[cfg(windows)]
 use {
@@ -282,4 +283,8 @@ impl IntoRawHandleOrSocket for UdpSocket {
 /// Safety: `UdpSocket` wraps a `net::UdpSocket` which owns its handle.
 unsafe impl OwnsRaw for UdpSocket {}
 
-// TODO: impl Debug for UdpSocket
+impl fmt::Debug for UdpSocket {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.std.fmt(f)
+    }
+}

--- a/cap-async-std/src/os/unix/net/incoming.rs
+++ b/cap-async-std/src/os/unix/net/incoming.rs
@@ -5,7 +5,7 @@ use async_std::{
     stream::Stream,
     task::{Context, Poll},
 };
-use std::pin::Pin;
+use std::{fmt, pin::Pin};
 
 /// An iterator over incoming connections to a [`UnixListener`].
 ///
@@ -49,4 +49,8 @@ impl<'a> Stream for Incoming<'a> {
     }
 }
 
-// TODO: impl Debug for Incoming
+impl<'a> fmt::Debug for Incoming<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.std.fmt(f)
+    }
+}

--- a/cap-async-std/src/os/unix/net/unix_datagram.rs
+++ b/cap-async-std/src/os/unix/net/unix_datagram.rs
@@ -6,6 +6,7 @@ use async_std::{
         io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
     },
 };
+use std::fmt;
 use unsafe_io::OwnsRaw;
 
 /// A Unix datagram socket.
@@ -164,4 +165,8 @@ impl IntoRawFd for UnixDatagram {
 // Safety: `UnixDatagram` wraps a `net::UnixDatagram` which owns its handle.
 unsafe impl OwnsRaw for UnixDatagram {}
 
-// TODO: impl Debug for UnixDatagram
+impl fmt::Debug for UnixDatagram {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.std.fmt(f)
+    }
+}

--- a/cap-async-std/src/os/unix/net/unix_listener.rs
+++ b/cap-async-std/src/os/unix/net/unix_listener.rs
@@ -6,6 +6,7 @@ use async_std::{
         io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
     },
 };
+use std::fmt;
 use unsafe_io::OwnsRaw;
 
 /// A structure representing a Unix domain socket server.
@@ -102,4 +103,8 @@ impl IntoRawFd for UnixListener {
 // Safety: `UnixListener` wraps a `net::UnixListener` which owns its handle.
 unsafe impl OwnsRaw for UnixListener {}
 
-// TODO: impl Debug for UnixListener
+impl fmt::Debug for UnixListener {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.std.fmt(f)
+    }
+}

--- a/cap-async-std/src/os/unix/net/unix_stream.rs
+++ b/cap-async-std/src/os/unix/net/unix_stream.rs
@@ -7,7 +7,7 @@ use async_std::{
     },
     task::{Context, Poll},
 };
-use std::pin::Pin;
+use std::{fmt, pin::Pin};
 use unsafe_io::OwnsRaw;
 
 /// A Unix stream socket.
@@ -231,4 +231,8 @@ impl Write for &UnixStream {
     // async_std doesn't have `write_all_vectored`.
 }
 
-// TODO: impl Debug for UnixStream
+impl fmt::Debug for UnixStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.std.fmt(f)
+    }
+}

--- a/cap-primitives/README.md
+++ b/cap-primitives/README.md
@@ -15,13 +15,13 @@
 The `cap-primitives` crate provides primitive sandboxing operations that
 [`cap-std`] and [`cap-async-std`] are built on.
 
-The filesystem module [`cap_primitives::fs`] and time module
-[`cap_primitives::time`] currently support Linux, macOS, FreeBSD, and Windows.
-WASI support is in development, though not yet usable.
-
-The networking module, `net`, is not yet usable.
+The filesystem module [`cap_primitives::fs`], the networking module
+[`cap_primitives::net`], and time module [`cap_primitives::time`] currently
+support Linux, macOS, FreeBSD, and Windows. WASI support is in development,
+though not yet usable.
 
 [`cap-std`]: https://github.com/bytecodealliance/cap-std/blob/main/cap-std/README.md
 [`cap-async-std`]: https://github.com/bytecodealliance/cap-std/blob/main/cap-async-std/README.md
 [`cap_primitives::fs`]: https://docs.rs/cap-primitives/latest/cap_primitives/fs/index.html
+[`cap_primitives::net`]: https://docs.rs/cap-primitives/latest/cap_primitives/net/index.html
 [`cap_primitives::time`]: https://docs.rs/cap-primitives/latest/cap_primitives/time/index.html

--- a/cap-primitives/src/net/mod.rs
+++ b/cap-primitives/src/net/mod.rs
@@ -1,5 +1,5 @@
 //! Networking utilities.
 
-mod catalog;
+mod pool;
 
-pub use catalog::*;
+pub use pool::*;

--- a/cap-primitives/src/net/pool.rs
+++ b/cap-primitives/src/net/pool.rs
@@ -39,6 +39,31 @@ pub struct Pool {
 }
 
 impl Pool {
+    /// Construct a new empty pool.
+    pub fn new() -> Self {
+        Self { grants: Vec::new() }
+    }
+
+    /// # Safety
+    ///
+    /// This function allows ambient access to any IP address.
+    pub unsafe fn insert_ip_net(&mut self, ip_net: ipnet::IpNet, port: u16) {
+        self.grants.push(IpGrant {
+            set: AddrSet::Net(ip_net),
+            port,
+        })
+    }
+
+    /// # Safety
+    ///
+    /// This function allows ambient access to any IP address.
+    pub unsafe fn insert_socket_addr(&mut self, addr: net::SocketAddr) {
+        self.grants.push(IpGrant {
+            set: AddrSet::Net(addr.ip().into()),
+            port: addr.port(),
+        })
+    }
+
     pub fn check_addr(&self, addr: &net::SocketAddr) -> io::Result<()> {
         if self.grants.iter().any(|grant| grant.contains(addr)) {
             Ok(())

--- a/cap-primitives/src/net/pool.rs
+++ b/cap-primitives/src/net/pool.rs
@@ -6,6 +6,7 @@ use std::{io, net};
 
 // FIXME: lots more to do here
 
+#[derive(Clone)]
 enum AddrSet {
     Net(IpNet),
     NameWildcard(String),
@@ -20,6 +21,7 @@ impl AddrSet {
     }
 }
 
+#[derive(Clone)]
 struct IpGrant {
     set: AddrSet,
     port: u16, // TODO: IANA port names, TODO: range
@@ -33,6 +35,7 @@ impl IpGrant {
 
 /// A representation of a set of network resources that may be accessed.
 /// This is presently a very incomplete concept.
+#[derive(Clone)]
 pub struct Pool {
     // TODO: when compiling for WASI, use WASI-specific handle instead
     grants: Vec<IpGrant>,

--- a/cap-primitives/src/net/pool.rs
+++ b/cap-primitives/src/net/pool.rs
@@ -33,21 +33,19 @@ impl IpGrant {
 
 /// A representation of a set of network resources that may be accessed.
 /// This is presently a very incomplete concept.
-///
-/// TODO: rename this?
-pub struct Catalog {
+pub struct Pool {
     // TODO: when compiling for WASI, use WASI-specific handle instead
     grants: Vec<IpGrant>,
 }
 
-impl Catalog {
+impl Pool {
     pub fn check_addr(&self, addr: &net::SocketAddr) -> io::Result<()> {
         if self.grants.iter().any(|grant| grant.contains(addr)) {
             Ok(())
         } else {
             Err(io::Error::new(
                 io::ErrorKind::PermissionDenied,
-                "An address led outside the catalog",
+                "An address was outside the pool",
             ))
         }
     }

--- a/cap-primitives/src/net/pool.rs
+++ b/cap-primitives/src/net/pool.rs
@@ -9,6 +9,10 @@ use std::{io, net};
 #[derive(Clone)]
 enum AddrSet {
     Net(IpNet),
+
+    // TODO: Perhaps we should have our own version of `ToSocketAddrs`
+    // which returns hostnames rather than parsing them, so we can
+    // look up hostnames here.
     NameWildcard(String),
 }
 

--- a/cap-primitives/src/net/pool.rs
+++ b/cap-primitives/src/net/pool.rs
@@ -1,26 +1,18 @@
-#![allow(missing_docs)] // TODO: add docs
-#![allow(dead_code, unused_variables)] // TODO: When more things are implemented, remove these.
-
 use ipnet::IpNet;
 use std::{io, net};
 
-// FIXME: lots more to do here
-
+// TODO: Perhaps we should have our own version of `ToSocketAddrs` which
+// returns hostnames rather than parsing them, so we can add unresolved
+// hostnames to the pool.
 #[derive(Clone)]
 enum AddrSet {
     Net(IpNet),
-
-    // TODO: Perhaps we should have our own version of `ToSocketAddrs`
-    // which returns hostnames rather than parsing them, so we can
-    // look up hostnames here.
-    NameWildcard(String),
 }
 
 impl AddrSet {
     fn contains(&self, addr: net::IpAddr) -> bool {
         match self {
             Self::Net(ip_net) => ip_net.contains(&addr),
-            Self::NameWildcard(name) => false,
         }
     }
 }
@@ -38,7 +30,9 @@ impl IpGrant {
 }
 
 /// A representation of a set of network resources that may be accessed.
-/// This is presently a very incomplete concept.
+///
+/// This is presently a very simple concept, though it could grow in
+/// sophistication in the future.
 #[derive(Clone)]
 pub struct Pool {
     // TODO: when compiling for WASI, use WASI-specific handle instead
@@ -51,6 +45,8 @@ impl Pool {
         Self { grants: Vec::new() }
     }
 
+    /// Add a range of network addresses with a specific port to the pool.
+    ///
     /// # Safety
     ///
     /// This function allows ambient access to any IP address.
@@ -61,6 +57,8 @@ impl Pool {
         })
     }
 
+    /// Add a specific [`net::SocketAddr`] to the pool.
+    ///
     /// # Safety
     ///
     /// This function allows ambient access to any IP address.
@@ -71,6 +69,7 @@ impl Pool {
         })
     }
 
+    /// Check whether the given address is within the pool.
     pub fn check_addr(&self, addr: &net::SocketAddr) -> io::Result<()> {
         if self.grants.iter().any(|grant| grant.contains(addr)) {
             Ok(())
@@ -83,4 +82,5 @@ impl Pool {
     }
 }
 
+/// An empty array of `SocketAddr`s.
 pub const NO_SOCKET_ADDRS: &[net::SocketAddr] = &[];

--- a/cap-std/Cargo.toml
+++ b/cap-std/Cargo.toml
@@ -18,6 +18,7 @@ rustc_version = "0.3.0"
 [dependencies]
 arf-strings = { version = "0.3.0", optional = true }
 cap-primitives = { path = "../cap-primitives", version = "^0.13.11-alpha.0"}
+ipnet = "2.3.0"
 unsafe-io = "0.6.0"
 
 [target.'cfg(not(windows))'.dependencies]

--- a/cap-std/README.md
+++ b/cap-std/README.md
@@ -15,13 +15,12 @@
 This crate provides a capability-oriented version of [`std`]. See the
 [toplevel README.md] for more information about capability-oriented security.
 
-The filesystem module [`cap_std::fs`] and the time module [`cap_std::time`]
-currently support Linux, macOS, FreeBSD, and Windows. WASI support is in
-development, though not yet usable.
-
-The networking module, `net`, is not yet usable.
+The filesystem module [`cap_std::fs`], the networking module [`cap_std::net`],
+and the time module [`cap_std::time`] currently support Linux, macOS, FreeBSD,
+and Windows. WASI support is in development, though not yet usable.
 
 [`std`]: https://doc.rust-lang.org/std/
 [toplevel README.md]: https://github.com/bytecodealliance/cap-std/blob/main/README.md
 [`cap_std::fs`]: https://docs.rs/cap-std/latest/cap_std/fs/index.html
+[`cap_std::net`]: https://docs.rs/cap-std/latest/cap_std/net/index.html
 [`cap_std::time`]: https://docs.rs/cap-std/latest/cap_std/time/index.html

--- a/cap-std/src/lib.rs
+++ b/cap-std/src/lib.rs
@@ -6,22 +6,22 @@
 //! objects which can be passed around between different parts of a
 //! program.
 //!
-//! Two notable features are the [`Dir`] and [`Catalog`] types:
+//! Two notable features are the [`Dir`] and [`Pool`] types:
 //!  - `Dir` represents an open directory in a filesystem. Instead of
 //!    opening files by absolute paths or paths relative to the current
 //!    working directory, files are opened via paths relative to a
 //!    `Dir`. The concepts of a process-wide "current working directory"
 //!    and a single global filesystem namespace are de-emphasized.
-//!  - `Catalog` represents a set of network addresses. Instead of
+//!  - `Pool` represents a set of network addresses. Instead of
 //!    allowing applications to request access to any address and then
 //!    applying process-wide filtering rules, filtering rules are
-//!    built into catalogs which may be passed through the program.
+//!    built into pools which may be passed through the program.
 //!
 //! On WASI, use of this library closely reflects the underlying system
 //! API, so it avoids compatibility layers.
 //!
 //! [`Dir`]: fs::Dir
-//! [`Catalog`]: net::Catalog
+//! [`Pool`]: net::Pool
 
 #![deny(missing_docs)]
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]

--- a/cap-std/src/net/incoming.rs
+++ b/cap-std/src/net/incoming.rs
@@ -1,5 +1,5 @@
 use crate::net::TcpStream;
-use std::{io, net};
+use std::{fmt, io, net};
 
 /// An iterator that infinitely `accept`s connections on a [`TcpListener`].
 ///
@@ -40,4 +40,8 @@ impl<'a> Iterator for Incoming<'a> {
     }
 }
 
-// TODO: impl Debug for Incoming
+impl<'a> fmt::Debug for Incoming<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.std.fmt(f)
+    }
+}

--- a/cap-std/src/net/mod.rs
+++ b/cap-std/src/net/mod.rs
@@ -1,7 +1,5 @@
 //! A capability-oriented network API modeled after `std::net`.
 //!
-//! XXX: The interfaces in this module are not yet implemented.
-//!
 //! This corresponds to [`std::net`].
 //!
 //! Instead of [`std::net`]'s constructor methods which take an address to

--- a/cap-std/src/net/mod.rs
+++ b/cap-std/src/net/mod.rs
@@ -5,18 +5,18 @@
 //! This corresponds to [`std::net`].
 //!
 //! Instead of [`std::net`]'s constructor methods which take an address to
-//! connect to, this crates has methods on [`Catalog`] which operate on addresses
-//! which must be present in the catalog.
+//! connect to, this crates has methods on [`Pool`] which operate on addresses
+//! which must be present in the pool.
 //!
-//! [`Catalog`]: struct.Catalog.html
+//! [`Pool`]: struct.Pool.html
 
-mod catalog;
+mod pool;
 mod incoming;
 mod tcp_listener;
 mod tcp_stream;
 mod udp_socket;
 
-pub use catalog::*;
+pub use pool::*;
 pub use incoming::*;
 pub use tcp_listener::*;
 pub use tcp_stream::*;

--- a/cap-std/src/net/mod.rs
+++ b/cap-std/src/net/mod.rs
@@ -10,14 +10,14 @@
 //!
 //! [`Pool`]: struct.Pool.html
 
-mod pool;
 mod incoming;
+mod pool;
 mod tcp_listener;
 mod tcp_stream;
 mod udp_socket;
 
-pub use pool::*;
 pub use incoming::*;
+pub use pool::*;
 pub use tcp_listener::*;
 pub use tcp_stream::*;
 pub use udp_socket::*;

--- a/cap-std/src/net/pool.rs
+++ b/cap-std/src/net/pool.rs
@@ -1,9 +1,11 @@
-#![allow(missing_docs)] // TODO: add docs
-
 use crate::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs, UdpSocket};
 use cap_primitives::net::NO_SOCKET_ADDRS;
 use std::{io, net, time::Duration};
 
+/// A pool of network addresses.
+///
+/// This does not directly correspond to anything in `std`, however its methods
+/// correspond to the several functions in [`std::net`].
 #[derive(Clone)]
 pub struct Pool {
     cap: cap_primitives::net::Pool,
@@ -17,6 +19,8 @@ impl Pool {
         }
     }
 
+    /// Add a range of network addresses with a specific port to the pool.
+    ///
     /// # Safety
     ///
     /// This function allows ambient access to any IP address.
@@ -24,6 +28,8 @@ impl Pool {
         self.cap.insert_ip_net(ip_net, port)
     }
 
+    /// Add a specific [`net::SocketAddr`] to the pool.
+    ///
     /// # Safety
     ///
     /// This function allows ambient access to any IP address.
@@ -31,6 +37,9 @@ impl Pool {
         self.cap.insert_socket_addr(addr)
     }
 
+    /// Creates a new `TcpListener` which will be bound to the specified address.
+    ///
+    /// This corresponds to [`std::net::TcpListener::bind`].
     #[inline]
     pub fn bind_tcp_listener<A: ToSocketAddrs>(&self, addr: A) -> io::Result<TcpListener> {
         let addrs = addr.to_socket_addrs()?;
@@ -50,6 +59,9 @@ impl Pool {
         }
     }
 
+    /// Opens a TCP connection to a remote host.
+    ///
+    /// This corresponds to [`std::net::TcpStream::connect`].
     #[inline]
     pub fn connect_tcp_stream<A: ToSocketAddrs>(&self, addr: A) -> io::Result<TcpStream> {
         let addrs = addr.to_socket_addrs()?;
@@ -69,6 +81,9 @@ impl Pool {
         }
     }
 
+    /// Opens a TCP connection to a remote host with a timeout.
+    ///
+    /// This corresponds to [`std::net::TcpStream::connect_timeout`].
     #[inline]
     pub fn connect_timeout_tcp_stream(
         &self,
@@ -80,6 +95,9 @@ impl Pool {
         Ok(unsafe { TcpStream::from_std(tcp_stream) })
     }
 
+    /// Creates a UDP socket from the given address.
+    ///
+    /// This corresponds to [`std::net::UdpSocket::bind`].
     #[inline]
     pub fn bind_udp_socket<A: ToSocketAddrs>(&self, addr: A) -> io::Result<UdpSocket> {
         let addrs = addr.to_socket_addrs()?;
@@ -98,6 +116,10 @@ impl Pool {
         }
     }
 
+    /// Sends data on the socket to the given address. On success, returns the
+    /// number of bytes written.
+    ///
+    /// This corresponds to [`std::net::UdpSocket::send_to`].
     #[inline]
     pub fn send_to_udp_socket_addr<A: ToSocketAddrs>(
         &self,
@@ -115,6 +137,11 @@ impl Pool {
         udp_socket.std.send_to(buf, addr)
     }
 
+    /// Connects this UDP socket to a remote address, allowing the `send` and
+    /// `recv` syscalls to be used to send data and also applies filters to
+    /// only receive data from the specified address.
+    ///
+    /// This corresponds to [`std::net::UdpSocket::connect`].
     #[inline]
     pub fn connect_udp_socket<A: ToSocketAddrs>(
         &self,

--- a/cap-std/src/net/pool.rs
+++ b/cap-std/src/net/pool.rs
@@ -11,6 +11,27 @@ pub struct Pool {
 }
 
 impl Pool {
+    /// Construct a new empty pool.
+    pub fn new() -> Self {
+        Self {
+            cap: cap_primitives::net::Pool::new(),
+        }
+    }
+
+    /// # Safety
+    ///
+    /// This function allows ambient access to any IP address.
+    pub unsafe fn insert_ip_net(&mut self, ip_net: ipnet::IpNet, port: u16) {
+        self.cap.insert_ip_net(ip_net, port)
+    }
+
+    /// # Safety
+    ///
+    /// This function allows ambient access to any IP address.
+    pub unsafe fn insert_socket_addr(&mut self, addr: net::SocketAddr) {
+        self.cap.insert_socket_addr(addr)
+    }
+
     #[inline]
     pub fn bind_tcp_listener<A: ToSocketAddrs>(&self, addr: A) -> io::Result<TcpListener> {
         let addrs = addr.to_socket_addrs()?;

--- a/cap-std/src/net/pool.rs
+++ b/cap-std/src/net/pool.rs
@@ -6,6 +6,7 @@ use std::{io, net, time::Duration};
 
 // FIXME: lots more to do here
 
+#[derive(Clone)]
 pub struct Pool {
     cap: cap_primitives::net::Pool,
 }

--- a/cap-std/src/net/pool.rs
+++ b/cap-std/src/net/pool.rs
@@ -1,111 +1,119 @@
 #![allow(missing_docs)] // TODO: add docs
 
-use crate::net::{TcpListener, TcpStream, ToSocketAddrs, UdpSocket};
-use async_std::{io, net};
+use crate::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs, UdpSocket};
 use cap_primitives::net::NO_SOCKET_ADDRS;
+use std::{io, net, time::Duration};
 
 // FIXME: lots more to do here
 
-pub struct Catalog {
-    cap: cap_primitives::net::Catalog,
+pub struct Pool {
+    cap: cap_primitives::net::Pool,
 }
 
-impl Catalog {
+impl Pool {
     #[inline]
-    pub async fn bind_tcp_listener<A: ToSocketAddrs>(&self, addr: A) -> io::Result<TcpListener> {
-        let addrs = addr.to_socket_addrs().await?;
+    pub fn bind_tcp_listener<A: ToSocketAddrs>(&self, addr: A) -> io::Result<TcpListener> {
+        let addrs = addr.to_socket_addrs()?;
 
         let mut last_err = None;
         for addr in addrs {
             self.cap.check_addr(&addr)?;
             // TODO: when compiling for WASI, use WASI-specific methods instead
-            match net::TcpListener::bind(addr).await {
+            match net::TcpListener::bind(addr) {
                 Ok(tcp_listener) => return Ok(unsafe { TcpListener::from_std(tcp_listener) }),
                 Err(e) => last_err = Some(e),
             }
         }
         match last_err {
             Some(e) => Err(e),
-            None => Err(net::TcpListener::bind(NO_SOCKET_ADDRS).await.unwrap_err()),
+            None => Err(net::TcpListener::bind(NO_SOCKET_ADDRS).unwrap_err()),
         }
     }
 
     #[inline]
-    pub async fn connect_tcp_stream<A: ToSocketAddrs>(&self, addr: A) -> io::Result<TcpStream> {
-        let addrs = addr.to_socket_addrs().await?;
+    pub fn connect_tcp_stream<A: ToSocketAddrs>(&self, addr: A) -> io::Result<TcpStream> {
+        let addrs = addr.to_socket_addrs()?;
 
         let mut last_err = None;
         for addr in addrs {
             self.cap.check_addr(&addr)?;
             // TODO: when compiling for WASI, use WASI-specific methods instead
-            match net::TcpStream::connect(addr).await {
+            match net::TcpStream::connect(addr) {
                 Ok(tcp_stream) => return Ok(unsafe { TcpStream::from_std(tcp_stream) }),
                 Err(e) => last_err = Some(e),
             }
         }
         match last_err {
             Some(e) => Err(e),
-            None => Err(net::TcpStream::connect(NO_SOCKET_ADDRS).await.unwrap_err()),
+            None => Err(net::TcpStream::connect(NO_SOCKET_ADDRS).unwrap_err()),
         }
     }
 
-    // async_std doesn't have `connect_timeout`.
+    #[inline]
+    pub fn connect_timeout_tcp_stream(
+        &self,
+        addr: &SocketAddr,
+        timeout: Duration,
+    ) -> io::Result<TcpStream> {
+        self.cap.check_addr(addr)?;
+        let tcp_stream = net::TcpStream::connect_timeout(addr, timeout)?;
+        Ok(unsafe { TcpStream::from_std(tcp_stream) })
+    }
 
     #[inline]
-    pub async fn bind_udp_socket<A: ToSocketAddrs>(&self, addr: A) -> io::Result<UdpSocket> {
-        let addrs = addr.to_socket_addrs().await?;
+    pub fn bind_udp_socket<A: ToSocketAddrs>(&self, addr: A) -> io::Result<UdpSocket> {
+        let addrs = addr.to_socket_addrs()?;
 
         let mut last_err = None;
         for addr in addrs {
             self.cap.check_addr(&addr)?;
-            match net::UdpSocket::bind(addr).await {
+            match net::UdpSocket::bind(addr) {
                 Ok(udp_socket) => return Ok(unsafe { UdpSocket::from_std(udp_socket) }),
                 Err(e) => last_err = Some(e),
             }
         }
         match last_err {
             Some(e) => Err(e),
-            None => Err(net::UdpSocket::bind(NO_SOCKET_ADDRS).await.unwrap_err()),
+            None => Err(net::UdpSocket::bind(NO_SOCKET_ADDRS).unwrap_err()),
         }
     }
 
     #[inline]
-    pub async fn send_to_udp_socket_addr<A: ToSocketAddrs>(
+    pub fn send_to_udp_socket_addr<A: ToSocketAddrs>(
         &self,
         udp_socket: &UdpSocket,
         buf: &[u8],
         addr: A,
     ) -> io::Result<usize> {
-        let mut addrs = addr.to_socket_addrs().await?;
+        let mut addrs = addr.to_socket_addrs()?;
 
         // `UdpSocket::send_to` only sends to the first address.
-        let addr = match addrs.next() {
-            None => return Err(net::UdpSocket::bind(NO_SOCKET_ADDRS).await.unwrap_err()),
-            Some(addr) => addr,
-        };
+        let addr = addrs
+            .next()
+            .ok_or_else(|| net::UdpSocket::bind(NO_SOCKET_ADDRS).unwrap_err())?;
         self.cap.check_addr(&addr)?;
-        udp_socket.std.send_to(buf, addr).await
+        udp_socket.std.send_to(buf, addr)
     }
 
     #[inline]
-    pub async fn connect_udp_socket<A: ToSocketAddrs>(
+    pub fn connect_udp_socket<A: ToSocketAddrs>(
         &self,
         udp_socket: &UdpSocket,
         addr: A,
     ) -> io::Result<()> {
-        let addrs = addr.to_socket_addrs().await?;
+        let addrs = addr.to_socket_addrs()?;
 
         let mut last_err = None;
         for addr in addrs {
             self.cap.check_addr(&addr)?;
-            match udp_socket.std.connect(addr).await {
+            match udp_socket.std.connect(addr) {
                 Ok(()) => return Ok(()),
                 Err(e) => last_err = Some(e),
             }
         }
         match last_err {
             Some(e) => Err(e),
-            None => Err(net::UdpSocket::bind(NO_SOCKET_ADDRS).await.unwrap_err()),
+            None => Err(net::UdpSocket::bind(NO_SOCKET_ADDRS).unwrap_err()),
         }
     }
 }

--- a/cap-std/src/net/pool.rs
+++ b/cap-std/src/net/pool.rs
@@ -4,8 +4,6 @@ use crate::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs, UdpSocket};
 use cap_primitives::net::NO_SOCKET_ADDRS;
 use std::{io, net, time::Duration};
 
-// FIXME: lots more to do here
-
 #[derive(Clone)]
 pub struct Pool {
     cap: cap_primitives::net::Pool,

--- a/cap-std/src/net/tcp_listener.rs
+++ b/cap-std/src/net/tcp_listener.rs
@@ -173,8 +173,6 @@ unsafe impl OwnsRaw for TcpListener {}
 
 impl fmt::Debug for TcpListener {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Don't leak the address/port.
-        let mut res = f.debug_struct("TcpListener");
-        res.finish()
+        self.std.fmt(f)
     }
 }

--- a/cap-std/src/net/tcp_listener.rs
+++ b/cap-std/src/net/tcp_listener.rs
@@ -14,11 +14,11 @@ use {
 /// This corresponds to [`std::net::TcpListener`].
 ///
 /// Note that this `TcpListener` has no `bind` method. To bind it to a socket
-/// address, you must first obtain a [`Catalog`] permitting the address, and
-/// then call [`Catalog::bind_tcp_listener`].
+/// address, you must first obtain a [`Pool`] permitting the address, and
+/// then call [`Pool::bind_tcp_listener`].
 ///
-/// [`Catalog`]: struct.Catalog.html
-/// [`Catalog::bind_tcp_listener`]: struct.Catalog.html#method.bind_tcp_listener
+/// [`Pool`]: struct.Pool.html
+/// [`Pool::bind_tcp_listener`]: struct.Pool.html#method.bind_tcp_listener
 pub struct TcpListener {
     std: net::TcpListener,
 }

--- a/cap-std/src/net/tcp_stream.rs
+++ b/cap-std/src/net/tcp_stream.rs
@@ -1,5 +1,6 @@
 use crate::net::{Shutdown, SocketAddr};
 use std::{
+    fmt,
     io::{self, IoSlice, IoSliceMut, Read, Write},
     net,
     time::Duration,
@@ -355,4 +356,8 @@ impl Write for &TcpStream {
     }
 }
 
-// TODO: impl Debug for TcpStream
+impl fmt::Debug for TcpStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.std.fmt(f)
+    }
+}

--- a/cap-std/src/net/tcp_stream.rs
+++ b/cap-std/src/net/tcp_stream.rs
@@ -18,11 +18,11 @@ use {
 /// This corresponds to [`std::net::TcpStream`].
 ///
 /// Note that this `TcpStream` has no `connect` method. To create a `TcpStream`,
-/// you must first obtain a [`Catalog`] permitting the address, and then call
-/// [`Catalog::connect_tcp_stream`].
+/// you must first obtain a [`Pool`] permitting the address, and then call
+/// [`Pool::connect_tcp_stream`].
 ///
-/// [`Catalog`]: struct.Catalog.html
-/// [`Catalog::connect_tcp_stream`]: struct.Catalog.html#method.connect_tcp_stream
+/// [`Pool`]: struct.Pool.html
+/// [`Pool::connect_tcp_stream`]: struct.Pool.html#method.connect_tcp_stream
 pub struct TcpStream {
     std: net::TcpStream,
 }

--- a/cap-std/src/net/tcp_stream.rs
+++ b/cap-std/src/net/tcp_stream.rs
@@ -40,6 +40,14 @@ impl TcpStream {
         Self { std }
     }
 
+    /// Returns the socket address of the remote peer of this TCP connection.
+    ///
+    /// This corresponds to [`std::net::TcpStream::peer_addr`].
+    #[inline]
+    pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+        self.std.peer_addr()
+    }
+
     /// Returns the local socket address of this listener.
     ///
     /// This corresponds to [`std::net::TcpStream::local_addr`].

--- a/cap-std/src/net/udp_socket.rs
+++ b/cap-std/src/net/udp_socket.rs
@@ -1,5 +1,5 @@
 use crate::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
-use std::{io, net, time::Duration};
+use std::{fmt, io, net, time::Duration};
 #[cfg(not(windows))]
 use unsafe_io::os::posish::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use unsafe_io::OwnsRaw;
@@ -338,4 +338,8 @@ impl IntoRawHandleOrSocket for UdpSocket {
 // Safety: `UdpSocket` wraps a `net::UdpSocket` which owns its handle.
 unsafe impl OwnsRaw for UdpSocket {}
 
-// TODO: impl Debug for UdpSocket
+impl fmt::Debug for UdpSocket {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.std.fmt(f)
+    }
+}

--- a/cap-std/src/net/udp_socket.rs
+++ b/cap-std/src/net/udp_socket.rs
@@ -15,14 +15,14 @@ use {
 ///
 /// Note that this `UdpSocket` has no `bind`, `connect`, or `send_to` methods. To
 /// create a `UdpSocket` bound to an address or to send a message to an address,
-/// you must first obtain a [`Catalog`] permitting the address, and then call
-/// [`Catalog::bind_udp_socket`], or [`Catalog::connect_udp_socket`], or
-/// [`Catalog::send_to_udp_socket_addr`].
+/// you must first obtain a [`Pool`] permitting the address, and then call
+/// [`Pool::bind_udp_socket`], or [`Pool::connect_udp_socket`], or
+/// [`Pool::send_to_udp_socket_addr`].
 ///
-/// [`Catalog`]: struct.Catalog.html
-/// [`Catalog::bind_udp_socket`]: struct.Catalog.html#method.bind_udp_socket
-/// [`Catalog::connect_udp_socket`]: struct.Catalog.html#method.connect_udp_socket
-/// [`Catalog::send_to_udp_socket_addr`]: struct.Catalog.html#method.send_to_udp_socket_addr
+/// [`Pool`]: struct.Pool.html
+/// [`Pool::bind_udp_socket`]: struct.Pool.html#method.bind_udp_socket
+/// [`Pool::connect_udp_socket`]: struct.Pool.html#method.connect_udp_socket
+/// [`Pool::send_to_udp_socket_addr`]: struct.Pool.html#method.send_to_udp_socket_addr
 pub struct UdpSocket {
     pub(crate) std: net::UdpSocket,
 }

--- a/cap-std/src/os/unix/net/incoming.rs
+++ b/cap-std/src/os/unix/net/incoming.rs
@@ -1,5 +1,5 @@
 use crate::os::unix::net::UnixStream;
-use std::{io, os::unix};
+use std::{fmt, io, os::unix};
 
 /// An iterator over incoming connections to a [`UnixListener`].
 ///
@@ -41,4 +41,8 @@ impl<'a> Iterator for Incoming<'a> {
     }
 }
 
-// TODO: impl Debug for Incoming
+impl<'a> fmt::Debug for Incoming<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.std.fmt(f)
+    }
+}

--- a/cap-std/src/os/unix/net/unix_datagram.rs
+++ b/cap-std/src/os/unix/net/unix_datagram.rs
@@ -1,6 +1,6 @@
 use crate::{net::Shutdown, os::unix::net::SocketAddr};
 use std::{
-    io,
+    fmt, io,
     os::unix::{
         self,
         io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
@@ -222,4 +222,8 @@ impl IntoRawFd for UnixDatagram {
 // Safety: `UnixDatagram` wraps a `net::UnixDatagram` which owns its handle.
 unsafe impl OwnsRaw for UnixDatagram {}
 
-// TODO: impl Debug for UnixDatagram
+impl fmt::Debug for UnixDatagram {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.std.fmt(f)
+    }
+}

--- a/cap-std/src/os/unix/net/unix_listener.rs
+++ b/cap-std/src/os/unix/net/unix_listener.rs
@@ -1,6 +1,6 @@
 use crate::os::unix::net::{Incoming, SocketAddr, UnixStream};
 use std::{
-    io,
+    fmt, io,
     os::unix::{
         self,
         io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
@@ -135,4 +135,8 @@ impl<'a> IntoIterator for &'a UnixListener {
     }
 }
 
-// TODO: impl Debug for UnixListener
+impl fmt::Debug for UnixListener {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.std.fmt(f)
+    }
+}

--- a/cap-std/src/os/unix/net/unix_stream.rs
+++ b/cap-std/src/os/unix/net/unix_stream.rs
@@ -1,5 +1,6 @@
 use crate::{net::Shutdown, os::unix::net::SocketAddr};
 use std::{
+    fmt,
     io::{self, IoSlice, IoSliceMut, Read, Write},
     os::unix::{
         self,
@@ -309,4 +310,8 @@ impl Write for &UnixStream {
     }
 }
 
-// TODO: impl Debug for UnixStream
+impl fmt::Debug for UnixStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.std.fmt(f)
+    }
+}

--- a/tests/net-tcp.rs
+++ b/tests/net-tcp.rs
@@ -1,0 +1,1131 @@
+// This file is derived from Rust's library/std/src/net/tcp/tests.rs at
+// revision 377d1a984cd2a53327092b90aa1d8b7e22d1e347.
+
+mod net;
+
+use cap_std::net::*;
+use net::{next_test_ip4, next_test_ip6};
+use std::{
+    fmt,
+    io::{prelude::*, ErrorKind, IoSlice, IoSliceMut},
+    sync::mpsc::channel,
+    thread,
+    time::{Duration, Instant},
+};
+
+fn each_ip(f: &mut dyn FnMut(SocketAddr)) {
+    f(next_test_ip4());
+    f(next_test_ip6());
+}
+
+macro_rules! t {
+    ($e:expr) => {
+        match $e {
+            Ok(t) => t,
+            Err(e) => panic!("received error for `{}`: {}", stringify!($e), e),
+        }
+    };
+}
+
+#[test]
+fn bind_error() {
+    let mut pool = Pool::new();
+    unsafe {
+        pool.insert_socket_addr("1.1.1.1:9999".parse().unwrap());
+    }
+
+    match pool.bind_tcp_listener("1.1.1.1:9999") {
+        Ok(..) => panic!(),
+        Err(e) => assert_eq!(e.kind(), ErrorKind::AddrNotAvailable),
+    }
+}
+
+#[test]
+fn connect_error() {
+    let mut pool = Pool::new();
+    unsafe {
+        pool.insert_socket_addr("0.0.0.0:1".parse().unwrap());
+    }
+
+    match pool.connect_tcp_stream("0.0.0.0:1") {
+        Ok(..) => panic!(),
+        Err(e) => assert!(
+            e.kind() == ErrorKind::ConnectionRefused
+                || e.kind() == ErrorKind::InvalidInput
+                || e.kind() == ErrorKind::AddrInUse
+                || e.kind() == ErrorKind::AddrNotAvailable,
+            "bad error: {} {:?}",
+            e,
+            e.kind()
+        ),
+    }
+}
+
+#[test]
+fn listen_localhost() {
+    let socket_addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    unsafe {
+        pool.insert_socket_addr(socket_addr);
+    }
+    for resolved in format!("localhost:{}", socket_addr.port())
+        .to_socket_addrs()
+        .unwrap()
+    {
+        unsafe {
+            pool.insert_socket_addr(resolved);
+        }
+    }
+
+    let listener = t!(pool.bind_tcp_listener(&socket_addr));
+
+    let _t = thread::spawn(move || {
+        let mut stream = t!(pool.connect_tcp_stream(&("localhost", socket_addr.port())));
+        t!(stream.write(&[144]));
+    });
+
+    let mut stream = t!(listener.accept()).0;
+    let mut buf = [0];
+    t!(stream.read(&mut buf));
+    assert!(buf[0] == 144);
+}
+
+#[test]
+fn connect_loopback() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let acceptor = t!(pool.bind_tcp_listener(&addr));
+
+        let _t = thread::spawn(move || {
+            let host = match addr {
+                SocketAddr::V4(..) => "127.0.0.1",
+                SocketAddr::V6(..) => "::1",
+            };
+            let mut stream = t!(pool.connect_tcp_stream(&(host, addr.port())));
+            t!(stream.write(&[66]));
+        });
+
+        let mut stream = t!(acceptor.accept()).0;
+        let mut buf = [0];
+        t!(stream.read(&mut buf));
+        assert!(buf[0] == 66);
+    })
+}
+
+#[test]
+fn smoke_test() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let acceptor = t!(pool.bind_tcp_listener(&addr));
+
+        let (tx, rx) = channel();
+        let _t = thread::spawn(move || {
+            let mut stream = t!(pool.connect_tcp_stream(&addr));
+            t!(stream.write(&[99]));
+            tx.send(t!(stream.local_addr())).unwrap();
+        });
+
+        let (mut stream, addr) = t!(acceptor.accept());
+        let mut buf = [0];
+        t!(stream.read(&mut buf));
+        assert!(buf[0] == 99);
+        assert_eq!(addr, t!(rx.recv()));
+    })
+}
+
+#[test]
+fn read_eof() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let acceptor = t!(pool.bind_tcp_listener(&addr));
+
+        let _t = thread::spawn(move || {
+            let _stream = t!(pool.connect_tcp_stream(&addr));
+            // Close
+        });
+
+        let mut stream = t!(acceptor.accept()).0;
+        let mut buf = [0];
+        let nread = t!(stream.read(&mut buf));
+        assert_eq!(nread, 0);
+        let nread = t!(stream.read(&mut buf));
+        assert_eq!(nread, 0);
+    })
+}
+
+#[test]
+fn write_close() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let acceptor = t!(pool.bind_tcp_listener(&addr));
+
+        let (tx, rx) = channel();
+        let _t = thread::spawn(move || {
+            drop(t!(pool.connect_tcp_stream(&addr)));
+            tx.send(()).unwrap();
+        });
+
+        let mut stream = t!(acceptor.accept()).0;
+        rx.recv().unwrap();
+        let buf = [0];
+        match stream.write(&buf) {
+            Ok(..) => {}
+            Err(e) => {
+                assert!(
+                    e.kind() == ErrorKind::ConnectionReset
+                        || e.kind() == ErrorKind::BrokenPipe
+                        || e.kind() == ErrorKind::ConnectionAborted,
+                    "unknown error: {}",
+                    e
+                );
+            }
+        }
+    })
+}
+
+#[test]
+fn multiple_connect_serial() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let max = 10;
+        let acceptor = t!(pool.bind_tcp_listener(&addr));
+
+        let _t = thread::spawn(move || {
+            for _ in 0..max {
+                let mut stream = t!(pool.connect_tcp_stream(&addr));
+                t!(stream.write(&[99]));
+            }
+        });
+
+        for stream in acceptor.incoming().take(max) {
+            let mut stream = t!(stream);
+            let mut buf = [0];
+            t!(stream.read(&mut buf));
+            assert_eq!(buf[0], 99);
+        }
+    })
+}
+
+#[test]
+fn multiple_connect_interleaved_greedy_schedule() {
+    const MAX: usize = 10;
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let acceptor = t!(pool.bind_tcp_listener(&addr));
+
+        let _t = thread::spawn(move || {
+            let acceptor = acceptor;
+            for (i, stream) in acceptor.incoming().enumerate().take(MAX) {
+                // Start another thread to handle the connection
+                let _t = thread::spawn(move || {
+                    let mut stream = t!(stream);
+                    let mut buf = [0];
+                    t!(stream.read(&mut buf));
+                    assert!(buf[0] == i as u8);
+                });
+            }
+        });
+
+        connect(0, addr, pool);
+    });
+
+    fn connect(i: usize, addr: SocketAddr, pool: Pool) {
+        if i == MAX {
+            return;
+        }
+
+        let t = thread::spawn(move || {
+            let mut stream = t!(pool.connect_tcp_stream(&addr));
+            // Connect again before writing
+            connect(i + 1, addr, pool);
+            t!(stream.write(&[i as u8]));
+        });
+        t.join().ok().expect("thread panicked");
+    }
+}
+
+#[test]
+fn multiple_connect_interleaved_lazy_schedule() {
+    const MAX: usize = 10;
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let acceptor = t!(pool.bind_tcp_listener(&addr));
+
+        let _t = thread::spawn(move || {
+            for stream in acceptor.incoming().take(MAX) {
+                // Start another thread to handle the connection
+                let _t = thread::spawn(move || {
+                    let mut stream = t!(stream);
+                    let mut buf = [0];
+                    t!(stream.read(&mut buf));
+                    assert!(buf[0] == 99);
+                });
+            }
+        });
+
+        connect(0, addr, pool);
+    });
+
+    fn connect(i: usize, addr: SocketAddr, pool: Pool) {
+        if i == MAX {
+            return;
+        }
+
+        let t = thread::spawn(move || {
+            let mut stream = t!(pool.connect_tcp_stream(&addr));
+            connect(i + 1, addr, pool);
+            t!(stream.write(&[99]));
+        });
+        t.join().ok().expect("thread panicked");
+    }
+}
+
+#[test]
+fn socket_and_peer_name() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let listener = t!(pool.bind_tcp_listener(&addr));
+        let so_name = t!(listener.local_addr());
+        assert_eq!(addr, so_name);
+        let _t = thread::spawn(move || {
+            t!(listener.accept());
+        });
+
+        let stream = t!(pool.connect_tcp_stream(&addr));
+        assert_eq!(addr, t!(stream.peer_addr()));
+    })
+}
+
+#[test]
+fn partial_read() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let (tx, rx) = channel();
+        let srv = t!(pool.bind_tcp_listener(&addr));
+        let _t = thread::spawn(move || {
+            let mut cl = t!(srv.accept()).0;
+            cl.write(&[10]).unwrap();
+            let mut b = [0];
+            t!(cl.read(&mut b));
+            tx.send(()).unwrap();
+        });
+
+        let mut c = t!(pool.connect_tcp_stream(&addr));
+        let mut b = [0; 10];
+        assert_eq!(c.read(&mut b).unwrap(), 1);
+        t!(c.write(&[1]));
+        rx.recv().unwrap();
+    })
+}
+
+#[test]
+fn read_vectored() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let srv = t!(pool.bind_tcp_listener(&addr));
+        let mut s1 = t!(pool.connect_tcp_stream(&addr));
+        let mut s2 = t!(srv.accept()).0;
+
+        let len = s1.write(&[10, 11, 12]).unwrap();
+        assert_eq!(len, 3);
+
+        let mut a = [];
+        let mut b = [0];
+        let mut c = [0; 3];
+        let len = t!(s2.read_vectored(&mut [
+            IoSliceMut::new(&mut a),
+            IoSliceMut::new(&mut b),
+            IoSliceMut::new(&mut c)
+        ],));
+        assert!(len > 0);
+        assert_eq!(b, [10]);
+        // some implementations don't support readv, so we may only fill the first buffer
+        assert!(len == 1 || c == [11, 12, 0]);
+    })
+}
+
+#[test]
+fn write_vectored() {
+    let mut pool = Pool::new();
+
+    each_ip(&mut |addr| {
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let srv = t!(pool.bind_tcp_listener(&addr));
+        let mut s1 = t!(pool.connect_tcp_stream(&addr));
+        let mut s2 = t!(srv.accept()).0;
+
+        let a = [];
+        let b = [10];
+        let c = [11, 12];
+        t!(s1.write_vectored(&[IoSlice::new(&a), IoSlice::new(&b), IoSlice::new(&c)]));
+
+        let mut buf = [0; 4];
+        let len = t!(s2.read(&mut buf));
+        // some implementations don't support writev, so we may only write the first buffer
+        if len == 1 {
+            assert_eq!(buf, [10, 0, 0, 0]);
+        } else {
+            assert_eq!(len, 3);
+            assert_eq!(buf, [10, 11, 12, 0]);
+        }
+    })
+}
+
+#[test]
+fn double_bind() {
+    let mut pool = Pool::new();
+
+    each_ip(&mut |addr| {
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let listener1 = t!(pool.bind_tcp_listener(&addr));
+        match pool.bind_tcp_listener(&addr) {
+            Ok(listener2) => panic!(
+                "This system (perhaps due to options set by pool.bind_tcp_listener) \
+                 permits double binding: {:?} and {:?}",
+                listener1, listener2
+            ),
+            Err(e) => {
+                assert!(
+                    e.kind() == ErrorKind::ConnectionRefused
+                        || e.kind() == ErrorKind::Other
+                        || e.kind() == ErrorKind::AddrInUse,
+                    "unknown error: {} {:?}",
+                    e,
+                    e.kind()
+                );
+            }
+        }
+    })
+}
+
+#[test]
+fn tcp_clone_smoke() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let acceptor = t!(pool.bind_tcp_listener(&addr));
+
+        let _t = thread::spawn(move || {
+            let mut s = t!(pool.connect_tcp_stream(&addr));
+            let mut buf = [0, 0];
+            assert_eq!(s.read(&mut buf).unwrap(), 1);
+            assert_eq!(buf[0], 1);
+            t!(s.write(&[2]));
+        });
+
+        let mut s1 = t!(acceptor.accept()).0;
+        let s2 = t!(s1.try_clone());
+
+        let (tx1, rx1) = channel();
+        let (tx2, rx2) = channel();
+        let _t = thread::spawn(move || {
+            let mut s2 = s2;
+            rx1.recv().unwrap();
+            t!(s2.write(&[1]));
+            tx2.send(()).unwrap();
+        });
+        tx1.send(()).unwrap();
+        let mut buf = [0, 0];
+        assert_eq!(s1.read(&mut buf).unwrap(), 1);
+        rx2.recv().unwrap();
+    })
+}
+
+#[test]
+fn tcp_clone_two_read() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let acceptor = t!(pool.bind_tcp_listener(&addr));
+        let (tx1, rx) = channel();
+        let tx2 = tx1.clone();
+
+        let _t = thread::spawn(move || {
+            let mut s = t!(pool.connect_tcp_stream(&addr));
+            t!(s.write(&[1]));
+            rx.recv().unwrap();
+            t!(s.write(&[2]));
+            rx.recv().unwrap();
+        });
+
+        let mut s1 = t!(acceptor.accept()).0;
+        let s2 = t!(s1.try_clone());
+
+        let (done, rx) = channel();
+        let _t = thread::spawn(move || {
+            let mut s2 = s2;
+            let mut buf = [0, 0];
+            t!(s2.read(&mut buf));
+            tx2.send(()).unwrap();
+            done.send(()).unwrap();
+        });
+        let mut buf = [0, 0];
+        t!(s1.read(&mut buf));
+        tx1.send(()).unwrap();
+
+        rx.recv().unwrap();
+    })
+}
+
+#[test]
+fn tcp_clone_two_write() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let acceptor = t!(pool.bind_tcp_listener(&addr));
+
+        let _t = thread::spawn(move || {
+            let mut s = t!(pool.connect_tcp_stream(&addr));
+            let mut buf = [0, 1];
+            t!(s.read(&mut buf));
+            t!(s.read(&mut buf));
+        });
+
+        let mut s1 = t!(acceptor.accept()).0;
+        let s2 = t!(s1.try_clone());
+
+        let (done, rx) = channel();
+        let _t = thread::spawn(move || {
+            let mut s2 = s2;
+            t!(s2.write(&[1]));
+            done.send(()).unwrap();
+        });
+        t!(s1.write(&[2]));
+
+        rx.recv().unwrap();
+    })
+}
+
+#[test]
+// FIXME: https://github.com/fortanix/rust-sgx/issues/110
+#[cfg_attr(target_env = "sgx", ignore)]
+fn shutdown_smoke() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let a = t!(pool.bind_tcp_listener(&addr));
+        let _t = thread::spawn(move || {
+            let mut c = t!(a.accept()).0;
+            let mut b = [0];
+            assert_eq!(c.read(&mut b).unwrap(), 0);
+            t!(c.write(&[1]));
+        });
+
+        let mut s = t!(pool.connect_tcp_stream(&addr));
+        t!(s.shutdown(Shutdown::Write));
+        assert!(s.write(&[1]).is_err());
+        let mut b = [0, 0];
+        assert_eq!(t!(s.read(&mut b)), 1);
+        assert_eq!(b[0], 1);
+    })
+}
+
+#[test]
+// FIXME: https://github.com/fortanix/rust-sgx/issues/110
+#[cfg_attr(target_env = "sgx", ignore)]
+fn close_readwrite_smoke() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let a = t!(pool.bind_tcp_listener(&addr));
+        let (tx, rx) = channel::<()>();
+        let _t = thread::spawn(move || {
+            let _s = t!(a.accept());
+            let _ = rx.recv();
+        });
+
+        let mut b = [0];
+        let mut s = t!(pool.connect_tcp_stream(&addr));
+        let mut s2 = t!(s.try_clone());
+
+        // closing should prevent reads/writes
+        t!(s.shutdown(Shutdown::Write));
+        assert!(s.write(&[0]).is_err());
+        t!(s.shutdown(Shutdown::Read));
+        assert_eq!(s.read(&mut b).unwrap(), 0);
+
+        // closing should affect previous handles
+        assert!(s2.write(&[0]).is_err());
+        assert_eq!(s2.read(&mut b).unwrap(), 0);
+
+        // closing should affect new handles
+        let mut s3 = t!(s.try_clone());
+        assert!(s3.write(&[0]).is_err());
+        assert_eq!(s3.read(&mut b).unwrap(), 0);
+
+        // make sure these don't die
+        let _ = s2.shutdown(Shutdown::Read);
+        let _ = s2.shutdown(Shutdown::Write);
+        let _ = s3.shutdown(Shutdown::Read);
+        let _ = s3.shutdown(Shutdown::Write);
+        drop(tx);
+    })
+}
+
+#[test]
+#[cfg(unix)] // test doesn't work on Windows, see #31657
+fn close_read_wakes_up() {
+    let mut pool = Pool::new();
+
+    each_ip(&mut |addr| {
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let a = t!(pool.bind_tcp_listener(&addr));
+        let (tx1, rx) = channel::<()>();
+        let _t = thread::spawn(move || {
+            let _s = t!(a.accept());
+            let _ = rx.recv();
+        });
+
+        let s = t!(pool.connect_tcp_stream(&addr));
+        let s2 = t!(s.try_clone());
+        let (tx, rx) = channel();
+        let _t = thread::spawn(move || {
+            let mut s2 = s2;
+            assert_eq!(t!(s2.read(&mut [0])), 0);
+            tx.send(()).unwrap();
+        });
+        // this should wake up the child thread
+        t!(s.shutdown(Shutdown::Read));
+
+        // this test will never finish if the child doesn't wake up
+        rx.recv().unwrap();
+        drop(tx1);
+    })
+}
+
+#[test]
+fn clone_while_reading() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let accept = t!(pool.bind_tcp_listener(&addr));
+
+        // Enqueue a thread to write to a socket
+        let (tx, rx) = channel();
+        let (txdone, rxdone) = channel();
+        let txdone2 = txdone.clone();
+        let _t = thread::spawn(move || {
+            let mut tcp = t!(pool.connect_tcp_stream(&addr));
+            rx.recv().unwrap();
+            t!(tcp.write(&[0]));
+            txdone2.send(()).unwrap();
+        });
+
+        // Spawn off a reading clone
+        let tcp = t!(accept.accept()).0;
+        let tcp2 = t!(tcp.try_clone());
+        let txdone3 = txdone.clone();
+        let _t = thread::spawn(move || {
+            let mut tcp2 = tcp2;
+            t!(tcp2.read(&mut [0]));
+            txdone3.send(()).unwrap();
+        });
+
+        // Try to ensure that the reading clone is indeed reading
+        for _ in 0..50 {
+            thread::yield_now();
+        }
+
+        // clone the handle again while it's reading, then let it finish the
+        // read.
+        let _ = t!(tcp.try_clone());
+        tx.send(()).unwrap();
+        rxdone.recv().unwrap();
+        rxdone.recv().unwrap();
+    })
+}
+
+#[test]
+fn clone_accept_smoke() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let a = t!(pool.bind_tcp_listener(&addr));
+        let a2 = t!(a.try_clone());
+
+        let p = pool.clone();
+        let _t = thread::spawn(move || {
+            let _ = p.connect_tcp_stream(&addr);
+        });
+        let p = pool.clone();
+        let _t = thread::spawn(move || {
+            let _ = p.connect_tcp_stream(&addr);
+        });
+
+        t!(a.accept());
+        t!(a2.accept());
+    })
+}
+
+#[test]
+fn clone_accept_concurrent() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let a = t!(pool.bind_tcp_listener(&addr));
+        let a2 = t!(a.try_clone());
+
+        let (tx, rx) = channel();
+        let tx2 = tx.clone();
+
+        let _t = thread::spawn(move || {
+            tx.send(t!(a.accept())).unwrap();
+        });
+        let _t = thread::spawn(move || {
+            tx2.send(t!(a2.accept())).unwrap();
+        });
+
+        let p = pool.clone();
+        let _t = thread::spawn(move || {
+            let _ = p.connect_tcp_stream(&addr);
+        });
+        let p = pool.clone();
+        let _t = thread::spawn(move || {
+            let _ = p.connect_tcp_stream(&addr);
+        });
+
+        rx.recv().unwrap();
+        rx.recv().unwrap();
+    })
+}
+
+#[test]
+fn debug() {
+    let mut pool = Pool::new();
+
+    #[cfg(not(target_env = "sgx"))]
+    fn render_socket_addr<'a>(addr: &'a SocketAddr) -> impl fmt::Debug + 'a {
+        addr
+    }
+    #[cfg(target_env = "sgx")]
+    fn render_socket_addr<'a>(addr: &'a SocketAddr) -> impl fmt::Debug + 'a {
+        addr.to_string()
+    }
+
+    #[cfg(target_env = "sgx")]
+    use std::os::fortanix_sgx::io::AsRawFd;
+    #[cfg(unix)]
+    use std::os::unix::io::AsRawFd;
+    #[cfg(not(windows))]
+    fn render_inner(addr: &dyn AsRawFd) -> impl fmt::Debug {
+        addr.as_raw_fd()
+    }
+    #[cfg(windows)]
+    fn render_inner(addr: &dyn std::os::windows::io::AsRawSocket) -> impl fmt::Debug {
+        addr.as_raw_socket()
+    }
+
+    let inner_name = if cfg!(windows) { "socket" } else { "fd" };
+    let socket_addr = next_test_ip4();
+    unsafe {
+        pool.insert_socket_addr(socket_addr);
+    }
+    for resolved in format!("localhost:{}", socket_addr.port())
+        .to_socket_addrs()
+        .unwrap()
+    {
+        unsafe {
+            pool.insert_socket_addr(resolved);
+        }
+    }
+
+    let listener = t!(pool.bind_tcp_listener(&socket_addr));
+    let compare = format!(
+        "TcpListener {{ addr: {:?}, {}: {:?} }}",
+        render_socket_addr(&socket_addr),
+        inner_name,
+        render_inner(&listener)
+    );
+    assert_eq!(format!("{:?}", listener), compare);
+
+    let stream = t!(pool.connect_tcp_stream(&("localhost", socket_addr.port())));
+    let compare = format!(
+        "TcpStream {{ addr: {:?}, peer: {:?}, {}: {:?} }}",
+        render_socket_addr(&stream.local_addr().unwrap()),
+        render_socket_addr(&stream.peer_addr().unwrap()),
+        inner_name,
+        render_inner(&stream)
+    );
+    assert_eq!(format!("{:?}", stream), compare);
+}
+
+// FIXME: re-enabled openbsd tests once their socket timeout code
+//        no longer has rounding errors.
+// VxWorks ignores SO_SNDTIMEO.
+#[cfg_attr(
+    any(target_os = "netbsd", target_os = "openbsd", target_os = "vxworks"),
+    ignore
+)]
+#[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
+#[test]
+fn timeouts() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    unsafe {
+        pool.insert_socket_addr(addr);
+    }
+    for resolved in format!("localhost:{}", addr.port())
+        .to_socket_addrs()
+        .unwrap()
+    {
+        unsafe {
+            pool.insert_socket_addr(resolved);
+        }
+    }
+
+    let listener = t!(pool.bind_tcp_listener(&addr));
+
+    let stream = t!(pool.connect_tcp_stream(&("localhost", addr.port())));
+    let dur = Duration::new(15410, 0);
+
+    assert_eq!(None, t!(stream.read_timeout()));
+
+    t!(stream.set_read_timeout(Some(dur)));
+    assert_eq!(Some(dur), t!(stream.read_timeout()));
+
+    assert_eq!(None, t!(stream.write_timeout()));
+
+    t!(stream.set_write_timeout(Some(dur)));
+    assert_eq!(Some(dur), t!(stream.write_timeout()));
+
+    t!(stream.set_read_timeout(None));
+    assert_eq!(None, t!(stream.read_timeout()));
+
+    t!(stream.set_write_timeout(None));
+    assert_eq!(None, t!(stream.write_timeout()));
+    drop(listener);
+}
+
+#[test]
+#[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
+fn test_read_timeout() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    unsafe {
+        pool.insert_socket_addr(addr);
+    }
+    for resolved in format!("localhost:{}", addr.port())
+        .to_socket_addrs()
+        .unwrap()
+    {
+        unsafe {
+            pool.insert_socket_addr(resolved);
+        }
+    }
+
+    let listener = t!(pool.bind_tcp_listener(&addr));
+
+    let mut stream = t!(pool.connect_tcp_stream(&("localhost", addr.port())));
+    t!(stream.set_read_timeout(Some(Duration::from_millis(1000))));
+
+    let mut buf = [0; 10];
+    let start = Instant::now();
+    let kind = stream
+        .read_exact(&mut buf)
+        .err()
+        .expect("expected error")
+        .kind();
+    assert!(
+        kind == ErrorKind::WouldBlock || kind == ErrorKind::TimedOut,
+        "unexpected_error: {:?}",
+        kind
+    );
+    assert!(start.elapsed() > Duration::from_millis(400));
+    drop(listener);
+}
+
+#[test]
+#[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
+fn test_read_with_timeout() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    unsafe {
+        pool.insert_socket_addr(addr);
+    }
+    for resolved in format!("localhost:{}", addr.port())
+        .to_socket_addrs()
+        .unwrap()
+    {
+        unsafe {
+            pool.insert_socket_addr(resolved);
+        }
+    }
+
+    let listener = t!(pool.bind_tcp_listener(&addr));
+
+    let mut stream = t!(pool.connect_tcp_stream(&("localhost", addr.port())));
+    t!(stream.set_read_timeout(Some(Duration::from_millis(1000))));
+
+    let mut other_end = t!(listener.accept()).0;
+    t!(other_end.write_all(b"hello world"));
+
+    let mut buf = [0; 11];
+    t!(stream.read(&mut buf));
+    assert_eq!(b"hello world", &buf[..]);
+
+    let start = Instant::now();
+    let kind = stream
+        .read_exact(&mut buf)
+        .err()
+        .expect("expected error")
+        .kind();
+    assert!(
+        kind == ErrorKind::WouldBlock || kind == ErrorKind::TimedOut,
+        "unexpected_error: {:?}",
+        kind
+    );
+    assert!(start.elapsed() > Duration::from_millis(400));
+    drop(listener);
+}
+
+// Ensure the `set_read_timeout` and `set_write_timeout` calls return errors
+// when passed zero Durations
+#[test]
+fn test_timeout_zero_duration() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    unsafe {
+        pool.insert_socket_addr(addr);
+    }
+
+    let listener = t!(pool.bind_tcp_listener(&addr));
+    let stream = t!(pool.connect_tcp_stream(&addr));
+
+    let result = stream.set_write_timeout(Some(Duration::new(0, 0)));
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidInput);
+
+    let result = stream.set_read_timeout(Some(Duration::new(0, 0)));
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidInput);
+
+    drop(listener);
+}
+
+#[test]
+#[cfg_attr(target_env = "sgx", ignore)]
+fn nodelay() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    unsafe {
+        pool.insert_socket_addr(addr);
+    }
+    for resolved in format!("localhost:{}", addr.port())
+        .to_socket_addrs()
+        .unwrap()
+    {
+        unsafe {
+            pool.insert_socket_addr(resolved);
+        }
+    }
+
+    let _listener = t!(pool.bind_tcp_listener(&addr));
+
+    let stream = t!(pool.connect_tcp_stream(&("localhost", addr.port())));
+
+    assert_eq!(false, t!(stream.nodelay()));
+    t!(stream.set_nodelay(true));
+    assert_eq!(true, t!(stream.nodelay()));
+    t!(stream.set_nodelay(false));
+    assert_eq!(false, t!(stream.nodelay()));
+}
+
+#[test]
+#[cfg_attr(target_env = "sgx", ignore)]
+fn ttl() {
+    let ttl = 100;
+
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    unsafe {
+        pool.insert_socket_addr(addr);
+    }
+    for resolved in format!("localhost:{}", addr.port())
+        .to_socket_addrs()
+        .unwrap()
+    {
+        unsafe {
+            pool.insert_socket_addr(resolved);
+        }
+    }
+
+    let listener = t!(pool.bind_tcp_listener(&addr));
+
+    t!(listener.set_ttl(ttl));
+    assert_eq!(ttl, t!(listener.ttl()));
+
+    let stream = t!(pool.connect_tcp_stream(&("localhost", addr.port())));
+
+    t!(stream.set_ttl(ttl));
+    assert_eq!(ttl, t!(stream.ttl()));
+}
+
+#[test]
+#[cfg_attr(target_env = "sgx", ignore)]
+fn set_nonblocking() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    unsafe {
+        pool.insert_socket_addr(addr);
+    }
+    for resolved in format!("localhost:{}", addr.port())
+        .to_socket_addrs()
+        .unwrap()
+    {
+        unsafe {
+            pool.insert_socket_addr(resolved);
+        }
+    }
+
+    let listener = t!(pool.bind_tcp_listener(&addr));
+
+    t!(listener.set_nonblocking(true));
+    t!(listener.set_nonblocking(false));
+
+    let mut stream = t!(pool.connect_tcp_stream(&("localhost", addr.port())));
+
+    t!(stream.set_nonblocking(false));
+    t!(stream.set_nonblocking(true));
+
+    let mut buf = [0];
+    match stream.read(&mut buf) {
+        Ok(_) => panic!("expected error"),
+        Err(ref e) if e.kind() == ErrorKind::WouldBlock => {}
+        Err(e) => panic!("unexpected error {}", e),
+    }
+}
+
+#[test]
+#[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
+fn peek() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let (txdone, rxdone) = channel();
+
+        let srv = t!(pool.bind_tcp_listener(&addr));
+        let _t = thread::spawn(move || {
+            let mut cl = t!(srv.accept()).0;
+            cl.write(&[1, 3, 3, 7]).unwrap();
+            t!(rxdone.recv());
+        });
+
+        let mut c = t!(pool.connect_tcp_stream(&addr));
+        let mut b = [0; 10];
+        for _ in 1..3 {
+            let len = c.peek(&mut b).unwrap();
+            assert_eq!(len, 4);
+        }
+        let len = c.read(&mut b).unwrap();
+        assert_eq!(len, 4);
+
+        t!(c.set_nonblocking(true));
+        match c.peek(&mut b) {
+            Ok(_) => panic!("expected error"),
+            Err(ref e) if e.kind() == ErrorKind::WouldBlock => {}
+            Err(e) => panic!("unexpected error {}", e),
+        }
+        t!(txdone.send(()));
+    })
+}
+
+#[test]
+#[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
+fn connect_timeout_valid() {
+    let mut pool = Pool::new();
+    unsafe {
+        pool.insert_socket_addr("127.0.0.1:0".parse().unwrap());
+    }
+    let listener = pool.bind_tcp_listener("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let mut pool = Pool::new();
+    unsafe {
+        pool.insert_socket_addr(addr);
+    }
+    pool.connect_timeout_tcp_stream(&addr, Duration::from_secs(2))
+        .unwrap();
+}

--- a/tests/net-udp.rs
+++ b/tests/net-udp.rs
@@ -1,0 +1,495 @@
+// This file is derived from Rust's library/std/src/net/udp/tests.rs at
+// revision 377d1a984cd2a53327092b90aa1d8b7e22d1e347.
+
+mod net;
+mod sys_common;
+
+use cap_std::net::*;
+use net::{next_test_ip4, next_test_ip6};
+use std::{io::ErrorKind, sync::mpsc::channel};
+//use sys_common::AsInner;
+use std::{
+    thread,
+    time::{Duration, Instant},
+};
+
+fn each_ip(f: &mut dyn FnMut(SocketAddr, SocketAddr)) {
+    f(next_test_ip4(), next_test_ip4());
+    f(next_test_ip6(), next_test_ip6());
+}
+
+macro_rules! t {
+    ($e:expr) => {
+        match $e {
+            Ok(t) => t,
+            Err(e) => panic!("received error for `{}`: {}", stringify!($e), e),
+        }
+    };
+}
+
+#[test]
+fn bind_error() {
+    let mut pool = Pool::new();
+    unsafe {
+        pool.insert_socket_addr("1.1.1.1:9999".parse().unwrap());
+    }
+
+    match pool.bind_udp_socket("1.1.1.1:9999") {
+        Ok(..) => panic!(),
+        Err(e) => assert_eq!(e.kind(), ErrorKind::AddrNotAvailable),
+    }
+}
+
+#[test]
+fn socket_smoke_test_ip4() {
+    each_ip(&mut |server_ip, client_ip| {
+        let mut client_pool = Pool::new();
+        unsafe {
+            client_pool.insert_socket_addr(client_ip);
+        }
+        let mut server_pool = Pool::new();
+        unsafe {
+            server_pool.insert_socket_addr(server_ip);
+        }
+
+        let (tx1, rx1) = channel();
+        let (tx2, rx2) = channel();
+
+        let p = server_pool.clone();
+        let _t = thread::spawn(move || {
+            let client = t!(client_pool.bind_udp_socket(&client_ip));
+            rx1.recv().unwrap();
+            t!(p.send_to_udp_socket_addr(&client, &[99], &server_ip));
+            tx2.send(()).unwrap();
+        });
+
+        let server = t!(server_pool.bind_udp_socket(&server_ip));
+        tx1.send(()).unwrap();
+        let mut buf = [0];
+        let (nread, src) = t!(server.recv_from(&mut buf));
+        assert_eq!(nread, 1);
+        assert_eq!(buf[0], 99);
+        assert_eq!(src, client_ip);
+        rx2.recv().unwrap();
+    })
+}
+
+#[test]
+fn socket_name() {
+    each_ip(&mut |addr, _| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let server = t!(pool.bind_udp_socket(&addr));
+        assert_eq!(addr, t!(server.local_addr()));
+    })
+}
+
+#[test]
+fn socket_peer() {
+    each_ip(&mut |addr1, addr2| {
+        let mut pool1 = Pool::new();
+        unsafe {
+            pool1.insert_socket_addr(addr1);
+        }
+        let mut pool2 = Pool::new();
+        unsafe {
+            pool2.insert_socket_addr(addr2);
+        }
+
+        let server = t!(pool1.bind_udp_socket(&addr1));
+        assert_eq!(
+            server.peer_addr().unwrap_err().kind(),
+            ErrorKind::NotConnected
+        );
+        t!(pool2.connect_udp_socket(&server, &addr2));
+        assert_eq!(addr2, t!(server.peer_addr()));
+    })
+}
+
+#[test]
+fn udp_clone_smoke() {
+    each_ip(&mut |addr1, addr2| {
+        let mut pool1 = Pool::new();
+        unsafe {
+            pool1.insert_socket_addr(addr1);
+        }
+        let mut pool2 = Pool::new();
+        unsafe {
+            pool2.insert_socket_addr(addr2);
+        }
+
+        let sock1 = t!(pool1.bind_udp_socket(&addr1));
+        let sock2 = t!(pool2.bind_udp_socket(&addr2));
+
+        let _t = thread::spawn(move || {
+            let mut buf = [0, 0];
+            assert_eq!(sock2.recv_from(&mut buf).unwrap(), (1, addr1));
+            assert_eq!(buf[0], 1);
+            t!(pool1.send_to_udp_socket_addr(&sock2, &[2], &addr1));
+        });
+
+        let sock3 = t!(sock1.try_clone());
+
+        let (tx1, rx1) = channel();
+        let (tx2, rx2) = channel();
+        let p = pool2.clone();
+        let _t = thread::spawn(move || {
+            rx1.recv().unwrap();
+            t!(p.send_to_udp_socket_addr(&sock3, &[1], &addr2));
+            tx2.send(()).unwrap();
+        });
+        tx1.send(()).unwrap();
+        let mut buf = [0, 0];
+        assert_eq!(sock1.recv_from(&mut buf).unwrap(), (1, addr2));
+        rx2.recv().unwrap();
+    })
+}
+
+#[test]
+fn udp_clone_two_read() {
+    each_ip(&mut |addr1, addr2| {
+        let mut pool1 = Pool::new();
+        unsafe {
+            pool1.insert_socket_addr(addr1);
+        }
+        let mut pool2 = Pool::new();
+        unsafe {
+            pool2.insert_socket_addr(addr2);
+        }
+
+        let sock1 = t!(pool1.bind_udp_socket(&addr1));
+        let sock2 = t!(pool2.bind_udp_socket(&addr2));
+        let (tx1, rx) = channel();
+        let tx2 = tx1.clone();
+
+        let _t = thread::spawn(move || {
+            t!(pool1.send_to_udp_socket_addr(&sock2, &[1], &addr1));
+            rx.recv().unwrap();
+            t!(pool1.send_to_udp_socket_addr(&sock2, &[2], &addr1));
+            rx.recv().unwrap();
+        });
+
+        let sock3 = t!(sock1.try_clone());
+
+        let (done, rx) = channel();
+        let _t = thread::spawn(move || {
+            let mut buf = [0, 0];
+            t!(sock3.recv_from(&mut buf));
+            tx2.send(()).unwrap();
+            done.send(()).unwrap();
+        });
+        let mut buf = [0, 0];
+        t!(sock1.recv_from(&mut buf));
+        tx1.send(()).unwrap();
+
+        rx.recv().unwrap();
+    })
+}
+
+#[test]
+fn udp_clone_two_write() {
+    each_ip(&mut |addr1, addr2| {
+        let mut pool1 = Pool::new();
+        unsafe {
+            pool1.insert_socket_addr(addr1);
+        }
+        let mut pool2 = Pool::new();
+        unsafe {
+            pool2.insert_socket_addr(addr2);
+        }
+
+        let sock1 = t!(pool1.bind_udp_socket(&addr1));
+        let sock2 = t!(pool2.bind_udp_socket(&addr2));
+
+        let (tx, rx) = channel();
+        let (serv_tx, serv_rx) = channel();
+
+        let _t = thread::spawn(move || {
+            let mut buf = [0, 1];
+            rx.recv().unwrap();
+            t!(sock2.recv_from(&mut buf));
+            serv_tx.send(()).unwrap();
+        });
+
+        let sock3 = t!(sock1.try_clone());
+
+        let (done, rx) = channel();
+        let tx2 = tx.clone();
+        let p = pool2.clone();
+        let _t = thread::spawn(move || {
+            if p.send_to_udp_socket_addr(&sock3, &[1], &addr2).is_ok() {
+                let _ = tx2.send(());
+            }
+            done.send(()).unwrap();
+        });
+        if pool2.send_to_udp_socket_addr(&sock1, &[2], &addr2).is_ok() {
+            let _ = tx.send(());
+        }
+        drop(tx);
+
+        rx.recv().unwrap();
+        serv_rx.recv().unwrap();
+    })
+}
+
+/* Disable this test, as it depends on Rust-internal details.
+#[test]
+fn debug() {
+    let name = if cfg!(windows) { "socket" } else { "fd" };
+    let socket_addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    unsafe { pool.insert_socket_addr(socket_addr); }
+
+    let udpsock = t!(pool.bind_udp_socket(&socket_addr));
+    let udpsock_inner = udpsock.0.socket().as_inner();
+    let compare = format!("UdpSocket {{ addr: {:?}, {}: {:?} }}", socket_addr, name, udpsock_inner);
+    assert_eq!(format!("{:?}", udpsock), compare);
+}
+*/
+
+// FIXME: re-enabled openbsd/netbsd tests once their socket timeout code
+//        no longer has rounding errors.
+// VxWorks ignores SO_SNDTIMEO.
+#[cfg_attr(
+    any(target_os = "netbsd", target_os = "openbsd", target_os = "vxworks"),
+    ignore
+)]
+#[test]
+fn timeouts() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    unsafe {
+        pool.insert_socket_addr(addr);
+    }
+
+    let stream = t!(pool.bind_udp_socket(&addr));
+    let dur = Duration::new(15410, 0);
+
+    assert_eq!(None, t!(stream.read_timeout()));
+
+    t!(stream.set_read_timeout(Some(dur)));
+    assert_eq!(Some(dur), t!(stream.read_timeout()));
+
+    assert_eq!(None, t!(stream.write_timeout()));
+
+    t!(stream.set_write_timeout(Some(dur)));
+    assert_eq!(Some(dur), t!(stream.write_timeout()));
+
+    t!(stream.set_read_timeout(None));
+    assert_eq!(None, t!(stream.read_timeout()));
+
+    t!(stream.set_write_timeout(None));
+    assert_eq!(None, t!(stream.write_timeout()));
+}
+
+#[test]
+fn test_read_timeout() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    unsafe {
+        pool.insert_socket_addr(addr);
+    }
+
+    let stream = t!(pool.bind_udp_socket(&addr));
+    t!(stream.set_read_timeout(Some(Duration::from_millis(1000))));
+
+    let mut buf = [0; 10];
+
+    let start = Instant::now();
+    loop {
+        let kind = stream
+            .recv_from(&mut buf)
+            .err()
+            .expect("expected error")
+            .kind();
+        if kind != ErrorKind::Interrupted {
+            assert!(
+                kind == ErrorKind::WouldBlock || kind == ErrorKind::TimedOut,
+                "unexpected_error: {:?}",
+                kind
+            );
+            break;
+        }
+    }
+    assert!(start.elapsed() > Duration::from_millis(400));
+}
+
+#[test]
+fn test_read_with_timeout() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    unsafe {
+        pool.insert_socket_addr(addr);
+    }
+
+    let stream = t!(pool.bind_udp_socket(&addr));
+    t!(stream.set_read_timeout(Some(Duration::from_millis(1000))));
+
+    t!(pool.send_to_udp_socket_addr(&stream, b"hello world", &addr));
+
+    let mut buf = [0; 11];
+    t!(stream.recv_from(&mut buf));
+    assert_eq!(b"hello world", &buf[..]);
+
+    let start = Instant::now();
+    loop {
+        let kind = stream
+            .recv_from(&mut buf)
+            .err()
+            .expect("expected error")
+            .kind();
+        if kind != ErrorKind::Interrupted {
+            assert!(
+                kind == ErrorKind::WouldBlock || kind == ErrorKind::TimedOut,
+                "unexpected_error: {:?}",
+                kind
+            );
+            break;
+        }
+    }
+    assert!(start.elapsed() > Duration::from_millis(400));
+}
+
+// Ensure the `set_read_timeout` and `set_write_timeout` calls return errors
+// when passed zero Durations
+#[test]
+fn test_timeout_zero_duration() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    unsafe {
+        pool.insert_socket_addr(addr);
+    }
+
+    let socket = t!(pool.bind_udp_socket(&addr));
+
+    let result = socket.set_write_timeout(Some(Duration::new(0, 0)));
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidInput);
+
+    let result = socket.set_read_timeout(Some(Duration::new(0, 0)));
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidInput);
+}
+
+#[test]
+fn connect_send_recv() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    unsafe {
+        pool.insert_socket_addr(addr);
+    }
+
+    let socket = t!(pool.bind_udp_socket(&addr));
+    t!(pool.connect_udp_socket(&socket, addr));
+
+    t!(socket.send(b"hello world"));
+
+    let mut buf = [0; 11];
+    t!(socket.recv(&mut buf));
+    assert_eq!(b"hello world", &buf[..]);
+}
+
+#[test]
+fn connect_send_peek_recv() {
+    each_ip(&mut |addr, _| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let socket = t!(pool.bind_udp_socket(&addr));
+        t!(pool.connect_udp_socket(&socket, addr));
+
+        t!(socket.send(b"hello world"));
+
+        for _ in 1..3 {
+            let mut buf = [0; 11];
+            let size = t!(socket.peek(&mut buf));
+            assert_eq!(b"hello world", &buf[..]);
+            assert_eq!(size, 11);
+        }
+
+        let mut buf = [0; 11];
+        let size = t!(socket.recv(&mut buf));
+        assert_eq!(b"hello world", &buf[..]);
+        assert_eq!(size, 11);
+    })
+}
+
+#[test]
+fn peek_from() {
+    each_ip(&mut |addr, _| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let socket = t!(pool.bind_udp_socket(&addr));
+        t!(pool.send_to_udp_socket_addr(&socket, b"hello world", &addr));
+
+        for _ in 1..3 {
+            let mut buf = [0; 11];
+            let (size, _) = t!(socket.peek_from(&mut buf));
+            assert_eq!(b"hello world", &buf[..]);
+            assert_eq!(size, 11);
+        }
+
+        let mut buf = [0; 11];
+        let (size, _) = t!(socket.recv_from(&mut buf));
+        assert_eq!(b"hello world", &buf[..]);
+        assert_eq!(size, 11);
+    })
+}
+
+#[test]
+fn ttl() {
+    let ttl = 100;
+
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    unsafe {
+        pool.insert_socket_addr(addr);
+    }
+
+    let stream = t!(pool.bind_udp_socket(&addr));
+
+    t!(stream.set_ttl(ttl));
+    assert_eq!(ttl, t!(stream.ttl()));
+}
+
+#[test]
+fn set_nonblocking() {
+    each_ip(&mut |addr, _| {
+        let mut pool = Pool::new();
+        unsafe {
+            pool.insert_socket_addr(addr);
+        }
+
+        let socket = t!(pool.bind_udp_socket(&addr));
+
+        t!(socket.set_nonblocking(true));
+        t!(socket.set_nonblocking(false));
+
+        t!(pool.connect_udp_socket(&socket, addr));
+
+        t!(socket.set_nonblocking(false));
+        t!(socket.set_nonblocking(true));
+
+        let mut buf = [0];
+        match socket.recv(&mut buf) {
+            Ok(_) => panic!("expected error"),
+            Err(ref e) if e.kind() == ErrorKind::WouldBlock => {}
+            Err(e) => panic!("unexpected error {}", e),
+        }
+    })
+}

--- a/tests/net.rs
+++ b/tests/net.rs
@@ -1,0 +1,78 @@
+// This file is derived from Rust's library/std/src/net/test.rs at
+// revision 377d1a984cd2a53327092b90aa1d8b7e22d1e347.
+
+#![allow(warnings)] // not used on emscripten
+
+use cap_std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs};
+use std::{
+    env,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+static PORT: AtomicUsize = AtomicUsize::new(0);
+
+pub fn next_test_ip4() -> SocketAddr {
+    let port = PORT.fetch_add(1, Ordering::SeqCst) as u16 + base_port();
+    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), port))
+}
+
+pub fn next_test_ip6() -> SocketAddr {
+    let port = PORT.fetch_add(1, Ordering::SeqCst) as u16 + base_port();
+    SocketAddr::V6(SocketAddrV6::new(
+        Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1),
+        port,
+        0,
+        0,
+    ))
+}
+
+pub fn sa4(a: Ipv4Addr, p: u16) -> SocketAddr {
+    SocketAddr::V4(SocketAddrV4::new(a, p))
+}
+
+pub fn sa6(a: Ipv6Addr, p: u16) -> SocketAddr {
+    SocketAddr::V6(SocketAddrV6::new(a, p, 0, 0))
+}
+
+pub fn tsa<A: ToSocketAddrs>(a: A) -> Result<Vec<SocketAddr>, String> {
+    match a.to_socket_addrs() {
+        Ok(a) => Ok(a.collect()),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+// The bots run multiple builds at the same time, and these builds
+// all want to use ports. This function figures out which workspace
+// it is running in and assigns a port range based on it.
+fn base_port() -> u16 {
+    let cwd = if cfg!(target_env = "sgx") {
+        String::from("sgx")
+    } else {
+        env::current_dir()
+            .unwrap()
+            .into_os_string()
+            .into_string()
+            .unwrap()
+    };
+    let dirs = [
+        "32-opt",
+        "32-nopt",
+        "musl-64-opt",
+        "cross-opt",
+        "64-opt",
+        "64-nopt",
+        "64-opt-vg",
+        "64-debug-opt",
+        "all-opt",
+        "snap3",
+        "dist",
+        "sgx",
+    ];
+    dirs.iter()
+        .enumerate()
+        .find(|&(_, dir)| cwd.contains(dir))
+        .map(|p| p.0)
+        .unwrap_or(0) as u16
+        * 1000
+        + 19600
+}


### PR DESCRIPTION
This series of patches gets `cap_std::net` to a point where basic networking code works, including all the TCP and UDP tests ported from Rust's standard library testsuite.

This renames `Catalog` to `Pool`, which seems like it might be a more intuitive name. And it adds methods for constructing and populating pools.

The pool mechanism here is not sophisticated, but it's a first step!
