### PR TITLE
Port to io-lifetimes, add optional linux-raw-sys support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -307,6 +307,35 @@ jobs:
     - run: rustup target add x86_64-unknown-linux-musl
     - run: cargo test --target x86_64-unknown-linux-musl --features fs_utf8 --workspace
 
+  test_linux_raw:
+    name: Test linux-raw support
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build: [ubuntu, ubuntu-16.04, ubuntu-18.04]
+        include:
+          - build: ubuntu
+            os: ubuntu-latest
+            rust: nightly
+          - build: ubuntu-16.04
+            os: ubuntu-16.04
+            rust: nightly
+          - build: ubuntu-18.04
+            os: ubuntu-18.04
+            rust: nightly
+
+    env:
+      RUSTFLAGS: --cfg linux_raw
+      RUSTDOCFLAGS: --cfg linux_raw
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: ${{ matrix.rust }}
+    - run: cargo test --all-features --workspace
+
   fuzz_targets:
     name: Fuzz Targets
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rand = "0.8.1"
 tempfile = "3.1.0"
 
 [target.'cfg(not(windows))'.dev-dependencies]
-posish = "0.8.0"
+posish = "0.8.3"
 
 [target.'cfg(windows)'.dev-dependencies]
 # nt_version uses internal Windows APIs, however we're only using it

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rand = "0.8.1"
 tempfile = "3.1.0"
 
 [target.'cfg(not(windows))'.dev-dependencies]
-libc = "0.2.81"
+posish = "0.8.0"
 
 [target.'cfg(windows)'.dev-dependencies]
 # nt_version uses internal Windows APIs, however we're only using it

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 publish = false
 
 [build-dependencies]
-rustc_version = "0.3.0"
+rustc_version = "0.4.0"
 
 [dev-dependencies]
 async-std = { version = "1.9.0", features = ["attributes"] }

--- a/cap-async-std/Cargo.toml
+++ b/cap-async-std/Cargo.toml
@@ -20,7 +20,7 @@ ipnet = "2.3.0"
 unsafe-io = { version = "0.6.0", features = ["async-std"] }
 
 [target.'cfg(not(windows))'.dependencies]
-posish = "0.6.0"
+posish = "0.8.0"
 
 [features]
 default = []

--- a/cap-async-std/Cargo.toml
+++ b/cap-async-std/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2018"
 arf-strings = { version = "0.3.0", optional = true }
 async-std = { version = "1.9.0", features = ["attributes"] }
 cap-primitives = { path = "../cap-primitives", version = "^0.13.11-alpha.0"}
+io-lifetimes = "0.1.0"
 ipnet = "2.3.0"
 unsafe-io = { version = "0.6.0", features = ["async-std"] }
 

--- a/cap-async-std/Cargo.toml
+++ b/cap-async-std/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 arf-strings = { version = "0.3.0", optional = true }
 async-std = { version = "1.9.0", features = ["attributes"] }
 cap-primitives = { path = "../cap-primitives", version = "^0.13.11-alpha.0"}
-io-lifetimes = "0.1.0"
+io-lifetimes = { version = "0.1.1", features = ["async-std"] }
 ipnet = "2.3.0"
 unsafe-io = { version = "0.6.0", features = ["async-std"] }
 

--- a/cap-async-std/src/fs/dir.rs
+++ b/cap-async-std/src/fs/dir.rs
@@ -18,6 +18,10 @@ use cap_primitives::{
     },
     AmbientAuthority,
 };
+#[cfg(not(windows))]
+use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+#[cfg(windows)]
+use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
 use std::fmt;
 use unsafe_io::{AsUnsafeFile, FromUnsafeFile, OwnsRaw};
 #[cfg(unix)]
@@ -606,6 +610,14 @@ impl FromRawFd for Dir {
     }
 }
 
+#[cfg(not(windows))]
+impl FromFd for Dir {
+    #[inline]
+    fn from_fd(fd: OwnedFd) -> Self {
+        Self::from_std_file(fs::File::from_fd(fd), ambient_authority())
+    }
+}
+
 #[cfg(windows)]
 impl FromRawHandle for Dir {
     /// To prevent race conditions on Windows, the handle must be opened without
@@ -621,6 +633,14 @@ impl AsRawFd for Dir {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.std_file.as_raw_fd()
+    }
+}
+
+#[cfg(not(windows))]
+impl<'f> AsFd<'f> for &'f Dir {
+    #[inline]
+    fn as_fd(self) -> BorrowedFd<'f> {
+        self.std_file.as_fd()
     }
 }
 
@@ -645,6 +665,14 @@ impl IntoRawFd for Dir {
     #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.std_file.into_raw_fd()
+    }
+}
+
+#[cfg(not(windows))]
+impl IntoFd for Dir {
+    #[inline]
+    fn into_fd(self) -> OwnedFd {
+        self.std_file.into_fd()
     }
 }
 

--- a/cap-async-std/src/fs/dir.rs
+++ b/cap-async-std/src/fs/dir.rs
@@ -664,7 +664,7 @@ impl AsRawHandle for Dir {
 impl<'h> AsHandle<'h> for &'h Dir {
     #[inline]
     fn as_handle(self) -> BorrowedHandle<'h> {
-        self.cap_std.as_handle()
+        self.std_file.as_handle()
     }
 }
 

--- a/cap-async-std/src/fs/dir.rs
+++ b/cap-async-std/src/fs/dir.rs
@@ -628,6 +628,14 @@ impl FromRawHandle for Dir {
     }
 }
 
+#[cfg(windows)]
+impl FromHandle for Dir {
+    #[inline]
+    fn from_handle(handle: OwnedHandle) -> Self {
+        Self::from_std_file(fs::File::from_handle(handle), ambient_authority())
+    }
+}
+
 #[cfg(not(windows))]
 impl AsRawFd for Dir {
     #[inline]
@@ -649,6 +657,14 @@ impl AsRawHandle for Dir {
     #[inline]
     fn as_raw_handle(&self) -> RawHandle {
         self.std_file.as_raw_handle()
+    }
+}
+
+#[cfg(windows)]
+impl<'h> AsHandle<'h> for &'h Dir {
+    #[inline]
+    fn as_handle(self) -> BorrowedHandle<'h> {
+        self.cap_std.as_handle()
     }
 }
 
@@ -681,6 +697,14 @@ impl IntoRawHandle for Dir {
     #[inline]
     fn into_raw_handle(self) -> RawHandle {
         self.std_file.into_raw_handle()
+    }
+}
+
+#[cfg(windows)]
+impl IntoHandle for Dir {
+    #[inline]
+    fn into_handle(self) -> OwnedHandle {
+        self.std_file.into_handle()
     }
 }
 

--- a/cap-async-std/src/fs/file.rs
+++ b/cap-async-std/src/fs/file.rs
@@ -159,6 +159,14 @@ impl FromRawHandle for File {
     }
 }
 
+#[cfg(windows)]
+impl FromHandle for File {
+    #[inline]
+    fn from_handle(handle: OwnedHandle) -> Self {
+        Self::from_std(fs::File::from_handle(handle), ambient_authority())
+    }
+}
+
 #[cfg(not(windows))]
 impl AsRawFd for File {
     #[inline]
@@ -180,6 +188,14 @@ impl AsRawHandle for File {
     #[inline]
     fn as_raw_handle(&self) -> RawHandle {
         self.std.as_raw_handle()
+    }
+}
+
+#[cfg(windows)]
+impl<'h> AsHandle<'h> for &'h File {
+    #[inline]
+    fn as_handle(self) -> BorrowedHandle<'h> {
+        self.cap_std.as_handle()
     }
 }
 
@@ -212,6 +228,14 @@ impl IntoRawHandle for File {
     #[inline]
     fn into_raw_handle(self) -> RawHandle {
         self.std.into_raw_handle()
+    }
+}
+
+#[cfg(windows)]
+impl IntoHandle for File {
+    #[inline]
+    fn into_handle(self) -> OwnedHandle {
+        self.std.into_handle()
     }
 }
 

--- a/cap-async-std/src/fs/file.rs
+++ b/cap-async-std/src/fs/file.rs
@@ -195,7 +195,7 @@ impl AsRawHandle for File {
 impl<'h> AsHandle<'h> for &'h File {
     #[inline]
     fn as_handle(self) -> BorrowedHandle<'h> {
-        self.cap_std.as_handle()
+        self.std.as_handle()
     }
 }
 

--- a/cap-async-std/src/fs/file.rs
+++ b/cap-async-std/src/fs/file.rs
@@ -9,6 +9,10 @@ use async_std::{
     task::{Context, Poll},
 };
 use cap_primitives::{ambient_authority, fs::is_file_read_write, AmbientAuthority};
+#[cfg(not(windows))]
+use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+#[cfg(windows)]
+use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
 use std::{fmt, pin::Pin};
 use unsafe_io::{AsUnsafeFile, OwnsRaw};
 #[cfg(windows)]
@@ -139,6 +143,14 @@ impl FromRawFd for File {
     }
 }
 
+#[cfg(not(windows))]
+impl FromFd for File {
+    #[inline]
+    fn from_fd(fd: OwnedFd) -> Self {
+        Self::from_std(fs::File::from_fd(fd), ambient_authority())
+    }
+}
+
 #[cfg(windows)]
 impl FromRawHandle for File {
     #[inline]
@@ -152,6 +164,14 @@ impl AsRawFd for File {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.std.as_raw_fd()
+    }
+}
+
+#[cfg(not(windows))]
+impl<'f> AsFd<'f> for &'f File {
+    #[inline]
+    fn as_fd(self) -> BorrowedFd<'f> {
+        self.std.as_fd()
     }
 }
 
@@ -176,6 +196,14 @@ impl IntoRawFd for File {
     #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.std.into_raw_fd()
+    }
+}
+
+#[cfg(not(windows))]
+impl IntoFd for File {
+    #[inline]
+    fn into_fd(self) -> OwnedFd {
+        self.std.into_fd()
     }
 }
 

--- a/cap-async-std/src/fs_utf8/dir.rs
+++ b/cap-async-std/src/fs_utf8/dir.rs
@@ -4,6 +4,10 @@ use crate::{
 };
 use async_std::{fs, io};
 use cap_primitives::{ambient_authority, AmbientAuthority};
+#[cfg(not(windows))]
+use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+#[cfg(windows)]
+use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
 use std::fmt;
 use unsafe_io::OwnsRaw;
 #[cfg(unix)]
@@ -519,6 +523,14 @@ impl FromRawFd for Dir {
     }
 }
 
+#[cfg(not(windows))]
+impl FromFd for Dir {
+    #[inline]
+    fn from_fd(fd: OwnedFd) -> Self {
+        Self::from_std_file(fs::File::from_fd(fd), ambient_authority())
+    }
+}
+
 #[cfg(windows)]
 impl FromRawHandle for Dir {
     /// To prevent race conditions on Windows, the handle must be opened without
@@ -534,6 +546,14 @@ impl AsRawFd for Dir {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.cap_std.as_raw_fd()
+    }
+}
+
+#[cfg(not(windows))]
+impl<'f> AsFd<'f> for &'f Dir {
+    #[inline]
+    fn as_fd(self) -> BorrowedFd<'f> {
+        self.std.as_fd()
     }
 }
 
@@ -558,6 +578,14 @@ impl IntoRawFd for Dir {
     #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.cap_std.into_raw_fd()
+    }
+}
+
+#[cfg(not(windows))]
+impl IntoFd for Dir {
+    #[inline]
+    fn into_fd(self) -> OwnedFd {
+        self.std.into_fd()
     }
 }
 

--- a/cap-async-std/src/fs_utf8/dir.rs
+++ b/cap-async-std/src/fs_utf8/dir.rs
@@ -561,7 +561,7 @@ impl AsRawFd for Dir {
 impl<'f> AsFd<'f> for &'f Dir {
     #[inline]
     fn as_fd(self) -> BorrowedFd<'f> {
-        self.std.as_fd()
+        self.cap_std.as_fd()
     }
 }
 
