### PR TITLE
cap-tempfile: dev-depend on winapi only on Windows

### DIFF
--- a/cap-tempfile/Cargo.toml
+++ b/cap-tempfile/Cargo.toml
@@ -19,7 +19,7 @@ uuid = { version = "0.8.1", features = ["v4"] }
 [target.'cfg(target_os = "emscripten")'.dependencies]
 rand = "0.8.1"
 
-[dev-dependencies]
+[target.'cfg(windows)'.dev-dependencies]
 winapi = "0.3.9"
 
 [badges]


### PR DESCRIPTION
`cap-tempfile` should have a dev-dependency on `winapi` only on Windows.

Only usage on `winapi` in `cap-tempfile`: https://github.com/bytecodealliance/cap-std/blob/1ec2258d7b03b4a4f64108cf4bf59003f0aa7ab0/cap-tempfile/src/lib.rs#L214-L218