### PR TITLE
Add a `Dir::create_ambient_dir_all` function.

### DIFF
--- a/cap-async-std/src/fs_utf8/dir.rs
+++ b/cap-async-std/src/fs_utf8/dir.rs
@@ -552,6 +552,39 @@ impl Dir {
             .await
             .map(Self::from_cap_std)
     }
+
+    /// Constructs a new instance of `Self` by opening the parent directory
+    /// (aka "..") of `self`, using the host process' ambient authority.
+    ///
+    /// # Ambient Authority
+    ///
+    /// This function accesses a directory outside of the `self` subtree.
+    #[inline]
+    pub async fn open_parent_dir<P: AsRef<str>>(
+        &self,
+        ambient_authority: AmbientAuthority,
+    ) -> io::Result<Self> {
+        self.cap_std
+            .open_parent_dir(ambient_authority)
+            .await
+            .map(Self::from_cap_std)
+    }
+
+    /// Recursively create a directory and all of its parent components if they
+    /// are missing, using the host process' ambient authority.
+    ///
+    /// # Ambient Authority
+    ///
+    /// This function is not sandboxed and may access any path that the host
+    /// process has access to.
+    #[inline]
+    pub async fn create_ambient_dir_all<P: AsRef<str>>(
+        path: P,
+        _ambient_authority: AmbientAuthority,
+    ) -> io::Result<()> {
+        let path = from_utf8(path)?;
+        fs::create_dir_all(path).await
+    }
 }
 
 #[cfg(not(windows))]

--- a/cap-primitives/src/fs/open_dir.rs
+++ b/cap-primitives/src/fs/open_dir.rs
@@ -5,7 +5,7 @@
 use crate::fs::open_unchecked;
 use crate::fs::{dir_options, open, open_ambient_dir_impl, readdir_options, FollowSymlinks};
 use ambient_authority::AmbientAuthority;
-use std::path::Path;
+use std::path::{Component, Path};
 use std::{fs, io};
 
 /// Open a directory by performing an `openat`-like operation,
@@ -57,4 +57,18 @@ pub(crate) fn open_dir_for_reading_unchecked(
 #[inline]
 pub fn open_ambient_dir(path: &Path, ambient_authority: AmbientAuthority) -> io::Result<fs::File> {
     open_ambient_dir_impl(path, ambient_authority)
+}
+
+/// Open the parent directory of a given open directory, using the host
+/// process' ambient authority.
+///
+/// # Ambient Authority
+///
+/// This function accesses a path outside of the `start` directory subtree.
+#[inline]
+pub fn open_parent_dir(
+    start: &fs::File,
+    _ambient_authority: AmbientAuthority,
+) -> io::Result<fs::File> {
+    open_dir_unchecked(start, Component::ParentDir.as_ref())
 }

--- a/cap-std/src/fs/dir.rs
+++ b/cap-std/src/fs/dir.rs
@@ -2,8 +2,8 @@ use crate::fs::{DirBuilder, File, Metadata, OpenOptions, ReadDir};
 #[cfg(unix)]
 use crate::os::unix::net::{UnixDatagram, UnixListener, UnixStream};
 use cap_primitives::fs::{
-    canonicalize, copy, create_dir, hard_link, open, open_ambient_dir, open_dir, read_base_dir,
-    read_dir, read_link, remove_dir, remove_dir_all, remove_file, remove_open_dir,
+    canonicalize, copy, create_dir, hard_link, open, open_ambient_dir, open_dir, open_parent_dir,
+    read_base_dir, read_dir, read_link, remove_dir, remove_dir_all, remove_file, remove_open_dir,
     remove_open_dir_all, rename, set_permissions, stat, DirOptions, FollowSymlinks, Permissions,
 };
 use cap_primitives::{ambient_authority, AmbientAuthority};
@@ -579,6 +579,33 @@ impl Dir {
     ) -> io::Result<Self> {
         let dir = open_ambient_dir(path.as_ref(), ambient_authority)?;
         Ok(Self::from_std_file(dir, ambient_authority))
+    }
+
+    /// Constructs a new instance of `Self` by opening the parent directory
+    /// (aka "..") of `self`, using the host process' ambient authority.
+    ///
+    /// # Ambient Authority
+    ///
+    /// This function accesses a directory outside of the `self` subtree.
+    #[inline]
+    pub fn open_parent_dir(&self, ambient_authority: AmbientAuthority) -> io::Result<Self> {
+        let dir = open_parent_dir(&self.std_file, ambient_authority)?;
+        Ok(Self::from_std_file(dir, ambient_authority))
+    }
+
+    /// Recursively create a directory and all of its parent components if they
+    /// are missing, using the host process' ambient authority.
+    ///
+    /// # Ambient Authority
+    ///
+    /// This function is not sandboxed and may access any path that the host
+    /// process has access to.
+    #[inline]
+    pub fn create_ambient_dir_all<P: AsRef<Path>>(
+        path: P,
+        _ambient_authority: AmbientAuthority,
+    ) -> io::Result<()> {
+        fs::create_dir_all(path)
     }
 }
 