@@ -601,7 +601,7 @@ impl IntoRawFd for Dir {
 impl IntoFd for Dir {
     #[inline]
     fn into_fd(self) -> OwnedFd {
-        self.std.into_fd()
+        self.cap_std.into_fd()
     }
 }
 

--- a/cap-async-std/src/fs_utf8/dir.rs
+++ b/cap-async-std/src/fs_utf8/dir.rs
@@ -541,6 +541,14 @@ impl FromRawHandle for Dir {
     }
 }
 
+#[cfg(windows)]
+impl FromHandle for Dir {
+    #[inline]
+    fn from_handle(handle: OwnedHandle) -> Self {
+        Self::from_std_file(fs::File::from_handle(handle), ambient_authority())
+    }
+}
+
 #[cfg(not(windows))]
 impl AsRawFd for Dir {
     #[inline]
@@ -562,6 +570,14 @@ impl AsRawHandle for Dir {
     #[inline]
     fn as_raw_handle(&self) -> RawHandle {
         self.cap_std.as_raw_handle()
+    }
+}
+
+#[cfg(windows)]
+impl<'h> AsHandle<'h> for &'h Dir {
+    #[inline]
+    fn as_handle(self) -> BorrowedHandle<'h> {
+        self.cap_std.as_handle()
     }
 }
 
@@ -594,6 +610,14 @@ impl IntoRawHandle for Dir {
     #[inline]
     fn into_raw_handle(self) -> RawHandle {
         self.cap_std.into_raw_handle()
+    }
+}
+
+#[cfg(windows)]
+impl IntoHandle for Dir {
+    #[inline]
+    fn into_handle(self) -> OwnedHandle {
+        self.cap_std.into_handle()
     }
 }
 

--- a/cap-async-std/src/fs_utf8/file.rs
+++ b/cap-async-std/src/fs_utf8/file.rs
@@ -9,6 +9,10 @@ use async_std::{
     task::{Context, Poll},
 };
 use cap_primitives::{ambient_authority, AmbientAuthority};
+#[cfg(not(windows))]
+use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+#[cfg(windows)]
+use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
 use std::{fmt, pin::Pin};
 use unsafe_io::OwnsRaw;
 #[cfg(windows)]
@@ -111,6 +115,14 @@ impl FromRawFd for File {
     }
 }
 
+#[cfg(not(windows))]
+impl FromFd for File {
+    #[inline]
+    fn from_fd(fd: OwnedFd) -> Self {
+        Self::from_std(fs::File::from_fd(fd), ambient_authority())
+    }
+}
+
 #[cfg(windows)]
 impl FromRawHandle for File {
     #[inline]
@@ -124,6 +136,14 @@ impl AsRawFd for File {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.cap_std.as_raw_fd()
+    }
+}
+
+#[cfg(not(windows))]
+impl<'f> AsFd<'f> for &'f File {
+    #[inline]
+    fn as_fd(self) -> BorrowedFd<'f> {
+        self.std.as_fd()
     }
 }
 
@@ -148,6 +168,14 @@ impl IntoRawFd for File {
     #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.cap_std.into_raw_fd()
+    }
+}
+
+#[cfg(not(windows))]
+impl IntoFd for File {
+    #[inline]
+    fn into_fd(self) -> OwnedFd {
+        self.std.into_fd()
     }
 }
 

--- a/cap-async-std/src/fs_utf8/file.rs
+++ b/cap-async-std/src/fs_utf8/file.rs
@@ -131,6 +131,14 @@ impl FromRawHandle for File {
     }
 }
 
+#[cfg(windows)]
+impl FromHandle for File {
+    #[inline]
+    fn from_handle(handle: OwnedHandle) -> Self {
+        Self::from_std(fs::File::from_handle(handle), ambient_authority())
+    }
+}
+
 #[cfg(not(windows))]
 impl AsRawFd for File {
     #[inline]
@@ -152,6 +160,14 @@ impl AsRawHandle for File {
     #[inline]
     fn as_raw_handle(&self) -> RawHandle {
         self.cap_std.as_raw_handle()
+    }
+}
+
+#[cfg(windows)]
+impl<'h> AsHandle<'h> for &'h File {
+    #[inline]
+    fn as_handle(self) -> BorrowedHandle<'h> {
+        self.cap_std.as_handle()
     }
 }
 
@@ -184,6 +200,14 @@ impl IntoRawHandle for File {
     #[inline]
     fn into_raw_handle(self) -> RawHandle {
         self.cap_std.into_raw_handle()
+    }
+}
+
+#[cfg(windows)]
+impl IntoHandle for File {
+    #[inline]
+    fn into_handle(self) -> OwnedHandle {
+        self.cap_std.into_handle()
     }
 }
 

--- a/cap-async-std/src/fs_utf8/file.rs
+++ b/cap-async-std/src/fs_utf8/file.rs
@@ -151,7 +151,7 @@ impl AsRawFd for File {
 impl<'f> AsFd<'f> for &'f File {
     #[inline]
     fn as_fd(self) -> BorrowedFd<'f> {
-        self.std.as_fd()
+        self.cap_std.as_fd()
     }
 }
 
@@ -191,7 +191,7 @@ impl IntoRawFd for File {
 impl IntoFd for File {
     #[inline]
     fn into_fd(self) -> OwnedFd {
-        self.std.into_fd()
+        self.cap_std.into_fd()
     }
 }
 

--- a/cap-async-std/src/net/tcp_listener.rs
+++ b/cap-async-std/src/net/tcp_listener.rs
@@ -6,7 +6,7 @@ use cap_primitives::{ambient_authority, AmbientAuthority};
 #[cfg(not(windows))]
 use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 #[cfg(windows)]
-use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
+use io_lifetimes::{AsSocket, BorrowedSocket, FromSocket, IntoSocket, OwnedSocket};
 use std::fmt;
 use unsafe_io::OwnsRaw;
 #[cfg(windows)]
@@ -142,8 +142,8 @@ impl AsRawSocket for TcpListener {
 #[cfg(windows)]
 impl<'s> AsSocket<'s> for &'s TcpListener {
     #[inline]
-    fn as_raw_socket(self) -> BorrowedSocket<'s> {
-        self.std.as_raw_socket()
+    fn as_socket(self) -> BorrowedSocket<'s> {
+        self.std.as_socket()
     }
 }
 

--- a/cap-async-std/src/net/tcp_listener.rs
+++ b/cap-async-std/src/net/tcp_listener.rs
@@ -107,6 +107,17 @@ impl FromRawSocket for TcpListener {
     }
 }
 
+#[cfg(windows)]
+impl FromSocket for TcpListener {
+    #[inline]
+    fn from_socket(socket: OwnedSocket) -> Self {
+        Self::from_std(
+            net::TcpListener::from_socket(socket),
+            ambient_authority(),
+        )
+    }
+}
+
 #[cfg(not(windows))]
 impl AsRawFd for TcpListener {
     #[inline]
@@ -127,6 +138,14 @@ impl<'f> AsFd<'f> for &'f TcpListener {
 impl AsRawSocket for TcpListener {
     #[inline]
     fn as_raw_socket(&self) -> RawSocket {
+        self.std.as_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl<'s> AsSocket<'s> for &'s TcpListener {
+    #[inline]
+    fn as_raw_socket(self) -> BorrowedSocket<'s> {
         self.std.as_raw_socket()
     }
 }
@@ -160,6 +179,14 @@ impl IntoRawSocket for TcpListener {
     #[inline]
     fn into_raw_socket(self) -> RawSocket {
         self.std.into_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl IntoSocket for TcpListener {
+    #[inline]
+    fn into_socket(self) -> OwnedSocket {
+        self.std.into_socket()
     }
 }
 

--- a/cap-async-std/src/net/tcp_listener.rs
+++ b/cap-async-std/src/net/tcp_listener.rs
@@ -111,10 +111,7 @@ impl FromRawSocket for TcpListener {
 impl FromSocket for TcpListener {
     #[inline]
     fn from_socket(socket: OwnedSocket) -> Self {
-        Self::from_std(
-            net::TcpListener::from_socket(socket),
-            ambient_authority(),
-        )
+        Self::from_std(net::TcpListener::from_socket(socket), ambient_authority())
     }
 }
 

--- a/cap-async-std/src/net/tcp_stream.rs
+++ b/cap-async-std/src/net/tcp_stream.rs
@@ -153,10 +153,7 @@ impl FromRawSocket for TcpStream {
 impl FromSocket for TcpStream {
     #[inline]
     fn from_socket(socket: OwnedSocket) -> Self {
-        Self::from_std(
-            net::TcpStream::from_socket(socket),
-            ambient_authority(),
-        )
+        Self::from_std(net::TcpStream::from_socket(socket), ambient_authority())
     }
 }
 

--- a/cap-async-std/src/net/tcp_stream.rs
+++ b/cap-async-std/src/net/tcp_stream.rs
@@ -7,6 +7,10 @@ use async_std::{
     task::{Context, Poll},
 };
 use cap_primitives::{ambient_authority, AmbientAuthority};
+#[cfg(not(windows))]
+use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+#[cfg(windows)]
+use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
 use std::{fmt, pin::Pin};
 use unsafe_io::OwnsRaw;
 #[cfg(windows)]
@@ -129,6 +133,14 @@ impl FromRawFd for TcpStream {
     }
 }
 
+#[cfg(not(windows))]
+impl FromFd for TcpStream {
+    #[inline]
+    fn from_fd(fd: OwnedFd) -> Self {
+        Self::from_std(net::TcpStream::from_fd(fd), ambient_authority())
+    }
+}
+
 #[cfg(windows)]
 impl FromRawSocket for TcpStream {
     #[inline]
@@ -142,6 +154,14 @@ impl AsRawFd for TcpStream {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.std.as_raw_fd()
+    }
+}
+
+#[cfg(not(windows))]
+impl<'f> AsFd<'f> for &'f TcpStream {
+    #[inline]
+    fn as_fd(self) -> BorrowedFd<'f> {
+        self.std.as_fd()
     }
 }
 
@@ -166,6 +186,14 @@ impl IntoRawFd for TcpStream {
     #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.std.into_raw_fd()
+    }
+}
+
+#[cfg(not(windows))]
+impl IntoFd for TcpStream {
+    #[inline]
+    fn into_fd(self) -> OwnedFd {
+        self.std.into_fd()
     }
 }
 

--- a/cap-async-std/src/net/tcp_stream.rs
+++ b/cap-async-std/src/net/tcp_stream.rs
@@ -10,7 +10,7 @@ use cap_primitives::{ambient_authority, AmbientAuthority};
 #[cfg(not(windows))]
 use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 #[cfg(windows)]
-use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
+use io_lifetimes::{AsSocket, BorrowedSocket, FromSocket, IntoSocket, OwnedSocket};
 use std::{fmt, pin::Pin};
 use unsafe_io::OwnsRaw;
 #[cfg(windows)]
@@ -184,8 +184,8 @@ impl AsRawSocket for TcpStream {
 #[cfg(windows)]
 impl<'s> AsSocket<'s> for &'s TcpStream {
     #[inline]
-    fn as_raw_socket(self) -> BorrowedSocket<'s> {
-        self.std.as_raw_socket()
+    fn as_socket(self) -> BorrowedSocket<'s> {
+        self.std.as_socket()
     }
 }
 

--- a/cap-async-std/src/net/tcp_stream.rs
+++ b/cap-async-std/src/net/tcp_stream.rs
@@ -149,6 +149,17 @@ impl FromRawSocket for TcpStream {
     }
 }
 
+#[cfg(windows)]
+impl FromSocket for TcpStream {
+    #[inline]
+    fn from_socket(socket: OwnedSocket) -> Self {
+        Self::from_std(
+            net::TcpStream::from_socket(socket),
+            ambient_authority(),
+        )
+    }
+}
+
 #[cfg(not(windows))]
 impl AsRawFd for TcpStream {
     #[inline]
@@ -169,6 +180,14 @@ impl<'f> AsFd<'f> for &'f TcpStream {
 impl AsRawSocket for TcpStream {
     #[inline]
     fn as_raw_socket(&self) -> RawSocket {
+        self.std.as_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl<'s> AsSocket<'s> for &'s TcpStream {
+    #[inline]
+    fn as_raw_socket(self) -> BorrowedSocket<'s> {
         self.std.as_raw_socket()
     }
 }
@@ -202,6 +221,14 @@ impl IntoRawSocket for TcpStream {
     #[inline]
     fn into_raw_socket(self) -> RawSocket {
         self.std.into_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl IntoSocket for TcpStream {
+    #[inline]
+    fn into_socket(self) -> OwnedSocket {
+        self.std.into_socket()
     }
 }
 

--- a/cap-async-std/src/net/udp_socket.rs
+++ b/cap-async-std/src/net/udp_socket.rs
@@ -249,10 +249,7 @@ impl FromRawSocket for UdpSocket {
 impl FromSocket for UdpSocket {
     #[inline]
     fn from_socket(socket: OwnedSocket) -> Self {
-        Self::from_std(
-            net::UdpSocket::from_socket(socket),
-            ambient_authority(),
-        )
+        Self::from_std(net::UdpSocket::from_socket(socket), ambient_authority())
     }
 }
 

--- a/cap-async-std/src/net/udp_socket.rs
+++ b/cap-async-std/src/net/udp_socket.rs
@@ -6,7 +6,7 @@ use cap_primitives::{ambient_authority, AmbientAuthority};
 #[cfg(not(windows))]
 use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 #[cfg(windows)]
-use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
+use io_lifetimes::{AsSocket, BorrowedSocket, FromSocket, IntoSocket, OwnedSocket};
 use std::fmt;
 use unsafe_io::OwnsRaw;
 #[cfg(windows)]
@@ -280,8 +280,8 @@ impl AsRawSocket for UdpSocket {
 #[cfg(windows)]
 impl<'s> AsSocket<'s> for &'s UdpSocket {
     #[inline]
-    fn as_raw_socket(self) -> BorrowedSocket<'s> {
-        self.std.as_raw_socket()
+    fn as_socket(self) -> BorrowedSocket<'s> {
+        self.std.as_socket()
     }
 }
 

--- a/cap-async-std/src/net/udp_socket.rs
+++ b/cap-async-std/src/net/udp_socket.rs
@@ -245,6 +245,17 @@ impl FromRawSocket for UdpSocket {
     }
 }
 
+#[cfg(windows)]
+impl FromSocket for UdpSocket {
+    #[inline]
+    fn from_socket(socket: OwnedSocket) -> Self {
+        Self::from_std(
+            net::UdpSocket::from_socket(socket),
+            ambient_authority(),
+        )
+    }
+}
+
 #[cfg(not(windows))]
 impl AsRawFd for UdpSocket {
     #[inline]
@@ -265,6 +276,14 @@ impl<'f> AsFd<'f> for &'f UdpSocket {
 impl AsRawSocket for UdpSocket {
     #[inline]
     fn as_raw_socket(&self) -> RawSocket {
+        self.std.as_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl<'s> AsSocket<'s> for &'s UdpSocket {
+    #[inline]
+    fn as_raw_socket(self) -> BorrowedSocket<'s> {
         self.std.as_raw_socket()
     }
 }
@@ -298,6 +317,14 @@ impl IntoRawSocket for UdpSocket {
     #[inline]
     fn into_raw_socket(self) -> RawSocket {
         self.std.into_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl IntoSocket for UdpSocket {
+    #[inline]
+    fn into_socket(self) -> OwnedSocket {
+        self.std.into_socket()
     }
 }
 

--- a/cap-async-std/src/os/unix/net/unix_datagram.rs
+++ b/cap-async-std/src/os/unix/net/unix_datagram.rs
@@ -7,6 +7,7 @@ use async_std::{
     },
 };
 use cap_primitives::{ambient_authority, AmbientAuthority};
+use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 use std::fmt;
 use unsafe_io::OwnsRaw;
 
@@ -156,6 +157,13 @@ impl FromRawFd for UnixDatagram {
     }
 }
 
+impl FromFd for UnixDatagram {
+    #[inline]
+    fn from_fd(fd: OwnedFd) -> Self {
+        Self::from_std(unix::net::UnixDatagram::from_fd(fd), ambient_authority())
+    }
+}
+
 impl AsRawFd for UnixDatagram {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
@@ -163,10 +171,24 @@ impl AsRawFd for UnixDatagram {
     }
 }
 
+impl<'f> AsFd<'f> for &'f UnixDatagram {
+    #[inline]
+    fn as_fd(self) -> BorrowedFd<'f> {
+        self.std.as_fd()
+    }
+}
+
 impl IntoRawFd for UnixDatagram {
     #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.std.into_raw_fd()
+    }
+}
+
+impl IntoFd for UnixDatagram {
+    #[inline]
+    fn into_fd(self) -> OwnedFd {
+        self.std.into_fd()
     }
 }
 

--- a/cap-async-std/src/os/unix/net/unix_listener.rs
+++ b/cap-async-std/src/os/unix/net/unix_listener.rs
@@ -7,6 +7,7 @@ use async_std::{
     },
 };
 use cap_primitives::{ambient_authority, AmbientAuthority};
+use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 use std::fmt;
 use unsafe_io::OwnsRaw;
 
@@ -87,6 +88,13 @@ impl FromRawFd for UnixListener {
     }
 }
 
+impl FromFd for UnixListener {
+    #[inline]
+    fn from_fd(fd: OwnedFd) -> Self {
+        Self::from_std(unix::net::UnixListener::from_fd(fd), ambient_authority())
+    }
+}
+
 impl AsRawFd for UnixListener {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
@@ -94,10 +102,24 @@ impl AsRawFd for UnixListener {
     }
 }
 
+impl<'f> AsFd<'f> for &'f UnixListener {
+    #[inline]
+    fn as_fd(self) -> BorrowedFd<'f> {
+        self.std.as_fd()
+    }
+}
+
 impl IntoRawFd for UnixListener {
     #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.std.into_raw_fd()
+    }
+}
+
+impl IntoFd for UnixListener {
+    #[inline]
+    fn into_fd(self) -> OwnedFd {
+        self.std.into_fd()
     }
 }
 

--- a/cap-async-std/src/os/unix/net/unix_stream.rs
+++ b/cap-async-std/src/os/unix/net/unix_stream.rs
@@ -8,6 +8,7 @@ use async_std::{
     task::{Context, Poll},
 };
 use cap_primitives::{ambient_authority, AmbientAuthority};
+use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 use std::{fmt, pin::Pin};
 use unsafe_io::OwnsRaw;
 
@@ -107,6 +108,13 @@ impl FromRawFd for UnixStream {
     }
 }
 
+impl FromFd for UnixStream {
+    #[inline]
+    fn from_fd(fd: OwnedFd) -> Self {
+        Self::from_std(unix::net::UnixStream::from_fd(fd), ambient_authority())
+    }
+}
+
 impl AsRawFd for UnixStream {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
@@ -114,10 +122,24 @@ impl AsRawFd for UnixStream {
     }
 }
 
+impl<'f> AsFd<'f> for &'f UnixStream {
+    #[inline]
+    fn as_fd(self) -> BorrowedFd<'f> {
+        self.std.as_fd()
+    }
+}
+
 impl IntoRawFd for UnixStream {
     #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.std.into_raw_fd()
+    }
+}
+
+impl IntoFd for UnixStream {
+    #[inline]
+    fn into_fd(self) -> OwnedFd {
+        self.std.into_fd()
     }
 }
 

--- a/cap-directories/Cargo.toml
+++ b/cap-directories/Cargo.toml
@@ -17,7 +17,7 @@ cap-std = { path = "../cap-std", version = "^0.13.11-alpha.0"}
 directories-next = "2.0.0"
 
 [target.'cfg(not(windows))'.dependencies]
-libc = "0.2.81"
+posish = "0.8.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"

--- a/cap-directories/src/lib.rs
+++ b/cap-directories/src/lib.rs
@@ -20,7 +20,7 @@ pub use user_dirs::UserDirs;
 
 #[cfg(not(windows))]
 pub(crate) fn not_found() -> io::Error {
-    io::Error::from_raw_os_error(libc::ENOENT)
+    posish::io::Errno::NOENT.io_error()
 }
 
 #[cfg(windows)]

--- a/cap-fs-ext/Cargo.toml
+++ b/cap-fs-ext/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/bytecodealliance/cap-std"
 edition = "2018"
 
 [build-dependencies]
-rustc_version = "0.3.0"
+rustc_version = "0.4.0"
 
 [dependencies]
 arf-strings = { version = "0.3.0", optional = true }

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/bytecodealliance/cap-std"
 edition = "2018"
 
 [build-dependencies]
-rustc_version = "0.3.0"
+rustc_version = "0.4.0"
 
 [dependencies]
 ambient-authority = "0.0.0"
@@ -37,7 +37,7 @@ errno = "0.2.7"
 errno = "0.2.7"
 
 [target.'cfg(windows)'.dependencies]
-winx = "0.25.0"
+winx = "0.26.0"
 winapi = "0.3.9"
 winapi-util = "0.1.5"
 

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -24,8 +24,8 @@ fs-set-times = "0.3.1"
 unsafe-io = "0.6.0"
 
 [target.'cfg(not(windows))'.dependencies]
-posish = "0.6.0"
-libc = "0.2.81"
+posish = "0.8.0"
+io-lifetimes = "0.1.1"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 once_cell = "1.4.1"

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -22,10 +22,10 @@ ipnet = "2.3.0"
 maybe-owned = "0.3.4"
 fs-set-times = "0.3.1"
 unsafe-io = "0.6.0"
+io-lifetimes = "0.1.1"
 
 [target.'cfg(not(windows))'.dependencies]
 posish = "0.8.0"
-io-lifetimes = "0.1.1"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 once_cell = "1.4.1"

--- a/cap-primitives/src/fs/manually/open.rs
+++ b/cap-primitives/src/fs/manually/open.rs
@@ -6,6 +6,8 @@ use crate::fs::{
     dir_options, errors, open_unchecked, path_has_trailing_dot, path_has_trailing_slash,
     stat_unchecked, FollowSymlinks, MaybeOwnedFile, Metadata, OpenOptions, OpenUncheckedError,
 };