--- a/cap-std/src/fs_utf8/dir.rs
+++ b/cap-std/src/fs_utf8/dir.rs
@@ -521,6 +521,38 @@ impl Dir {
         let path = from_utf8(path)?;
         crate::fs::Dir::open_ambient_dir(path, ambient_authority).map(Self::from_cap_std)
     }
+
+    /// Constructs a new instance of `Self` by opening the parent directory
+    /// (aka "..") of `self`, using the host process' ambient authority.
+    ///
+    /// # Ambient Authority
+    ///
+    /// This function accesses a directory outside of the `self` subtree.
+    #[inline]
+    pub fn open_parent_dir<P: AsRef<str>>(
+        &self,
+        ambient_authority: AmbientAuthority,
+    ) -> io::Result<Self> {
+        self.cap_std
+            .open_parent_dir(ambient_authority)
+            .map(Self::from_cap_std)
+    }
+
+    /// Recursively create a directory and all of its parent components if they
+    /// are missing, using the host process' ambient authority.
+    ///
+    /// # Ambient Authority
+    ///
+    /// This function is not sandboxed and may access any path that the host
+    /// process has access to.
+    #[inline]
+    pub fn create_ambient_dir_all<P: AsRef<str>>(
+        path: P,
+        _ambient_authority: AmbientAuthority,
+    ) -> io::Result<()> {
+        let path = from_utf8(path)?;
+        fs::create_dir_all(path)
+    }
 }
 
 #[cfg(not(windows))]

--- a/tests/open-ambient.rs
+++ b/tests/open-ambient.rs
@@ -3,7 +3,6 @@ mod sys_common;
 
 use cap_std::ambient_authority;
 use cap_std::fs::{Dir, File};
-use std::fs;
 
 #[test]
 fn test_open_ambient() {

--- a/tests/open-ambient.rs
+++ b/tests/open-ambient.rs
@@ -15,7 +15,6 @@ fn test_create_dir_ambient() {
     let dir = tempfile::tempdir().unwrap();
     let foo_path = dir.path().join("foo");
     Dir::create_ambient_dir_all(&foo_path, ambient_authority()).unwrap();
-    let _foo_via_std = fs::File::open(&foo_path).unwrap();
     let foo = Dir::open_ambient_dir(&foo_path, ambient_authority()).unwrap();
     let base = foo.open_parent_dir(ambient_authority()).unwrap();
     let _foo_again = base.open_dir("foo").unwrap();

--- a/tests/open-ambient.rs
+++ b/tests/open-ambient.rs
@@ -1,7 +1,22 @@
+#[macro_use]
+mod sys_common;
+
 use cap_std::ambient_authority;
-use cap_std::fs::File;
+use cap_std::fs::{Dir, File};
+use std::fs;
 
 #[test]
 fn test_open_ambient() {
     let _ = File::open_ambient("Cargo.toml", ambient_authority()).unwrap();
+}
+
+#[test]
+fn test_create_dir_ambient() {
+    let dir = tempfile::tempdir().unwrap();
+    let foo_path = dir.path().join("foo");
+    Dir::create_ambient_dir_all(&foo_path, ambient_authority()).unwrap();
+    let _foo_via_std = fs::File::open(&foo_path).unwrap();
+    let foo = Dir::open_ambient_dir(&foo_path, ambient_authority()).unwrap();
+    let base = foo.open_parent_dir(ambient_authority()).unwrap();
+    let _foo_again = base.open_dir("foo").unwrap();
 }


### PR DESCRIPTION
Add `Dir::create_ambient_dir_all` as well as `Dir::open_parent_dir`
functions, using ambient authorities.

Fixes #182.