+#[cfg(any(target_os = "android", target_os = "linux"))]
+use posish::fs::OFlags;
 use std::{
     borrow::Cow,
     ffi::OsStr,
@@ -529,7 +531,7 @@ pub(crate) fn stat(start: &fs::File, path: &Path, follow: FollowSymlinks) -> io:
 /// potentially being a symlink we need to follow, due to use of `O_PATH`.
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn should_emulate_o_path(use_options: &OpenOptions) -> bool {
-    (use_options.ext.custom_flags & libc::O_PATH) == libc::O_PATH
+    (use_options.ext.custom_flags & OFlags::PATH.bits()) == OFlags::PATH.bits()
         && use_options.follow == FollowSymlinks::Yes
 }
 

--- a/cap-primitives/src/fs/manually/open.rs
+++ b/cap-primitives/src/fs/manually/open.rs
@@ -531,7 +531,7 @@ pub(crate) fn stat(start: &fs::File, path: &Path, follow: FollowSymlinks) -> io:
 /// potentially being a symlink we need to follow, due to use of `O_PATH`.
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn should_emulate_o_path(use_options: &OpenOptions) -> bool {
-    (use_options.ext.custom_flags & OFlags::PATH.bits()) == OFlags::PATH.bits()
+    (use_options.ext.custom_flags & (OFlags::PATH.bits() as i32)) == (OFlags::PATH.bits() as i32)
         && use_options.follow == FollowSymlinks::Yes
 }
 

--- a/cap-primitives/src/fs/permissions.rs
+++ b/cap-primitives/src/fs/permissions.rs
@@ -1,5 +1,6 @@
 #[cfg(any(unix, target_os = "vxworks"))]
 use crate::fs::PermissionsExt;
+use posish::fs::RawMode;
 use std::{fs, io};
 
 /// Representation of the various permissions on a file.
@@ -92,7 +93,7 @@ impl std::os::unix::fs::PermissionsExt for Permissions {
     #[inline]
     fn from_mode(mode: u32) -> Self {
         Self {
-            readonly: PermissionsExt::readonly(mode as libc::mode_t),
+            readonly: PermissionsExt::readonly(mode as RawMode),
             ext: PermissionsExt::from_mode(mode),
         }
     }

--- a/cap-primitives/src/fs/permissions.rs
+++ b/cap-primitives/src/fs/permissions.rs
@@ -1,5 +1,6 @@
 #[cfg(any(unix, target_os = "vxworks"))]
 use crate::fs::PermissionsExt;
+#[cfg(unix)]
 use posish::fs::RawMode;
 use std::{fs, io};
 

--- a/cap-primitives/src/lib.rs
+++ b/cap-primitives/src/lib.rs
@@ -1,7 +1,7 @@
 //! Capability-based primitives.
 
 #![deny(missing_docs)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(all(windows, windows_by_handle), feature(windows_by_handle))]
 #![cfg_attr(all(windows, windows_file_type_ext), feature(windows_file_type_ext))]

--- a/cap-primitives/src/posish/darwin/fs/file_path.rs
+++ b/cap-primitives/src/posish/darwin/fs/file_path.rs
@@ -4,20 +4,11 @@
 
 use crate::posish::fs::file_path_by_ttyname_or_seaching;
 use posish::fs::getpath;
-use std::{fs, os::unix::ffi::OsStringExt, path::PathBuf};
+use std::{fs, path::PathBuf};
 
 pub(crate) fn file_path(file: &fs::File) -> Option<PathBuf> {
-    // The use of PATH_MAX is generally not encouraged, but it
-    // is inevitable in this case because macOS defines `fcntl` with
-    // `F_GETPATH` in terms of `MAXPATHLEN`, and there are no
-    // alternatives. If a better method is invented, it should be used
-    // instead.
-    let mut buf = vec![0; libc::PATH_MAX as usize];
-    if let Ok(()) = getpath(file, &mut buf) {
-        let l = buf.iter().position(|&c| c == 0).unwrap();
-        buf.truncate(l as usize);
-        buf.shrink_to_fit();
-        return Some(PathBuf::from(std::ffi::OsString::from_vec(buf)));
+    if let Ok(path) = getpath(file) {
+        return Some(path);
     }
 
     file_path_by_ttyname_or_seaching(file)

--- a/cap-primitives/src/posish/fs/copy_impl.rs
+++ b/cap-primitives/src/posish/fs/copy_impl.rs
@@ -3,13 +3,16 @@
 // 108e90ca78f052c0c1c49c42a22c85620be19712.
 
 use crate::fs::{open, OpenOptions};
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-use posish::fs::{
-    copyfile_state_alloc, copyfile_state_free, copyfile_state_get_copied, copyfile_state_t,
-    fclonefileat, fcopyfile, CloneFlags, CopyfileFlags,
-};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use posish::{fs::copy_file_range, io::Errno};
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+use posish::{
+    fs::{
+        copyfile_state_alloc, copyfile_state_free, copyfile_state_get_copied, copyfile_state_t,
+        fclonefileat, fcopyfile, CloneFlags, CopyfileFlags,
+    },
+    io::Errno,
+};
 use std::{fs, io, path::Path};
 
 fn open_from(start: &fs::File, path: &Path) -> io::Result<(fs::File, fs::Metadata)> {

--- a/cap-primitives/src/posish/fs/create_dir_unchecked.rs
+++ b/cap-primitives/src/posish/fs/create_dir_unchecked.rs
@@ -1,5 +1,5 @@
 use crate::fs::DirOptions;
-use posish::fs::{mkdirat, Mode};
+use posish::fs::{mkdirat, Mode, RawMode};
 use std::{fs, io, path::Path};
 
 /// *Unsandboxed* function similar to `create_dir`, but which does not perform
@@ -12,6 +12,6 @@ pub(crate) fn create_dir_unchecked(
     mkdirat(
         start,
         path,
-        Mode::from_bits(options.ext.mode as libc::mode_t).unwrap(),
+        Mode::from_bits(options.ext.mode as RawMode).unwrap(),
     )
 }

--- a/cap-primitives/src/posish/fs/dir_utils.rs
+++ b/cap-primitives/src/posish/fs/dir_utils.rs
@@ -103,7 +103,7 @@ pub(crate) fn open_ambient_dir_impl(path: &Path, _: AmbientAuthority) -> io::Res
 
     fs::OpenOptions::new()
         .read(true)
-        .custom_flags(flags.bits())
+        .custom_flags(flags.bits() as i32)
         .open(&path)
 }
 

--- a/cap-primitives/src/posish/fs/errors.rs
+++ b/cap-primitives/src/posish/fs/errors.rs
@@ -1,26 +1,27 @@
+use posish::io::Errno;
 use std::io;
 
 #[cold]
 pub(crate) fn invalid_flags() -> io::Error {
-    io::Error::from_raw_os_error(libc::EINVAL)
+    Errno::INVAL.io_error()
 }
 
 #[cold]
 pub(crate) fn no_such_file_or_directory() -> io::Error {
-    io::Error::from_raw_os_error(libc::ENOENT)
+    Errno::NOENT.io_error()
 }
 
 #[cold]
 pub(crate) fn is_directory() -> io::Error {
-    io::Error::from_raw_os_error(libc::EISDIR)
+    Errno::ISDIR.io_error()
 }
 
 #[cold]
 pub(crate) fn is_not_directory() -> io::Error {
-    io::Error::from_raw_os_error(libc::ENOTDIR)
+    Errno::NOTDIR.io_error()
 }
 
 #[cold]
 pub(crate) fn too_many_symlinks() -> io::Error {
-    io::Error::from_raw_os_error(libc::ELOOP)
+    Errno::LOOP.io_error()
 }

--- a/cap-primitives/src/posish/fs/file_type_ext.rs
+++ b/cap-primitives/src/posish/fs/file_type_ext.rs
@@ -1,4 +1,5 @@
 use crate::fs::FileType;
+use posish::fs::RawMode;
 use std::{fs, io};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
@@ -53,17 +54,17 @@ impl FileTypeExt {
     }
 
     /// Constructs a new instance of `FileType` from the given
-    /// [`libc::mode_t`].
+    /// [`RawMode`].
     #[inline]
-    pub(crate) const fn from_libc(mode: libc::mode_t) -> FileType {
-        match mode & libc::S_IFMT {
-            libc::S_IFREG => FileType::file(),
-            libc::S_IFDIR => FileType::dir(),
-            libc::S_IFLNK => FileType::ext(Self::symlink()),
-            libc::S_IFIFO => FileType::ext(Self::fifo()),
-            libc::S_IFCHR => FileType::ext(Self::char_device()),
-            libc::S_IFBLK => FileType::ext(Self::block_device()),
-            libc::S_IFSOCK => FileType::ext(Self::socket()),
+    pub(crate) const fn from_raw_mode(mode: RawMode) -> FileType {
+        match posish::fs::FileType::from_raw_mode(mode) {
+            posish::fs::FileType::RegularFile => FileType::file(),
+            posish::fs::FileType::Directory => FileType::dir(),
+            posish::fs::FileType::Symlink => FileType::ext(Self::symlink()),
+            posish::fs::FileType::Fifo => FileType::ext(Self::fifo()),
+            posish::fs::FileType::CharacterDevice => FileType::ext(Self::char_device()),
+            posish::fs::FileType::BlockDevice => FileType::ext(Self::block_device()),
+            posish::fs::FileType::Socket => FileType::ext(Self::socket()),
             _ => FileType::unknown(),
         }
     }

--- a/cap-primitives/src/posish/fs/oflags.rs
+++ b/cap-primitives/src/posish/fs/oflags.rs
@@ -20,8 +20,8 @@ pub(in super::super) fn compute_oflags(options: &OpenOptions) -> io::Result<OFla
         }
     }
     // Use `RWMODE` here instead of `ACCMODE` so that we preserve the `O_PATH` flag.
-    oflags |=
-        OFlags::from_bits(options.ext.custom_flags).expect("unrecognized OFlags") & !OFlags::RWMODE;
+    oflags |= OFlags::from_bits(options.ext.custom_flags as _).expect("unrecognized OFlags")
+        & !OFlags::RWMODE;
     Ok(oflags)
 }
 

--- a/cap-primitives/src/posish/fs/oflags.rs
+++ b/cap-primitives/src/posish/fs/oflags.rs
@@ -1,5 +1,5 @@
 use crate::fs::{target_o_path, FollowSymlinks, OpenOptions};
-use posish::fs::OFlags;
+use posish::{fs::OFlags, io::Errno};
 use std::io;
 
 pub(in super::super) fn compute_oflags(options: &OpenOptions) -> io::Result<OFlags> {
@@ -36,7 +36,7 @@ pub(crate) fn get_access_mode(options: &OpenOptions) -> io::Result<OFlags> {
         (true, true, false) => Ok(OFlags::RDWR),
         (false, _, true) => Ok(OFlags::WRONLY | OFlags::APPEND),
         (true, _, true) => Ok(OFlags::RDWR | OFlags::APPEND),
-        (false, false, false) => Err(io::Error::from_raw_os_error(libc::EINVAL)),
+        (false, false, false) => Err(Errno::INVAL.io_error()),
     }
 }
 
@@ -45,12 +45,12 @@ pub(crate) fn get_creation_mode(options: &OpenOptions) -> io::Result<OFlags> {
         (true, false) => {}
         (false, false) => {
             if options.truncate || options.create || options.create_new {
-                return Err(io::Error::from_raw_os_error(libc::EINVAL));
+                return Err(Errno::INVAL.io_error());
             }
         }
         (_, true) => {
             if options.truncate && !options.create_new {
-                return Err(io::Error::from_raw_os_error(libc::EINVAL));
+                return Err(Errno::INVAL.io_error());
             }
         }
     }

--- a/cap-primitives/src/posish/fs/open_unchecked.rs
+++ b/cap-primitives/src/posish/fs/open_unchecked.rs
@@ -1,11 +1,11 @@
 use super::compute_oflags;
-#[cfg(any(target_os = "android", target_os = "linux"))]
-use crate::fs::ensure_cloexec;
 use crate::fs::{stat_unchecked, OpenOptions, OpenUncheckedError};
-use io_lifetimes::{AsFd, FromFd};
+use io_lifetimes::FromFd;
 use posish::fs::{openat, Mode};
 use posish::io::Errno;
 use std::{fs, path::Path};
+#[cfg(any(target_os = "android", target_os = "linux"))]
+use {crate::fs::ensure_cloexec, io_lifetimes::AsFd};
 
 /// *Unsandboxed* function similar to `open`, but which does not perform sandboxing.
 pub(crate) fn open_unchecked(

--- a/cap-primitives/src/posish/fs/permissions_ext.rs
+++ b/cap-primitives/src/posish/fs/permissions_ext.rs
@@ -1,9 +1,10 @@
 use crate::fs::Permissions;
+use posish::fs::RawMode;
 use std::fs;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) struct PermissionsExt {
-    mode: libc::mode_t,
+    mode: RawMode,
 }
 
 impl PermissionsExt {
@@ -13,14 +14,14 @@ impl PermissionsExt {
     pub(crate) fn from_std(std: fs::Permissions) -> Self {
         use std::os::unix::fs::PermissionsExt;
         Self {
-            mode: std.mode() as libc::mode_t & 0o7777,
+            mode: std.mode() as RawMode & 0o7777,
         }
     }
 
     /// Constructs a new instance of `Permissions` from the given
-    /// `libc::mode_t`.
+    /// `RawMode`.
     #[inline]
-    pub(crate) const fn from_libc(mode: libc::mode_t) -> Permissions {
+    pub(crate) const fn from_raw_mode(mode: RawMode) -> Permissions {
         Permissions {
             readonly: Self::readonly(mode),
             ext: Self {
@@ -29,13 +30,13 @@ impl PermissionsExt {
         }
     }
 
-    /// Test whether the given `libc::mode_t` lacks write permissions.
+    /// Test whether the given `RawMode` lacks write permissions.
     #[inline]
-    pub(crate) const fn readonly(mode: libc::mode_t) -> bool {
+    pub(crate) const fn readonly(mode: RawMode) -> bool {
         mode & 0o222 == 0
     }
 
-    /// Test whether the given `libc::mode_t` lacks write permissions.
+    /// Test whether the given `RawMode` lacks write permissions.
     #[inline]
     pub(crate) fn set_readonly(&mut self, readonly: bool) {
         if readonly {
@@ -54,12 +55,12 @@ impl std::os::unix::fs::PermissionsExt for PermissionsExt {
     }
 
     fn set_mode(&mut self, mode: u32) {
-        self.mode = mode as libc::mode_t & 0o7777;
+        self.mode = mode as RawMode & 0o7777;
     }
 
     fn from_mode(mode: u32) -> Self {
         Self {
-            mode: mode as libc::mode_t & 0o7777,
+            mode: mode as RawMode & 0o7777,
         }
     }
 }

--- a/cap-primitives/src/posish/fs/reopen_impl.rs
+++ b/cap-primitives/src/posish/fs/reopen_impl.rs
@@ -2,13 +2,18 @@ use crate::{
     fs::{open_unchecked, OpenOptions},
     posish::fs::file_path,
 };
+use io_lifetimes::AsFilelike;
 use posish::fs::cwd;
 use std::{fs, io};
 
 /// Implementation of `reopen`.
 pub(crate) fn reopen_impl(file: &fs::File, options: &OpenOptions) -> io::Result<fs::File> {
     if let Some(path) = file_path(file) {
-        Ok(open_unchecked(&cwd(), &path, options)?)
+        Ok(open_unchecked(
+            &cwd().as_filelike_view::<fs::File>(),
+            &path,
+            options,
+        )?)
     } else {
         Err(io::Error::new(io::ErrorKind::Other, "Couldn't reopen file"))
     }

--- a/cap-primitives/src/posish/fs/set_permissions_impl.rs
+++ b/cap-primitives/src/posish/fs/set_permissions_impl.rs
@@ -23,7 +23,7 @@ pub(crate) fn set_permissions_impl(
     // access, so first try read.
     match open(start, path, OpenOptions::new().read(true)) {
         Ok(file) => return set_file_permissions(&file, std_perm),
-        Err(err) => match Errno::from_io_error(err) {
+        Err(err) => match Errno::from_io_error(&err) {
             Some(Errno::ACCES) => (),
             _ => return Err(err),
         },

--- a/cap-primitives/src/posish/fs/set_permissions_impl.rs
+++ b/cap-primitives/src/posish/fs/set_permissions_impl.rs
@@ -1,5 +1,8 @@
 use crate::fs::{errors, open, OpenOptions, Permissions};
-use posish::fs::{fchmod, Mode};
+use posish::{
+    fs::{fchmod, Mode},
+    io::Errno,
+};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::{convert::TryInto, fs, io, path::Path};
@@ -20,8 +23,8 @@ pub(crate) fn set_permissions_impl(
     // access, so first try read.
     match open(start, path, OpenOptions::new().read(true)) {
         Ok(file) => return set_file_permissions(&file, std_perm),
-        Err(err) => match err.raw_os_error() {
-            Some(libc::EACCES) => (),
+        Err(err) => match Errno::from_io_error(err) {
+            Some(Errno::ACCES) => (),
             _ => return Err(err),
         },
     }
@@ -29,14 +32,14 @@ pub(crate) fn set_permissions_impl(
     // Next try write.
     match open(start, path, OpenOptions::new().write(true)) {
         Ok(file) => return set_file_permissions(&file, std_perm),
-        Err(err) => match err.raw_os_error() {
-            Some(libc::EACCES) | Some(libc::EISDIR) => (),
+        Err(err) => match Errno::from_io_error(&err) {
+            Some(Errno::ACCES) | Some(Errno::ISDIR) => (),
             _ => return Err(err),
         },
     }
 
     // If neither of those worked, we're out of luck.
-    Err(io::Error::from_raw_os_error(libc::ENOTSUP))
+    Err(Errno::NOTSUP.io_error())
 }
 
 pub(crate) fn set_file_permissions(file: &fs::File, perm: fs::Permissions) -> io::Result<()> {

--- a/cap-primitives/src/posish/fs/set_times_impl.rs
+++ b/cap-primitives/src/posish/fs/set_times_impl.rs
@@ -21,7 +21,7 @@ pub(crate) fn set_times_impl(
                 mtime.map(SystemTimeSpec::into_std),
             )
         }
-        Err(err) => match Errno::from_io_error(err) {
+        Err(err) => match Errno::from_io_error(&err) {
             Some(Errno::ACCES) | Some(Errno::ISDIR) => (),
             _ => return Err(err),
         },

--- a/cap-primitives/src/posish/fs/set_times_impl.rs
+++ b/cap-primitives/src/posish/fs/set_times_impl.rs
@@ -3,6 +3,7 @@
 
 use crate::fs::{open, OpenOptions, SystemTimeSpec};
 use fs_set_times::SetTimes;
+use posish::io::Errno;
 use std::{fs, io, path::Path};
 
 pub(crate) fn set_times_impl(
@@ -20,8 +21,8 @@ pub(crate) fn set_times_impl(
                 mtime.map(SystemTimeSpec::into_std),
             )
         }
-        Err(err) => match err.raw_os_error() {
-            Some(libc::EACCES) | Some(libc::EISDIR) => (),
+        Err(err) => match Errno::from_io_error(err) {
+            Some(Errno::ACCES) | Some(Errno::ISDIR) => (),
             _ => return Err(err),
         },
     }
@@ -34,8 +35,8 @@ pub(crate) fn set_times_impl(
                 mtime.map(SystemTimeSpec::into_std),
             )
         }
-        Err(err) => match err.raw_os_error() {
-            Some(libc::EACCES) => (),
+        Err(err) => match Errno::from_io_error(&err) {
+            Some(Errno::ACCES) => (),
             _ => return Err(err),
         },
     }
@@ -49,5 +50,5 @@ pub(crate) fn set_times_impl(
     //    symlink instead of the file we're trying to get to.
     //
     // So neither does what we need.
-    Err(io::Error::from_raw_os_error(libc::ENOTSUP))
+    Err(Errno::NOTSUP.io_error())
 }

--- a/cap-primitives/src/posish/fs/stat_unchecked.rs
+++ b/cap-primitives/src/posish/fs/stat_unchecked.rs
@@ -13,5 +13,5 @@ pub(crate) fn stat_unchecked(
         FollowSymlinks::No => AtFlags::SYMLINK_NOFOLLOW,
     };
 
-    statat(start, path, atflags).map(MetadataExt::from_libc)
+    statat(start, path, atflags).map(MetadataExt::from_posish)
 }

--- a/cap-primitives/src/posish/linux/fs/canonicalize_impl.rs
+++ b/cap-primitives/src/posish/linux/fs/canonicalize_impl.rs
@@ -21,7 +21,7 @@ pub(crate) fn canonicalize_impl(start: &fs::File, path: &Path) -> io::Result<Pat
         OpenOptions::new()
             .read(true)
             .follow(FollowSymlinks::Yes)
-            .custom_flags(OFlags::PATH.bits()),
+            .custom_flags(OFlags::PATH.bits() as i32),
     );
 
     // If that worked, call `readlink`.

--- a/cap-primitives/src/posish/linux/fs/open_entry_impl.rs
+++ b/cap-primitives/src/posish/linux/fs/open_entry_impl.rs
@@ -1,4 +1,5 @@
 use crate::fs::{manually, open_beneath, OpenOptions};
+use posish::io::Errno;
 use std::{ffi::OsStr, fs, io};
 
 pub(crate) fn open_entry_impl(
@@ -10,8 +11,8 @@ pub(crate) fn open_entry_impl(
 
     match result {
         Ok(file) => Ok(file),
-        Err(err) => match err.raw_os_error() {
-            Some(libc::ENOSYS) => manually::open_entry(start, path, options),
+        Err(err) => match Errno::from_io_error(&err) {
+            Some(Errno::NOSYS) => manually::open_entry(start, path, options),
             _ => Err(err),
         },
     }

--- a/cap-primitives/src/posish/linux/fs/procfs.rs
+++ b/cap-primitives/src/posish/linux/fs/procfs.rs
@@ -176,7 +176,7 @@ fn proc_self_fd() -> io::Result<&'static fs::File> {
         // Linux ignores `O_RDONLY` with `O_PATH`.
         let proc = fs::OpenOptions::new()
             .read(true)
-            .custom_flags((OFlags::PATH | OFlags::DIRECTORY | OFlags::NOFOLLOW).bits())
+            .custom_flags((OFlags::PATH | OFlags::DIRECTORY | OFlags::NOFOLLOW).bits() as i32)
             .open("/proc")?;
         let proc_metadata = check_proc_dir(Subdir::Proc, &proc, None, 0, 0)?;
 
@@ -185,7 +185,7 @@ fn proc_self_fd() -> io::Result<&'static fs::File> {
         let options = options
             .read(true)
             .follow(FollowSymlinks::No)
-            .custom_flags((OFlags::PATH | OFlags::DIRECTORY).bits());
+            .custom_flags((OFlags::PATH | OFlags::DIRECTORY).bits() as i32);
 
         // Open "/proc/self". Use our pid to compute the name rather than literally
         // using "self", as "self" is a symlink.
@@ -223,7 +223,7 @@ pub(crate) fn set_permissions_through_proc_self_fd(
         path,
         OpenOptions::new()
             .read(true)
-            .custom_flags(OFlags::PATH.bits()),
+            .custom_flags(OFlags::PATH.bits() as i32),
     )?;
 
     let dirfd = proc_self_fd()?;
@@ -242,7 +242,7 @@ pub(crate) fn set_times_through_proc_self_fd(
         path,
         OpenOptions::new()
             .read(true)
-            .custom_flags(OFlags::PATH.bits()),
+            .custom_flags(OFlags::PATH.bits() as i32),
     )?;
 
     // Don't pass `AT_SYMLINK_NOFOLLOW`, because we do actually want to follow

--- a/cap-primitives/src/posish/linux/fs/set_permissions_impl.rs
+++ b/cap-primitives/src/posish/linux/fs/set_permissions_impl.rs
@@ -31,7 +31,7 @@ pub(crate) fn set_permissions_impl(
             path,
             OpenOptions::new()
                 .read(true)
-                .custom_flags(OFlags::PATH.bits()),
+                .custom_flags(OFlags::PATH.bits() as i32),
         );
 
         // If `O_PATH` worked, try to use `fchmod` on it.

--- a/cap-primitives/src/posish/linux/fs/set_permissions_impl.rs
+++ b/cap-primitives/src/posish/linux/fs/set_permissions_impl.rs
@@ -1,6 +1,7 @@
 use super::procfs::set_permissions_through_proc_self_fd;
 use crate::fs::{errors, open, OpenOptions, Permissions};
-use posish::fs::{fchmod, Mode};
+use posish::fs::{fchmod, Mode, OFlags};
+use posish::io::Errno;
 use std::{
     fs, io,
     os::unix::fs::{OpenOptionsExt, PermissionsExt},
@@ -28,17 +29,19 @@ pub(crate) fn set_permissions_impl(
         let opath_result = open(
             start,
             path,
-            OpenOptions::new().read(true).custom_flags(libc::O_PATH),
+            OpenOptions::new()
+                .read(true)
+                .custom_flags(OFlags::PATH.bits()),
         );
 
         // If `O_PATH` worked, try to use `fchmod` on it.
         if let Ok(file) = opath_result {
             match set_file_permissions(&file, std_perm.clone()) {
                 Ok(()) => return Ok(()),
-                Err(err) => match err.raw_os_error() {
+                Err(err) => match Errno::from_io_error(&err) {
                     // If it fails with `EBADF`, `fchmod` didn't like `O_PATH`,
                     // so proceed to the fallback strategies below.
-                    Some(libc::EBADF) => FCHMOD_PATH_BADF.store(true, Relaxed),
+                    Some(Errno::BADF) => FCHMOD_PATH_BADF.store(true, Relaxed),
                     _ => return Err(err),
                 },
             }
@@ -49,8 +52,8 @@ pub(crate) fn set_permissions_impl(
     // access, so first try read.
     match open(start, path, OpenOptions::new().read(true)) {
         Ok(file) => return set_file_permissions(&file, std_perm),
-        Err(err) => match err.raw_os_error() {
-            Some(libc::EACCES) => (),
+        Err(err) => match Errno::from_io_error(&err) {
+            Some(Errno::ACCES) => (),
             _ => return Err(err),
         },
     }
@@ -58,8 +61,8 @@ pub(crate) fn set_permissions_impl(
     // Next try write.
     match open(start, path, OpenOptions::new().write(true)) {
         Ok(file) => return set_file_permissions(&file, std_perm),
-        Err(err) => match err.raw_os_error() {
-            Some(libc::EACCES) | Some(libc::EISDIR) => (),
+        Err(err) => match Errno::from_io_error(&err) {
+            Some(Errno::ACCES) | Some(Errno::ISDIR) => (),
             _ => return Err(err),
         },
     }
@@ -68,9 +71,6 @@ pub(crate) fn set_permissions_impl(
     set_permissions_through_proc_self_fd(start, path, std_perm)
 }
 
-/// Like `file.set_permissions(perm)`, but without depending on libc's
-/// `fchmod`, since some libc implementations such as musl emulate `O_PATH`
-/// support by emulating it with /proc.
 fn set_file_permissions(file: &fs::File, perm: fs::Permissions) -> io::Result<()> {
     let mode = Mode::from_bits(perm.mode()).ok_or_else(errors::invalid_flags)?;
     fchmod(file, mode)

--- a/cap-primitives/src/posish/linux/fs/set_times_impl.rs
+++ b/cap-primitives/src/posish/linux/fs/set_times_impl.rs
@@ -4,6 +4,7 @@
 use super::procfs::set_times_through_proc_self_fd;
 use crate::fs::{open, OpenOptions, SystemTimeSpec};
 use fs_set_times::SetTimes;
+use posish::io::Errno;
 use std::{fs, io, path::Path};
 
 pub(crate) fn set_times_impl(
@@ -21,8 +22,8 @@ pub(crate) fn set_times_impl(
                 mtime.map(SystemTimeSpec::into_std),
             )
         }
-        Err(err) => match err.raw_os_error() {
-            Some(libc::EACCES) | Some(libc::EISDIR) => (),
+        Err(err) => match Errno::from_io_error(&err) {
+            Some(Errno::ACCES) | Some(Errno::ISDIR) => (),
             _ => return Err(err),
         },
     }
@@ -35,8 +36,8 @@ pub(crate) fn set_times_impl(
                 mtime.map(SystemTimeSpec::into_std),
             )
         }
-        Err(err) => match err.raw_os_error() {
-            Some(libc::EACCES) => (),
+        Err(err) => match Errno::from_io_error(&err) {
+            Some(Errno::ACCES) => (),
             _ => return Err(err),
         },
     }

--- a/cap-primitives/src/posish/linux/fs/stat_impl.rs
+++ b/cap-primitives/src/posish/linux/fs/stat_impl.rs
@@ -26,7 +26,7 @@ pub(crate) fn stat_impl(
         OpenOptions::new()
             .read(true)
             .follow(follow)
-            .custom_flags(OFlags::PATH.bits()),
+            .custom_flags(OFlags::PATH.bits() as i32),
     );
 
     // If that worked, call `fstat`.

--- a/cap-primitives/src/windows/fs/is_file_read_write_impl.rs
+++ b/cap-primitives/src/windows/fs/is_file_read_write_impl.rs
@@ -1,7 +1,8 @@
-use std::{fs, io, os::windows::io::AsRawHandle};
+use io_lifetimes::AsHandle;
+use std::{fs, io};
 
 pub(crate) fn is_file_read_write_impl(file: &fs::File) -> io::Result<(bool, bool)> {
-    let handle = file.as_raw_handle();
+    let handle = file.as_handle();
     let access_mode = winx::file::query_access_information(handle)?;
     let read = access_mode.contains(winx::file::AccessMode::FILE_READ_DATA);
     let write = access_mode.contains(winx::file::AccessMode::FILE_WRITE_DATA)

--- a/cap-primitives/src/windows/fs/metadata_ext.rs
+++ b/cap-primitives/src/windows/fs/metadata_ext.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::useless_conversion)]
 
-use std::{convert::TryInto, fs, io};
+#[cfg(not(windows_by_handle))]
+use std::convert::TryInto;
+use std::{fs, io};
 
 #[derive(Debug, Clone)]
 pub(crate) struct MetadataExt {

--- a/cap-primitives/src/windows/fs/reopen_impl.rs
+++ b/cap-primitives/src/windows/fs/reopen_impl.rs
@@ -85,7 +85,7 @@ pub(crate) fn reopen_impl(file: &fs::File, options: &OpenOptions) -> io::Result<
         return Err(io::Error::new(io::ErrorKind::Other, "Can't reopen file"));
     }
 
-    winx::file::reopen_file(file.as_raw_handle(), new_access_mode, flags)
+    winx::file::reopen_file(file.as_handle(), new_access_mode, flags)
 }
 
 fn get_access_mode(options: &OpenOptions) -> io::Result<DWORD> {

--- a/cap-primitives/src/windows/fs/reopen_impl.rs
+++ b/cap-primitives/src/windows/fs/reopen_impl.rs
@@ -1,5 +1,6 @@
 use crate::fs::OpenOptions;
-use std::{fs, io, os::windows::io::AsRawHandle};
+use io_lifetimes::AsHandle;
+use std::{fs, io};
 use winapi::{
     shared::{minwindef::DWORD, winerror::ERROR_INVALID_PARAMETER},
     um::{
@@ -17,7 +18,7 @@ use winx::file::{AccessMode, Flags};
 
 /// Implementation of `reopen`.
 pub(crate) fn reopen_impl(file: &fs::File, options: &OpenOptions) -> io::Result<fs::File> {
-    let old_access_mode = winx::file::query_access_information(file.as_raw_handle())?;
+    let old_access_mode = winx::file::query_access_information(file.as_handle())?;
     let new_access_mode = get_access_mode(options)?;
     let flags = get_flags_and_attributes(options);
 

--- a/cap-std/Cargo.toml
+++ b/cap-std/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/bytecodealliance/cap-std"
 edition = "2018"
 
 [build-dependencies]
-rustc_version = "0.3.0"
+rustc_version = "0.4.0"
 
 [dependencies]
 arf-strings = { version = "0.3.0", optional = true }

--- a/cap-std/Cargo.toml
+++ b/cap-std/Cargo.toml
@@ -20,9 +20,10 @@ arf-strings = { version = "0.3.0", optional = true }
 cap-primitives = { path = "../cap-primitives", version = "^0.13.11-alpha.0"}
 ipnet = "2.3.0"
 unsafe-io = "0.6.0"
+io-lifetimes = "0.1.1"
 
 [target.'cfg(not(windows))'.dependencies]
-posish = "0.6.0"
+posish = "0.8.0"
 
 [features]
 default = []

--- a/cap-std/src/fs/dir.rs
+++ b/cap-std/src/fs/dir.rs
@@ -604,6 +604,14 @@ impl FromRawHandle for Dir {
     }
 }
 
+#[cfg(windows)]
+impl FromHandle for Dir {
+    #[inline]
+    fn from_handle(handle: OwnedHandle) -> Self {
+        Self::from_std_file(fs::File::from_handle(handle), ambient_authority())
+    }
+}
+
 #[cfg(not(windows))]
 impl AsRawFd for Dir {
     #[inline]
@@ -625,6 +633,14 @@ impl AsRawHandle for Dir {
     #[inline]
     fn as_raw_handle(&self) -> RawHandle {
         self.std_file.as_raw_handle()
+    }
+}
+
+#[cfg(windows)]
+impl<'h> AsHandle<'h> for &'h Dir {
+    #[inline]
+    fn as_handle(self) -> BorrowedHandle<'h> {
+        self.std.as_handle()
     }
 }
 
@@ -657,6 +673,14 @@ impl IntoRawHandle for Dir {
     #[inline]
     fn into_raw_handle(self) -> RawHandle {
         self.std_file.into_raw_handle()
+    }
+}
+
+#[cfg(windows)]
+impl IntoHandle for Dir {
+    #[inline]
+    fn into_handle(self) -> OwnedHandle {
+        self.std_file.into_handle()
     }
 }
 

--- a/cap-std/src/fs/dir.rs
+++ b/cap-std/src/fs/dir.rs
@@ -640,7 +640,7 @@ impl AsRawHandle for Dir {
 impl<'h> AsHandle<'h> for &'h Dir {
     #[inline]
     fn as_handle(self) -> BorrowedHandle<'h> {
-        self.std.as_handle()
+        self.std_file.as_handle()
     }
 }
 

--- a/cap-std/src/fs/dir.rs
+++ b/cap-std/src/fs/dir.rs
@@ -11,6 +11,10 @@ use cap_primitives::{
     },
     AmbientAuthority,
 };
+#[cfg(not(windows))]
+use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+#[cfg(windows)]
+use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
 #[cfg(target_os = "wasi")]
 use posish::fs::OpenOptionsExt;
 use std::{
@@ -582,6 +586,14 @@ impl FromRawFd for Dir {
     }
 }
 
+#[cfg(not(windows))]
+impl FromFd for Dir {
+    #[inline]
+    fn from_fd(fd: OwnedFd) -> Self {
+        Self::from_std_file(fs::File::from_fd(fd), ambient_authority())
+    }
+}
+
 #[cfg(windows)]
 impl FromRawHandle for Dir {
     /// To prevent race conditions on Windows, the handle must be opened without
@@ -597,6 +609,14 @@ impl AsRawFd for Dir {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.std_file.as_raw_fd()
+    }
+}
+
+#[cfg(not(windows))]
+impl<'f> AsFd<'f> for &'f Dir {
+    #[inline]
+    fn as_fd(self) -> BorrowedFd<'f> {
+        self.std_file.as_fd()
     }
 }
 
@@ -621,6 +641,14 @@ impl IntoRawFd for Dir {
     #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.std_file.into_raw_fd()
+    }
+}
+
+#[cfg(not(windows))]
+impl IntoFd for Dir {
+    #[inline]
+    fn into_fd(self) -> OwnedFd {
+        self.std_file.into_fd()
     }
 }
 

--- a/cap-std/src/fs/file.rs
+++ b/cap-std/src/fs/file.rs
@@ -169,7 +169,7 @@ impl FromRawHandle for File {
 #[cfg(windows)]
 impl FromHandle for File {
     #[inline]
-    fn from_handle(handle: OwnedFd) -> Self {
+    fn from_handle(handle: OwnedHandle) -> Self {
         Self::from_std(fs::File::from_handle(handle), ambient_authority())
     }
 }
@@ -199,9 +199,9 @@ impl AsRawHandle for File {
 }
 
 #[cfg(windows)]
-impl<'f> AsHandle<'f> for &'f File {
+impl<'h> AsHandle<'h> for &'h File {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'f> {
+    fn as_handle(self) -> BorrowedHandle<'h> {
         self.std.as_handle()
     }
 }

--- a/cap-std/src/fs_utf8/dir.rs
+++ b/cap-std/src/fs_utf8/dir.rs
@@ -541,6 +541,16 @@ impl FromRawHandle for Dir {
     }
 }
 
+#[cfg(windows)]
+impl FromHandle for Dir {
+    /// To prevent race conditions on Windows, the handle must be opened without
+    /// `FILE_SHARE_DELETE`.
+    #[inline]
+    fn from_handle(handle: OwnedHandle) -> Self {
+        Self::from_std_file(fs::File::from_handle(handle), ambient_authority())
+    }
+}
+
 #[cfg(not(windows))]
 impl AsRawFd for Dir {
     #[inline]
@@ -562,6 +572,14 @@ impl AsRawHandle for Dir {
     #[inline]
     fn as_raw_handle(&self) -> RawHandle {
         self.cap_std.as_raw_handle()
+    }
+}
+
+#[cfg(windows)]
+impl<'h> AsHandle<'h> for &'h Dir {
+    #[inline]
+    fn as_handle(self) -> BorrowedHandle<'h> {
+        self.cap_std.as_handle()
     }
 }
 
@@ -594,6 +612,14 @@ impl IntoRawHandle for Dir {
     #[inline]
     fn into_raw_handle(self) -> RawHandle {
         self.cap_std.into_raw_handle()
+    }
+}
+
+#[cfg(windows)]
+impl IntoHandle for Dir {
+    #[inline]
+    fn into_handle(self) -> OwnedHandle {
+        self.cap_std.into_handle()
     }
 }
 

--- a/cap-std/src/fs_utf8/dir.rs
+++ b/cap-std/src/fs_utf8/dir.rs
@@ -527,7 +527,7 @@ impl FromRawFd for Dir {
 impl FromFd for Dir {
     #[inline]
     fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(fs::File::from_fd(fd), ambient_authority())
+        Self::from_std_file(fs::File::from_fd(fd), ambient_authority())
     }
 }
 
@@ -563,7 +563,7 @@ impl AsRawFd for Dir {
 impl<'f> AsFd<'f> for &'f Dir {
     #[inline]
     fn as_fd(self) -> BorrowedFd<'f> {
-        self.std.as_fd()
+        self.cap_std.as_fd()
     }
 }
 
@@ -603,7 +603,7 @@ impl IntoRawFd for Dir {
 impl IntoFd for Dir {
     #[inline]
     fn into_fd(self) -> OwnedFd {
-        self.std.into_fd()
+        self.cap_std.into_fd()
     }
 }
 

--- a/cap-std/src/fs_utf8/dir.rs
+++ b/cap-std/src/fs_utf8/dir.rs
@@ -5,6 +5,10 @@ use crate::{
     fs_utf8::{from_utf8, to_utf8, DirBuilder, File, Metadata, ReadDir},
 };
 use cap_primitives::{ambient_authority, AmbientAuthority};
+#[cfg(not(windows))]
+use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+#[cfg(windows)]
+use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
 use std::{fmt, fs, io};
 #[cfg(not(windows))]
 use unsafe_io::os::posish::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -519,6 +523,14 @@ impl FromRawFd for Dir {
     }
 }
 
+#[cfg(not(windows))]
+impl FromFd for Dir {
+    #[inline]
+    fn from_fd(fd: OwnedFd) -> Self {
+        Self::from_std(fs::File::from_fd(fd), ambient_authority())
+    }
+}
+
 #[cfg(windows)]
 impl FromRawHandle for Dir {
     /// To prevent race conditions on Windows, the handle must be opened without
@@ -534,6 +546,14 @@ impl AsRawFd for Dir {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.cap_std.as_raw_fd()
+    }
+}
+
+#[cfg(not(windows))]
+impl<'f> AsFd<'f> for &'f Dir {
+    #[inline]
+    fn as_fd(self) -> BorrowedFd<'f> {
+        self.std.as_fd()
     }
 }
 
@@ -558,6 +578,14 @@ impl IntoRawFd for Dir {
     #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.cap_std.into_raw_fd()
+    }
+}
+
+#[cfg(not(windows))]
+impl IntoFd for Dir {
+    #[inline]
+    fn into_fd(self) -> OwnedFd {
+        self.std.into_fd()
     }
 }
 

--- a/cap-std/src/fs_utf8/file.rs
+++ b/cap-std/src/fs_utf8/file.rs
@@ -146,6 +146,14 @@ impl FromRawHandle for File {
     }
 }
 
+#[cfg(windows)]
+impl FromHandle for File {
+    #[inline]
+    fn from_handle(handle: OwnedHandle) -> Self {
+        Self::from_std(fs::File::from_handle(handle), ambient_authority())
+    }
+}
+
 #[cfg(not(windows))]
 impl AsRawFd for File {
     #[inline]
@@ -167,6 +175,14 @@ impl AsRawHandle for File {
     #[inline]
     fn as_raw_handle(&self) -> RawHandle {
         self.cap_std.as_raw_handle()
+    }
+}
+
+#[cfg(windows)]
+impl<'h> AsHandle<'h> for &'h File {
+    #[inline]
+    fn as_handle(self) -> BorrowedHandle<'h> {
+        self.cap_std.as_handle()
     }
 }
 
@@ -199,6 +215,14 @@ impl IntoRawHandle for File {
     #[inline]
     fn into_raw_handle(self) -> RawHandle {
         self.cap_std.into_raw_handle()
+    }
+}
+
+#[cfg(windows)]
+impl IntoHandle for File {
+    #[inline]
+    fn into_handle(self) -> OwnedHandle {
+        self.cap_std.into_handle()
     }
 }
 

--- a/cap-std/src/fs_utf8/file.rs
+++ b/cap-std/src/fs_utf8/file.rs
@@ -166,7 +166,7 @@ impl AsRawFd for File {
 impl<'f> AsFd<'f> for &'f File {
     #[inline]
     fn as_fd(self) -> BorrowedFd<'f> {
-        self.std.as_fd()
+        self.cap_std.as_fd()
     }
 }
 
@@ -206,7 +206,7 @@ impl IntoRawFd for File {
 impl IntoFd for File {
     #[inline]
     fn into_fd(self) -> OwnedFd {
-        self.std.into_fd()
+        self.cap_std.into_fd()
     }
 }
 

--- a/cap-std/src/net/tcp_listener.rs
+++ b/cap-std/src/net/tcp_listener.rs
@@ -1,5 +1,9 @@
 use crate::net::{Incoming, SocketAddr, TcpStream};
 use cap_primitives::{ambient_authority, AmbientAuthority};
+#[cfg(not(windows))]
+use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+#[cfg(windows)]
+use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
 use std::{fmt, io, net};
 #[cfg(not(windows))]
 use unsafe_io::os::posish::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -113,6 +117,14 @@ impl FromRawFd for TcpListener {
     }
 }
 
+#[cfg(not(windows))]
+impl FromFd for TcpListener {
+    #[inline]
+    fn from_fd(fd: OwnedFd) -> Self {
+        Self::from_std(net::TcpListener::from_fd(fd), ambient_authority())
+    }
+}
+
 #[cfg(windows)]
 impl FromRawSocket for TcpListener {
     #[inline]
@@ -129,6 +141,14 @@ impl AsRawFd for TcpListener {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.std.as_raw_fd()
+    }
+}
+
+#[cfg(not(windows))]
+impl<'f> AsFd<'f> for &'f TcpListener {
+    #[inline]
+    fn as_fd(self) -> BorrowedFd<'f> {
+        self.std.as_fd()
     }
 }
 
@@ -153,6 +173,14 @@ impl IntoRawFd for TcpListener {
     #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.std.into_raw_fd()
+    }
+}
+
+#[cfg(not(windows))]
+impl IntoFd for TcpListener {
+    #[inline]
+    fn into_fd(self) -> OwnedFd {
+        self.std.into_fd()
     }
 }
 

--- a/cap-std/src/net/tcp_listener.rs
+++ b/cap-std/src/net/tcp_listener.rs
@@ -136,6 +136,17 @@ impl FromRawSocket for TcpListener {
     }
 }
 
+#[cfg(windows)]
+impl FromSocket for TcpListener {
+    #[inline]
+    fn from_socket(socket: OwnedSocket) -> Self {
+        Self::from_std(
+            net::TcpListener::from_socket(socket),
+            ambient_authority(),
+        )
+    }
+}
+
 #[cfg(not(windows))]
 impl AsRawFd for TcpListener {
     #[inline]
@@ -156,6 +167,14 @@ impl<'f> AsFd<'f> for &'f TcpListener {
 impl AsRawSocket for TcpListener {
     #[inline]
     fn as_raw_socket(&self) -> RawSocket {
+        self.std.as_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl<'s> AsSocket<'s> for &'s TcpListener {
+    #[inline]
+    fn as_raw_socket(self) -> BorrowedSocket<'s> {
         self.std.as_raw_socket()
     }
 }
@@ -189,6 +208,14 @@ impl IntoRawSocket for TcpListener {
     #[inline]
     fn into_raw_socket(self) -> RawSocket {
         self.std.into_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl IntoSocket for TcpListener {
+    #[inline]
+    fn into_socket(self) -> OwnedSocket {
+        self.std.into_socket()
     }
 }
 

--- a/cap-std/src/net/tcp_listener.rs
+++ b/cap-std/src/net/tcp_listener.rs
@@ -3,7 +3,7 @@ use cap_primitives::{ambient_authority, AmbientAuthority};
 #[cfg(not(windows))]
 use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 #[cfg(windows)]
-use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
+use io_lifetimes::{AsSocket, BorrowedSocket, FromSocket, IntoSocket, OwnedSocket};
 use std::{fmt, io, net};
 #[cfg(not(windows))]
 use unsafe_io::os::posish::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -171,8 +171,8 @@ impl AsRawSocket for TcpListener {
 #[cfg(windows)]
 impl<'s> AsSocket<'s> for &'s TcpListener {
     #[inline]
-    fn as_raw_socket(self) -> BorrowedSocket<'s> {
-        self.std.as_raw_socket()
+    fn as_socket(self) -> BorrowedSocket<'s> {
+        self.std.as_socket()
     }
 }
 

--- a/cap-std/src/net/tcp_listener.rs
+++ b/cap-std/src/net/tcp_listener.rs
@@ -140,10 +140,7 @@ impl FromRawSocket for TcpListener {
 impl FromSocket for TcpListener {
     #[inline]
     fn from_socket(socket: OwnedSocket) -> Self {
-        Self::from_std(
-            net::TcpListener::from_socket(socket),
-            ambient_authority(),
-        )
+        Self::from_std(net::TcpListener::from_socket(socket), ambient_authority())
     }
 }
 

--- a/cap-std/src/net/tcp_stream.rs
+++ b/cap-std/src/net/tcp_stream.rs
@@ -3,7 +3,7 @@ use cap_primitives::{ambient_authority, AmbientAuthority};
 #[cfg(not(windows))]
 use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 #[cfg(windows)]
-use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
+use io_lifetimes::{AsSocket, BorrowedSocket, FromSocket, IntoSocket, OwnedSocket};
 use std::{
     fmt,
     io::{self, IoSlice, IoSliceMut, Read, Write},
@@ -227,8 +227,8 @@ impl AsRawSocket for TcpStream {
 #[cfg(windows)]
 impl<'s> AsSocket<'s> for &'s TcpStream {
     #[inline]
-    fn as_raw_socket(self) -> BorrowedSocket<'s> {
-        self.std.as_raw_socket()
+    fn as_socket(self) -> BorrowedSocket<'s> {
+        self.std.as_socket()
     }
 }
 

--- a/cap-std/src/net/tcp_stream.rs
+++ b/cap-std/src/net/tcp_stream.rs
@@ -196,10 +196,7 @@ impl FromRawSocket for TcpStream {
 impl FromSocket for TcpStream {
     #[inline]
     fn from_socket(socket: OwnedSocket) -> Self {
-        Self::from_std(
-            net::TcpStream::from_socket(socket),
-            ambient_authority(),
-        )
+        Self::from_std(net::TcpStream::from_socket(socket), ambient_authority())
     }
 }
 

--- a/cap-std/src/net/tcp_stream.rs
+++ b/cap-std/src/net/tcp_stream.rs
@@ -192,6 +192,17 @@ impl FromRawSocket for TcpStream {
     }
 }
 
+#[cfg(windows)]
+impl FromSocket for TcpStream {
+    #[inline]
+    fn from_socket(socket: OwnedSocket) -> Self {
+        Self::from_std(
+            net::TcpStream::from_socket(socket),
+            ambient_authority(),
+        )
+    }
+}
+
 #[cfg(not(windows))]
 impl AsRawFd for TcpStream {
     #[inline]
@@ -212,6 +223,14 @@ impl<'f> AsFd<'f> for &'f TcpStream {
 impl AsRawSocket for TcpStream {
     #[inline]
     fn as_raw_socket(&self) -> RawSocket {
+        self.std.as_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl<'s> AsSocket<'s> for &'s TcpStream {
+    #[inline]
+    fn as_raw_socket(self) -> BorrowedSocket<'s> {
         self.std.as_raw_socket()
     }
 }
@@ -245,6 +264,14 @@ impl IntoRawSocket for TcpStream {
     #[inline]
     fn into_raw_socket(self) -> RawSocket {
         self.std.into_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl IntoSocket for TcpStream {
+    #[inline]
+    fn into_socket(self) -> OwnedSocket {
+        self.std.into_socket()
     }
 }
 

--- a/cap-std/src/net/udp_socket.rs
+++ b/cap-std/src/net/udp_socket.rs
@@ -304,10 +304,7 @@ impl FromRawSocket for UdpSocket {
 impl FromSocket for UdpSocket {
     #[inline]
     fn from_socket(socket: OwnedSocket) -> Self {
-        Self::from_std(
-            net::UdpSocket::from_socket(socket),
-            ambient_authority(),
-        )
+        Self::from_std(net::UdpSocket::from_socket(socket), ambient_authority())
     }
 }
 

--- a/cap-std/src/net/udp_socket.rs
+++ b/cap-std/src/net/udp_socket.rs
@@ -1,5 +1,9 @@
 use crate::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use cap_primitives::{ambient_authority, AmbientAuthority};
+#[cfg(not(windows))]
+use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+#[cfg(windows)]
+use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
 use std::{fmt, io, net, time::Duration};
 #[cfg(not(windows))]
 use unsafe_io::os::posish::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -280,6 +284,14 @@ impl FromRawFd for UdpSocket {
     }
 }
 
+#[cfg(not(windows))]
+impl FromFd for UdpSocket {
+    #[inline]
+    fn from_fd(fd: OwnedFd) -> Self {
+        Self::from_std(net::UdpSocket::from_fd(fd), ambient_authority())
+    }
+}
+
 #[cfg(windows)]
 impl FromRawSocket for UdpSocket {
     #[inline]
@@ -293,6 +305,14 @@ impl AsRawFd for UdpSocket {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.std.as_raw_fd()
+    }
+}
+
+#[cfg(not(windows))]
+impl<'f> AsFd<'f> for &'f UdpSocket {
+    #[inline]
+    fn as_fd(self) -> BorrowedFd<'f> {
+        self.std.as_fd()
     }
 }
 
@@ -317,6 +337,14 @@ impl IntoRawFd for UdpSocket {
     #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.std.into_raw_fd()
+    }
+}
+
+#[cfg(not(windows))]
+impl IntoFd for UdpSocket {
+    #[inline]
+    fn into_fd(self) -> OwnedFd {
+        self.std.into_fd()
     }
 }
 

--- a/cap-std/src/net/udp_socket.rs
+++ b/cap-std/src/net/udp_socket.rs
@@ -300,6 +300,17 @@ impl FromRawSocket for UdpSocket {
     }
 }
 
+#[cfg(windows)]
+impl FromSocket for UdpSocket {
+    #[inline]
+    fn from_socket(socket: OwnedSocket) -> Self {
+        Self::from_std(
+            net::UdpSocket::from_socket(socket),
+            ambient_authority(),
+        )
+    }
+}
+
 #[cfg(not(windows))]
 impl AsRawFd for UdpSocket {
     #[inline]
@@ -320,6 +331,14 @@ impl<'f> AsFd<'f> for &'f UdpSocket {
 impl AsRawSocket for UdpSocket {
     #[inline]
     fn as_raw_socket(&self) -> RawSocket {
+        self.std.as_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl<'s> AsSocket<'s> for &'s UdpSocket {
+    #[inline]
+    fn as_raw_socket(self) -> BorrowedSocket<'s> {
         self.std.as_raw_socket()
     }
 }
@@ -353,6 +372,14 @@ impl IntoRawSocket for UdpSocket {
     #[inline]
     fn into_raw_socket(self) -> RawSocket {
         self.std.into_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl IntoSocket for UdpSocket {
+    #[inline]
+    fn into_socket(self) -> OwnedSocket {
+        self.std.into_socket()
     }
 }
 

--- a/cap-std/src/net/udp_socket.rs
+++ b/cap-std/src/net/udp_socket.rs
@@ -3,7 +3,7 @@ use cap_primitives::{ambient_authority, AmbientAuthority};
 #[cfg(not(windows))]
 use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 #[cfg(windows)]
-use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
+use io_lifetimes::{AsSocket, BorrowedSocket, FromSocket, IntoSocket, OwnedSocket};
 use std::{fmt, io, net, time::Duration};
 #[cfg(not(windows))]
 use unsafe_io::os::posish::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -335,8 +335,8 @@ impl AsRawSocket for UdpSocket {
 #[cfg(windows)]
 impl<'s> AsSocket<'s> for &'s UdpSocket {
     #[inline]
-    fn as_raw_socket(self) -> BorrowedSocket<'s> {
-        self.std.as_raw_socket()
+    fn as_socket(self) -> BorrowedSocket<'s> {
+        self.std.as_socket()
     }
 }
 

--- a/cap-std/src/os/unix/net/unix_datagram.rs
+++ b/cap-std/src/os/unix/net/unix_datagram.rs
@@ -1,5 +1,6 @@
 use crate::{net::Shutdown, os::unix::net::SocketAddr};
 use cap_primitives::{ambient_authority, AmbientAuthority};
+use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 use std::{
     fmt, io,
     os::unix::{
@@ -213,6 +214,13 @@ impl FromRawFd for UnixDatagram {
     }
 }
 
+impl FromFd for UnixDatagram {
+    #[inline]
+    fn from_fd(fd: OwnedFd) -> Self {
+        Self::from_std(unix::net::UnixDatagram::from_fd(fd), ambient_authority())
+    }
+}
+
 impl AsRawFd for UnixDatagram {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
@@ -220,10 +228,24 @@ impl AsRawFd for UnixDatagram {
     }
 }
 
+impl<'f> AsFd<'f> for &'f UnixDatagram {
+    #[inline]
+    fn as_fd(self) -> BorrowedFd<'f> {
+        self.std.as_fd()
+    }
+}
+
 impl IntoRawFd for UnixDatagram {
     #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.std.into_raw_fd()
+    }
+}
+
+impl IntoFd for UnixDatagram {
+    #[inline]
+    fn into_fd(self) -> OwnedFd {
+        self.std.into_fd()
     }
 }
 

--- a/cap-std/src/os/unix/net/unix_listener.rs
+++ b/cap-std/src/os/unix/net/unix_listener.rs
@@ -1,5 +1,6 @@
 use crate::os::unix::net::{Incoming, SocketAddr, UnixStream};
 use cap_primitives::{ambient_authority, AmbientAuthority};
+use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 use std::{
     fmt, io,
     os::unix::{
@@ -111,6 +112,13 @@ impl FromRawFd for UnixListener {
     }
 }
 
+impl FromFd for UnixListener {
+    #[inline]
+    fn from_fd(fd: OwnedFd) -> Self {
+        Self::from_std(unix::net::UnixListener::from_fd(fd), ambient_authority())
+    }
+}
+
 impl AsRawFd for UnixListener {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
@@ -118,10 +126,24 @@ impl AsRawFd for UnixListener {
     }
 }
 
+impl<'f> AsFd<'f> for &'f UnixListener {
+    #[inline]
+    fn as_fd(self) -> BorrowedFd<'f> {
+        self.std.as_fd()
+    }
+}
+
 impl IntoRawFd for UnixListener {
     #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.std.into_raw_fd()
+    }
+}
+
+impl IntoFd for UnixListener {
+    #[inline]
+    fn into_fd(self) -> OwnedFd {
+        self.std.into_fd()
     }
 }
 

--- a/cap-std/src/os/unix/net/unix_stream.rs
+++ b/cap-std/src/os/unix/net/unix_stream.rs
@@ -1,5 +1,6 @@
 use crate::{net::Shutdown, os::unix::net::SocketAddr};
 use cap_primitives::{ambient_authority, AmbientAuthority};
+use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 use std::{
     fmt,
     io::{self, IoSlice, IoSliceMut, Read, Write},
@@ -164,6 +165,13 @@ impl FromRawFd for UnixStream {
     }
 }
 
+impl FromFd for UnixStream {
+    #[inline]
+    fn from_fd(fd: OwnedFd) -> Self {
+        Self::from_std(unix::net::UnixStream::from_fd(fd), ambient_authority())
+    }
+}
+
 impl AsRawFd for UnixStream {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
@@ -171,10 +179,24 @@ impl AsRawFd for UnixStream {
     }
 }
 
+impl<'f> AsFd<'f> for &'f UnixStream {
+    #[inline]
+    fn as_fd(self) -> BorrowedFd<'f> {
+        self.std.as_fd()
+    }
+}
+
 impl IntoRawFd for UnixStream {
     #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.std.into_raw_fd()
+    }
+}
+
+impl IntoFd for UnixStream {
+    #[inline]
+    fn into_fd(self) -> OwnedFd {
+        self.std.into_fd()
     }
 }
 

--- a/cap-time-ext/Cargo.toml
+++ b/cap-time-ext/Cargo.toml
@@ -17,7 +17,7 @@ cap-primitives = { path = "../cap-primitives", version = "^0.13.11-alpha.0"}
 cap-std = { path = "../cap-std", optional = true, version = "^0.13.11-alpha.0"}
 
 [target.'cfg(not(windows))'.dependencies]
-posish = "0.6.0"
+posish = "0.8.0"
 
 [target.'cfg(windows)'.dependencies]
 once_cell = "1.5.2"

--- a/cap-time-ext/Cargo.toml
+++ b/cap-time-ext/Cargo.toml
@@ -21,7 +21,7 @@ posish = "0.8.0"
 
 [target.'cfg(windows)'.dependencies]
 once_cell = "1.5.2"
-winx = "0.25.0"
+winx = "0.26.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -814,7 +814,7 @@ fn readdir_write() {
                 "dir",
                 OpenOptions::new()
                     .write(true)
-                    .custom_flags(posish::fs::OFlags::DIRECTORY.bits())
+                    .custom_flags(posish::fs::OFlags::DIRECTORY.bits() as i32)
             )
             .is_err());
         assert!(tmpdir
@@ -822,7 +822,7 @@ fn readdir_write() {
                 "dir",
                 OpenOptions::new()
                     .append(true)
-                    .custom_flags(posish::fs::OFlags::DIRECTORY.bits())
+                    .custom_flags(posish::fs::OFlags::DIRECTORY.bits() as i32)
             )
             .is_err());
     }

--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -814,7 +814,7 @@ fn readdir_write() {
                 "dir",
                 OpenOptions::new()
                     .write(true)
-                    .custom_flags(libc::O_DIRECTORY)
+                    .custom_flags(posish::fs::OFlags::DIRECTORY.bits())
             )
             .is_err());
         assert!(tmpdir
@@ -822,7 +822,7 @@ fn readdir_write() {
                 "dir",
                 OpenOptions::new()
                     .append(true)
-                    .custom_flags(libc::O_DIRECTORY)
+                    .custom_flags(posish::fs::OFlags::DIRECTORY.bits())
             )
             .is_err());
     }

--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -6,7 +6,7 @@ use sys_common::io::tmpdir;
 /*
 #[cfg(not(windows))]
 fn rename_path_in_use() -> String {
-    std::io::Error::from_raw_os_error(libc::EBUSY).to_string()
+    posish::io::Errno::BUSY.io_error().to_string()
 }
 #[cfg(windows)]
 fn rename_path_in_use() -> String {
@@ -16,7 +16,7 @@ fn rename_path_in_use() -> String {
 
 #[cfg(not(windows))]
 fn no_such_file_or_directory() -> String {
-    std::io::Error::from_raw_os_error(libc::ENOENT).to_string()
+    posish::io::Errno::NOENT.io_error().to_string()
 }
 #[cfg(windows)]
 fn no_such_file_or_directory() -> String {
@@ -28,7 +28,7 @@ fn no_such_file_or_directory() -> String {
 cfg_if::cfg_if! {
     if #[cfg(any(target_os = "macos", target_os = "netbsd", target_os = "freebsd", target_os = "openbsd", target_os = "ios", target_os = "dragonfly"))] {
         fn rename_file_over_dir() -> String {
-            io::Error::from_raw_os_error(libc::EISDIR).to_string()
+            posish::io::Errno::ISDIR.io_error().to_string()
         }
 
         fn rename_file_over_dot() -> String {
@@ -36,11 +36,11 @@ cfg_if::cfg_if! {
         }
 
         fn rename_dot_over_file() -> String {
-            io::Error::from_raw_os_error(libc::EINVAL).to_string()
+            posish::io::Errno::INVAL.io_error().to_string()
         }
     } else {
         fn rename_file_over_dir() -> String {
-            io::Error::from_raw_os_error(libc::ENOTEMPTY).to_string()
+            posish::io::Errno::NOTEMPTY.io_error().to_string()
         }
 
         fn rename_file_over_dot() -> String {


### PR DESCRIPTION
This eliminates all direct dependencies from cap-std on libc, so that we can optionally enable posish's linux-raw-sys support. And, it adds io-lifetimes support and trait implementations.

For the moment, it depends on https://github.com/bytecodealliance/posish/pull/10/