### PR TITLE
Use camino instead of str/String in fs_utf8.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ cap-std = { path = "cap-std", version = "^0.18.1-alpha.0"}
 cap-tempfile = { path = "cap-tempfile", version = "^0.18.1-alpha.0"}
 rand = "0.8.1"
 tempfile = "3.1.0"
+camino = "1.0.5"
 
 [target.'cfg(not(windows))'.dev-dependencies]
 rsix = "0.20.0"
@@ -41,6 +42,7 @@ default = []
 fs_utf8 = [
     "cap-std/fs_utf8",
     "cap-fs-ext/fs_utf8",
+    "cap-tempfile/fs_utf8",
 ]
 async_std_fs_utf8 = [
     "cap-async-std/fs_utf8",

--- a/cap-async-std/Cargo.toml
+++ b/cap-async-std/Cargo.toml
@@ -20,13 +20,14 @@ cap-primitives = { path = "../cap-primitives", version = "^0.18.1-alpha.0"}
 io-lifetimes = { version = "0.3.0", default-features = false, features = ["async-std"] }
 ipnet = "2.3.0"
 unsafe-io = { version = "0.9.1", features = ["use_async_std"] }
+camino = { version = "1.0.5", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
 rsix = "0.20.0"
 
 [features]
 default = []
-fs_utf8 = ["arf-strings"]
+fs_utf8 = ["arf-strings", "camino"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/cap-async-std/src/fs_utf8/dir.rs
+++ b/cap-async-std/src/fs_utf8/dir.rs
@@ -1,6 +1,7 @@
 use crate::fs::{OpenOptions, Permissions};
 use crate::fs_utf8::{from_utf8, to_utf8, DirBuilder, File, Metadata, ReadDir};
 use async_std::{fs, io};
+use camino::{Utf8Path, Utf8PathBuf};
 use cap_primitives::{ambient_authority, AmbientAuthority};
 #[cfg(not(windows))]
 use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
@@ -61,7 +62,7 @@ impl Dir {
     /// This corresponds to [`async_std::fs::File::open`], but only accesses
     /// paths relative to `self`.
     #[inline]
-    pub async fn open<P: AsRef<str>>(&self, path: P) -> io::Result<File> {
+    pub async fn open<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<File> {
         let path = from_utf8(path)?;
         self.cap_std.open(path).await.map(File::from_cap_std)
     }
@@ -73,7 +74,7 @@ impl Dir {
     /// Instead of being a method on `OpenOptions`, this is a method on `Dir`,
     /// and it only accesses paths relative to `self`.
     #[inline]
-    pub async fn open_with<P: AsRef<str>>(
+    pub async fn open_with<P: AsRef<Utf8Path>>(
         &self,
         path: P,
         options: &OpenOptions,
@@ -87,7 +88,7 @@ impl Dir {
 
     /// Attempts to open a directory.
     #[inline]
-    pub async fn open_dir<P: AsRef<str>>(&self, path: P) -> io::Result<Self> {
+    pub async fn open_dir<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<Self> {
         let path = from_utf8(path)?;
         self.cap_std.open_dir(path).await.map(Self::from_cap_std)
     }
@@ -99,7 +100,7 @@ impl Dir {
     ///
     /// TODO: async: fix this when we fix https://github.com/bytecodealliance/cap-std/issues/51
     #[inline]
-    pub fn create_dir<P: AsRef<str>>(&self, path: P) -> io::Result<()> {
+    pub fn create_dir<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<()> {
         let path = from_utf8(path)?;
         self.cap_std.create_dir(path)
     }
@@ -112,7 +113,7 @@ impl Dir {
     ///
     /// TODO: async: fix this when we fix https://github.com/bytecodealliance/cap-std/issues/51
     #[inline]
-    pub fn create_dir_all<P: AsRef<str>>(&self, path: P) -> io::Result<()> {
+    pub fn create_dir_all<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<()> {
         let path = from_utf8(path)?;
         self.cap_std.create_dir_all(path)
     }
@@ -124,7 +125,7 @@ impl Dir {
     ///
     /// TODO: async: fix this when we fix https://github.com/bytecodealliance/cap-std/issues/51
     #[inline]
-    pub fn create_dir_with<P: AsRef<str>>(
+    pub fn create_dir_with<P: AsRef<Utf8Path>>(
         &self,
         path: P,
         dir_builder: &DirBuilder,
@@ -138,7 +139,7 @@ impl Dir {
     /// This corresponds to [`async_std::fs::File::create`], but only accesses
     /// paths relative to `self`.
     #[inline]
-    pub async fn create<P: AsRef<str>>(&self, path: P) -> io::Result<File> {
+    pub async fn create<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<File> {
         let path = from_utf8(path)?;
         self.cap_std.create(path).await.map(File::from_cap_std)
     }
@@ -150,7 +151,7 @@ impl Dir {
     /// returning an absolute path, returns a path relative to the
     /// directory represented by `self`.
     #[inline]
-    pub async fn canonicalize<P: AsRef<str>>(&self, path: P) -> io::Result<String> {
+    pub async fn canonicalize<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<Utf8PathBuf> {
         let path = from_utf8(path)?;
         self.cap_std.canonicalize(path).await.and_then(to_utf8)
     }
@@ -162,7 +163,7 @@ impl Dir {
     /// This corresponds to [`async_std::fs::copy`], but only accesses paths
     /// relative to `self`.
     #[inline]
-    pub async fn copy<P: AsRef<str>, Q: AsRef<str>>(
+    pub async fn copy<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(
         &self,
         from: P,
         to_dir: &Self,
@@ -178,7 +179,7 @@ impl Dir {
     /// This corresponds to [`async_std::fs::hard_link`], but only accesses
     /// paths relative to `self`.
     #[inline]
-    pub async fn hard_link<P: AsRef<str>, Q: AsRef<str>>(
+    pub async fn hard_link<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(
         &self,
         src: P,
         dst_dir: &Self,
@@ -195,7 +196,7 @@ impl Dir {
     /// This corresponds to [`async_std::fs::metadata`], but only accesses
     /// paths relative to `self`.
     #[inline]
-    pub async fn metadata<P: AsRef<str>>(&self, path: P) -> io::Result<Metadata> {
+    pub async fn metadata<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<Metadata> {
         let path = from_utf8(path)?;
         self.cap_std.metadata(path).await
     }
@@ -211,7 +212,7 @@ impl Dir {
     /// This corresponds to [`async_std::fs::read_dir`], but only accesses
     /// paths relative to `self`.
     #[inline]
-    pub async fn read_dir<P: AsRef<str>>(&self, path: P) -> io::Result<ReadDir> {
+    pub async fn read_dir<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<ReadDir> {
         let path = from_utf8(path)?;
         self.cap_std.read_dir(path).await.map(ReadDir::from_cap_std)
     }
@@ -221,7 +222,7 @@ impl Dir {
     /// This corresponds to [`async_std::fs::read`], but only accesses paths
     /// relative to `self`.
     #[inline]
-    pub async fn read<P: AsRef<str>>(&self, path: P) -> io::Result<Vec<u8>> {
+    pub async fn read<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<Vec<u8>> {
         let path = from_utf8(path)?;
         self.cap_std.read(path).await
     }
@@ -231,7 +232,7 @@ impl Dir {
     /// This corresponds to [`async_std::fs::read_link`], but only accesses
     /// paths relative to `self`.
     #[inline]
-    pub async fn read_link<P: AsRef<str>>(&self, path: P) -> io::Result<String> {
+    pub async fn read_link<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<Utf8PathBuf> {
         let path = from_utf8(path)?;
         self.cap_std.read_link(path).await.and_then(to_utf8)
     }
@@ -241,7 +242,7 @@ impl Dir {
     /// This corresponds to [`async_std::fs::read_to_string`], but only
     /// accesses paths relative to `self`.
     #[inline]
-    pub async fn read_to_string<P: AsRef<str>>(&self, path: P) -> io::Result<String> {
+    pub async fn read_to_string<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<String> {
         let path = from_utf8(path)?;
         self.cap_std.read_to_string(path).await
     }
@@ -251,7 +252,7 @@ impl Dir {
     /// This corresponds to [`async_std::fs::remove_dir`], but only accesses
     /// paths relative to `self`.
     #[inline]
-    pub async fn remove_dir<P: AsRef<str>>(&self, path: P) -> io::Result<()> {
+    pub async fn remove_dir<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<()> {
         let path = from_utf8(path)?;
         self.cap_std.remove_dir(path).await
     }
@@ -262,7 +263,7 @@ impl Dir {
     /// This corresponds to [`async_std::fs::remove_dir_all`], but only
     /// accesses paths relative to `self`.
     #[inline]
-    pub async fn remove_dir_all<P: AsRef<str>>(&self, path: P) -> io::Result<()> {
+    pub async fn remove_dir_all<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<()> {
         let path = from_utf8(path)?;
         self.cap_std.remove_dir_all(path).await
     }
@@ -293,7 +294,7 @@ impl Dir {
     /// This corresponds to [`async_std::fs::remove_file`], but only accesses
     /// paths relative to `self`.
     #[inline]
-    pub async fn remove_file<P: AsRef<str>>(&self, path: P) -> io::Result<()> {
+    pub async fn remove_file<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<()> {
         let path = from_utf8(path)?;
         self.cap_std.remove_file(path).await
     }
@@ -304,7 +305,7 @@ impl Dir {
     /// This corresponds to [`async_std::fs::rename`], but only accesses paths
     /// relative to `self`.
     #[inline]
-    pub async fn rename<P: AsRef<str>, Q: AsRef<str>>(
+    pub async fn rename<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(
         &self,
         from: P,
         to_dir: &Self,
@@ -321,7 +322,7 @@ impl Dir {
     /// accesses paths relative to `self`. Also, on some platforms, this
     /// function may fail if the file or directory cannot be opened for
     /// reading or writing first.
-    pub async fn set_permissions<P: AsRef<str>>(
+    pub async fn set_permissions<P: AsRef<Utf8Path>>(
         &self,
         path: P,
         perm: Permissions,
@@ -335,7 +336,7 @@ impl Dir {
     /// This corresponds to [`async_std::fs::symlink_metadata`], but only
     /// accesses paths relative to `self`.
     #[inline]
-    pub async fn symlink_metadata<P: AsRef<str>>(&self, path: P) -> io::Result<Metadata> {
+    pub async fn symlink_metadata<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<Metadata> {
         let path = from_utf8(path)?;
         self.cap_std.symlink_metadata(path).await
     }
@@ -345,7 +346,7 @@ impl Dir {
     /// This corresponds to [`async_std::fs::write`], but only accesses paths
     /// relative to `self`.
     #[inline]
-    pub async fn write<P: AsRef<str>, C: AsRef<[u8]>>(
+    pub async fn write<P: AsRef<Utf8Path>, C: AsRef<[u8]>>(
         &self,
         path: P,
         contents: C,
@@ -362,7 +363,11 @@ impl Dir {
     /// [`async_std::os::unix::fs::symlink`]: https://docs.rs/async-std/latest/async_std/os/unix/fs/fn.symlink.html
     #[cfg(not(windows))]
     #[inline]
-    pub async fn symlink<P: AsRef<str>, Q: AsRef<str>>(&self, src: P, dst: Q) -> io::Result<()> {
+    pub async fn symlink<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(
+        &self,
+        src: P,
+        dst: Q,
+    ) -> io::Result<()> {
         let src = from_utf8(src)?;
         let dst = from_utf8(dst)?;
         self.cap_std.symlink(src, dst).await
@@ -376,7 +381,7 @@ impl Dir {
     /// [`async_std::os::windows::fs::symlink_file`]: https://docs.rs/async-std/latest/async_std/os/windows/fs/fn.symlink_file.html
     #[cfg(windows)]
     #[inline]
-    pub async fn symlink_file<P: AsRef<str>, Q: AsRef<str>>(
+    pub async fn symlink_file<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(
         &self,
         src: P,
         dst: Q,
@@ -394,7 +399,7 @@ impl Dir {
     /// [`async_std::os::windows::fs::symlink_dir`]: https://docs.rs/async-std/latest/async_std/os/windows/fs/fn.symlink_dir.html
     #[cfg(windows)]
     #[inline]
-    pub async fn symlink_dir<P: AsRef<str>, Q: AsRef<str>>(
+    pub async fn symlink_dir<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(
         &self,
         src: P,
         dst: Q,
@@ -414,7 +419,10 @@ impl Dir {
     /// [`async_std::os::unix::net::UnixListener::bind`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixListener.html#method.bind
     #[cfg(unix)]
     #[inline]
-    pub async fn bind_unix_listener<P: AsRef<str>>(&self, path: P) -> io::Result<UnixListener> {
+    pub async fn bind_unix_listener<P: AsRef<Utf8Path>>(
+        &self,
+        path: P,
+    ) -> io::Result<UnixListener> {
         let path = from_utf8(path)?;
         self.cap_std.bind_unix_listener(path).await
     }
@@ -429,7 +437,7 @@ impl Dir {
     /// [`async_std::os::unix::net::UnixStream::connect`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixStream.html#method.connect
     #[cfg(unix)]
     #[inline]
-    pub async fn connect_unix_stream<P: AsRef<str>>(&self, path: P) -> io::Result<UnixStream> {
+    pub async fn connect_unix_stream<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<UnixStream> {
         let path = from_utf8(path)?;
         self.cap_std.connect_unix_stream(path).await
     }
@@ -444,7 +452,10 @@ impl Dir {
     /// [`async_std::os::unix::net::UnixDatagram::bind`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.bind
     #[cfg(unix)]
     #[inline]
-    pub async fn bind_unix_datagram<P: AsRef<str>>(&self, path: P) -> io::Result<UnixDatagram> {
+    pub async fn bind_unix_datagram<P: AsRef<Utf8Path>>(
+        &self,
+        path: P,
+    ) -> io::Result<UnixDatagram> {
         let path = from_utf8(path)?;
         self.cap_std.bind_unix_datagram(path).await
     }
@@ -460,7 +471,7 @@ impl Dir {
     /// [`async_std::os::unix::net::UnixDatagram::connect`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.connect
     #[cfg(unix)]
     #[inline]
-    pub async fn connect_unix_datagram<P: AsRef<str>>(
+    pub async fn connect_unix_datagram<P: AsRef<Utf8Path>>(
         &self,
         unix_datagram: &UnixDatagram,
         path: P,
@@ -482,7 +493,7 @@ impl Dir {
     /// [`async_std::os::unix::net::UnixDatagram::send_to`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.send_to
     #[cfg(unix)]
     #[inline]
-    pub async fn send_to_unix_datagram_addr<P: AsRef<str>>(
+    pub async fn send_to_unix_datagram_addr<P: AsRef<Utf8Path>>(
         &self,
         unix_datagram: &UnixDatagram,
         buf: &[u8],
@@ -501,7 +512,7 @@ impl Dir {
     /// This corresponds to [`async_std::path::Path::exists`], but only
     /// accesses paths relative to `self`.
     #[inline]
-    pub async fn exists<P: AsRef<str>>(&self, path: P) -> bool {
+    pub async fn exists<P: AsRef<Utf8Path>>(&self, path: P) -> bool {
         match from_utf8(path) {
             Ok(path) => self.cap_std.exists(path).await,
             Err(_) => false,
@@ -514,7 +525,7 @@ impl Dir {
     /// This corresponds to [`async_std::path::Path::is_file`], but only
     /// accesses paths relative to `self`.
     #[inline]
-    pub async fn is_file<P: AsRef<str>>(&self, path: P) -> bool {
+    pub async fn is_file<P: AsRef<Utf8Path>>(&self, path: P) -> bool {
         match from_utf8(path) {
             Ok(path) => self.cap_std.is_file(path).await,
             Err(_) => false,
@@ -528,7 +539,7 @@ impl Dir {
     /// symbolic links to query information about the destination file. In case
     /// of broken symbolic links, this will return `false`.
     #[inline]
-    pub async fn is_dir<P: AsRef<str>>(&self, path: P) -> bool {
+    pub async fn is_dir<P: AsRef<Utf8Path>>(&self, path: P) -> bool {
         match from_utf8(path) {
             Ok(path) => self.cap_std.is_dir(path).await,
             Err(_) => false,
@@ -543,7 +554,7 @@ impl Dir {
     /// This function is not sandboxed and may access any path that the host
     /// process has access to.
     #[inline]
-    pub async fn open_ambient_dir<P: AsRef<str>>(
+    pub async fn open_ambient_dir<P: AsRef<Utf8Path>>(
         path: P,
         ambient_authority: AmbientAuthority,
     ) -> io::Result<Self> {

--- a/cap-async-std/src/fs_utf8/dir_entry.rs
+++ b/cap-async-std/src/fs_utf8/dir_entry.rs
@@ -87,7 +87,7 @@ impl DirEntry {
     pub fn file_name(&self) -> String {
         // Unwrap because we can assume that paths coming from the OS don't
         // have embedded NULs.
-        to_utf8(self.cap_std.file_name()).unwrap()
+        to_utf8(self.cap_std.file_name()).unwrap().into()
     }
 }
 

--- a/cap-async-std/src/fs_utf8/file.rs
+++ b/cap-async-std/src/fs_utf8/file.rs
@@ -7,6 +7,7 @@ use async_std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(target_os = "wasi")]
 use async_std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use async_std::task::{Context, Poll};
+use camino::Utf8Path;
 use cap_primitives::{ambient_authority, AmbientAuthority};
 #[cfg(not(windows))]
 use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
@@ -115,7 +116,7 @@ impl File {
     /// This function is not sandboxed and may access any path that the host
     /// process has access to.
     #[inline]
-    pub async fn open_ambient<P: AsRef<str>>(
+    pub async fn open_ambient<P: AsRef<Utf8Path>>(
         path: P,
         ambient_authority: AmbientAuthority,
     ) -> io::Result<Self> {
@@ -134,7 +135,7 @@ impl File {
     /// This function is not sandboxed and may access any path that the host
     /// process has access to.
     #[inline]
-    pub async fn open_ambient_with<P: AsRef<str>>(
+    pub async fn open_ambient_with<P: AsRef<Utf8Path>>(
         path: P,
         options: &OpenOptions,
         ambient_authority: AmbientAuthority,

--- a/cap-async-std/src/fs_utf8/mod.rs
+++ b/cap-async-std/src/fs_utf8/mod.rs
@@ -1,7 +1,8 @@
 //! A fully UTF-8 filesystem API modeled after [`cap_async_std::fs`].
 //!
 //! Where `cap_async_std::fs` would use `Path` and `PathBuf`, this `fs_utf8`
-//! module uses `str` and `String`, meaning that all paths are valid UTF-8.
+//! module uses [`Utf8Path`] and [`Utf8PathBuf`], meaning that all paths are
+//! valid UTF-8.
 //!
 //! But wait, POSIX doesn't require filenames to be UTF-8! What happens if
 //! there's a file with a non-UTF-8 name? To address this, this module uses
@@ -30,10 +31,12 @@ pub use dir_entry::DirEntry;
 pub use file::File;
 pub use read_dir::ReadDir;
 
+use camino::{Utf8Path, Utf8PathBuf};
+
 // Re-export things from `cap_std::fs` that we can use as-is.
 pub use crate::fs::{DirBuilder, FileType, Metadata, OpenOptions, Permissions};
 
-fn from_utf8<P: AsRef<str>>(path: P) -> std::io::Result<async_std::path::PathBuf> {
+fn from_utf8<P: AsRef<Utf8Path>>(path: P) -> std::io::Result<async_std::path::PathBuf> {
     #[cfg(not(windows))]
     let path = {
         #[cfg(unix)]
@@ -41,28 +44,30 @@ fn from_utf8<P: AsRef<str>>(path: P) -> std::io::Result<async_std::path::PathBuf
         #[cfg(target_os = "wasi")]
         use std::{ffi::OsString, os::wasi::ffi::OsStringExt};
 
-        let string = arf_strings::str_to_host(path.as_ref())?;
+        let string = arf_strings::str_to_host(path.as_ref().as_str())?;
         OsString::from_vec(string.into_bytes())
     };
 
     #[cfg(windows)]
-    let path = arf_strings::str_to_host(path.as_ref())?;
+    let path = arf_strings::str_to_host(path.as_ref().as_str())?;
 
     Ok(path.into())
 }
 
-fn to_utf8<P: AsRef<async_std::path::Path>>(path: P) -> std::io::Result<String> {
+fn to_utf8<P: AsRef<async_std::path::Path>>(path: P) -> std::io::Result<Utf8PathBuf> {
     // For now, for WASI use the same logic as other OS's, but
     // in the future, the idea is we could avoid this.
     let osstr = path.as_ref().as_os_str();
 
     #[cfg(not(windows))]
     {
-        arf_strings::host_os_str_to_str(osstr).map(std::borrow::Cow::into_owned)
+        arf_strings::host_os_str_to_str(osstr)
+            .map(std::borrow::Cow::into_owned)
+            .map(Into::into)
     }
 
     #[cfg(windows)]
     {
-        arf_strings::host_to_str(osstr)
+        arf_strings::host_to_str(osstr).map(Into::into)
     }
 }

--- a/cap-fs-ext/Cargo.toml
+++ b/cap-fs-ext/Cargo.toml
@@ -24,13 +24,14 @@ io-lifetimes = "0.3.0"
 # Enable "unstable" for `spawn_blocking`.
 async-std = { version = "1.10.0", features = ["attributes", "unstable"], optional = true }
 async-trait = { version = "0.1.42", optional = true }
+camino = { version = "1.0.5", optional = true }
 
 [features]
 default = ["std"]
-fs_utf8 = ["arf-strings", "cap-std/fs_utf8"]
+fs_utf8 = ["arf-strings", "cap-std/fs_utf8", "camino"]
 std = ["cap-std"]
 async_std = ["cap-async-std", "async-std", "io-lifetimes/async-std", "async-trait"]
-async_std_fs_utf8 = ["cap-async-std/fs_utf8"]
+async_std_fs_utf8 = ["arf-strings", "cap-async-std/fs_utf8", "camino"]
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"

--- a/cap-fs-ext/src/dir_ext.rs
+++ b/cap-fs-ext/src/dir_ext.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "fs_utf8")]
 use camino::Utf8Path;
 use cap_primitives::ambient_authority;
 #[cfg(not(windows))]

--- a/cap-fs-ext/src/dir_ext.rs
+++ b/cap-fs-ext/src/dir_ext.rs
@@ -1,3 +1,4 @@
+use camino::Utf8Path;
 use cap_primitives::ambient_authority;
 #[cfg(not(windows))]
 use cap_primitives::fs::symlink;
@@ -225,21 +226,21 @@ pub trait DirExtUtf8 {
     /// This corresponds to [`filetime::set_file_atime`].
     ///
     /// [`filetime::set_file_atime`]: https://docs.rs/filetime/latest/filetime/fn.set_file_atime.html
-    fn set_atime<P: AsRef<str>>(&self, path: P, atime: SystemTimeSpec) -> io::Result<()>;
+    fn set_atime<P: AsRef<Utf8Path>>(&self, path: P, atime: SystemTimeSpec) -> io::Result<()>;
 
     /// Set the last modification time for a file on a filesystem.
     ///
     /// This corresponds to [`filetime::set_file_mtime`].
     ///
     /// [`filetime::set_file_mtime`]: https://docs.rs/filetime/latest/filetime/fn.set_file_mtime.html
-    fn set_mtime<P: AsRef<str>>(&self, path: P, mtime: SystemTimeSpec) -> io::Result<()>;
+    fn set_mtime<P: AsRef<Utf8Path>>(&self, path: P, mtime: SystemTimeSpec) -> io::Result<()>;
 
     /// Set the last access and modification times for a file on a filesystem.
     ///
     /// This corresponds to [`filetime::set_file_times`].
     ///
     /// [`filetime::set_file_times`]: https://docs.rs/filetime/latest/filetime/fn.set_file_times.html
-    fn set_times<P: AsRef<str>>(
+    fn set_times<P: AsRef<Utf8Path>>(
         &self,
         path: P,
         atime: Option<SystemTimeSpec>,
@@ -252,7 +253,7 @@ pub trait DirExtUtf8 {
     /// This corresponds to [`filetime::set_symlink_file_times`].
     ///
     /// [`filetime::set_symlink_file_times`]: https://docs.rs/filetime/latest/filetime/fn.set_symlink_file_times.html
-    fn set_symlink_times<P: AsRef<str>>(
+    fn set_symlink_times<P: AsRef<Utf8Path>>(
         &self,
         path: P,
         atime: Option<SystemTimeSpec>,
@@ -266,7 +267,7 @@ pub trait DirExtUtf8 {
     /// atomic.
     ///
     /// [`std::os::unix::fs::symlink`]: https://doc.rust-lang.org/std/os/unix/fs/fn.symlink.html
-    fn symlink<P: AsRef<str>, Q: AsRef<str>>(&self, src: P, dst: Q) -> io::Result<()>;
+    fn symlink<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(&self, src: P, dst: Q) -> io::Result<()>;
 
     /// Creates a new file symbolic link on a filesystem.
     ///
@@ -275,7 +276,11 @@ pub trait DirExtUtf8 {
     /// guaranteed to fail if the target is not a file.
     ///
     /// [`std::os::windows::fs::symlink_file`]: https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_file.html
-    fn symlink_file<P: AsRef<str>, Q: AsRef<str>>(&self, src: P, dst: Q) -> io::Result<()>;
+    fn symlink_file<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(
+        &self,
+        src: P,
+        dst: Q,
+    ) -> io::Result<()>;
 
     /// Creates a new directory symbolic link on a filesystem.
     ///
@@ -284,11 +289,12 @@ pub trait DirExtUtf8 {
     /// guaranteed to fail if the target is not a directory.
     ///
     /// [`std::os::windows::fs::symlink_dir`]: https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_dir.html
-    fn symlink_dir<P: AsRef<str>, Q: AsRef<str>>(&self, src: P, dst: Q) -> io::Result<()>;
+    fn symlink_dir<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(&self, src: P, dst: Q)
+        -> io::Result<()>;
 
     /// Similar to `cap_std::fs::Dir::open_dir`, but fails if the path names a
     /// symlink.
-    fn open_dir_nofollow<P: AsRef<str>>(&self, path: P) -> io::Result<Self>
+    fn open_dir_nofollow<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<Self>
     where
         Self: Sized;
 
@@ -297,7 +303,7 @@ pub trait DirExtUtf8 {
     /// This is similar to [`std::fs::remove_file`], except that it also works
     /// on symlinks to directories on Windows, similar to how `unlink` works
     /// on symlinks to directories on Posix-ish platforms.
-    fn remove_file_or_symlink<P: AsRef<str>>(&self, path: P) -> io::Result<()>;
+    fn remove_file_or_symlink<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<()>;
 }
 
 /// `fs_utf8` version of `DirExt`.
@@ -311,7 +317,7 @@ pub trait AsyncDirExtUtf8 {
     /// This corresponds to [`filetime::set_file_atime`].
     ///
     /// [`filetime::set_file_atime`]: https://docs.rs/filetime/latest/filetime/fn.set_file_atime.html
-    async fn set_atime<P: AsRef<str> + Send>(
+    async fn set_atime<P: AsRef<Utf8Path> + Send>(
         &self,
         path: P,
         atime: SystemTimeSpec,
@@ -322,7 +328,7 @@ pub trait AsyncDirExtUtf8 {
     /// This corresponds to [`filetime::set_file_mtime`].
     ///
     /// [`filetime::set_file_mtime`]: https://docs.rs/filetime/latest/filetime/fn.set_file_mtime.html
-    async fn set_mtime<P: AsRef<str> + Send>(
+    async fn set_mtime<P: AsRef<Utf8Path> + Send>(
         &self,
         path: P,
         mtime: SystemTimeSpec,
@@ -333,7 +339,7 @@ pub trait AsyncDirExtUtf8 {
     /// This corresponds to [`filetime::set_file_times`].
     ///
     /// [`filetime::set_file_times`]: https://docs.rs/filetime/latest/filetime/fn.set_file_times.html
-    async fn set_times<P: AsRef<str> + Send>(
+    async fn set_times<P: AsRef<Utf8Path> + Send>(
         &self,
         path: P,
         atime: Option<SystemTimeSpec>,
@@ -346,7 +352,7 @@ pub trait AsyncDirExtUtf8 {
     /// This corresponds to [`filetime::set_symlink_file_times`].
     ///
     /// [`filetime::set_symlink_file_times`]: https://docs.rs/filetime/latest/filetime/fn.set_symlink_file_times.html
-    async fn set_symlink_times<P: AsRef<str> + Send>(
+    async fn set_symlink_times<P: AsRef<Utf8Path> + Send>(
         &self,
         path: P,
         atime: Option<SystemTimeSpec>,
@@ -360,7 +366,7 @@ pub trait AsyncDirExtUtf8 {
     /// to be atomic.
     ///
     /// [`std::os::unix::fs::symlink`]: https://doc.rust-lang.org/std/os/unix/fs/fn.symlink.html
-    async fn symlink<P: AsRef<str> + Send, Q: AsRef<str> + Send>(
+    async fn symlink<P: AsRef<Utf8Path> + Send, Q: AsRef<Utf8Path> + Send>(
         &self,
         src: P,
         dst: Q,
@@ -373,7 +379,7 @@ pub trait AsyncDirExtUtf8 {
     /// guaranteed to fail if the target is not a file.
     ///
     /// [`std::os::windows::fs::symlink_file`]: https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_file.html
-    async fn symlink_file<P: AsRef<str> + Send, Q: AsRef<str> + Send>(
+    async fn symlink_file<P: AsRef<Utf8Path> + Send, Q: AsRef<Utf8Path> + Send>(
         &self,
         src: P,
         dst: Q,
@@ -386,7 +392,7 @@ pub trait AsyncDirExtUtf8 {
     /// guaranteed to fail if the target is not a directory.
     ///
     /// [`std::os::windows::fs::symlink_dir`]: https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_dir.html
-    async fn symlink_dir<P: AsRef<str> + Send, Q: AsRef<str> + Send>(
+    async fn symlink_dir<P: AsRef<Utf8Path> + Send, Q: AsRef<Utf8Path> + Send>(
         &self,
         src: P,
         dst: Q,
@@ -394,7 +400,7 @@ pub trait AsyncDirExtUtf8 {
 
     /// Similar to `cap_std::fs::Dir::open_dir`, but fails if the path names a
     /// symlink.
-    async fn open_dir_nofollow<P: AsRef<str> + Send>(&self, path: P) -> io::Result<Self>
+    async fn open_dir_nofollow<P: AsRef<Utf8Path> + Send>(&self, path: P) -> io::Result<Self>
     where
         Self: Sized;
 
@@ -403,7 +409,7 @@ pub trait AsyncDirExtUtf8 {
     /// Removal of symlinks has different behavior under Windows - if a symlink
     /// points to a directory, it cannot be removed with the `remove_file`
     /// operation. This method will remove files and all symlinks.
-    async fn remove_file_or_symlink<P: AsRef<str> + Send>(&self, path: P) -> io::Result<()>;
+    async fn remove_file_or_symlink<P: AsRef<Utf8Path> + Send>(&self, path: P) -> io::Result<()>;
 }
 
 #[cfg(feature = "std")]
@@ -857,7 +863,7 @@ impl AsyncDirExt for cap_async_std::fs::Dir {
 #[cfg(all(feature = "std", feature = "fs_utf8"))]
 impl DirExtUtf8 for cap_std::fs_utf8::Dir {
     #[inline]
-    fn set_atime<P: AsRef<str>>(&self, path: P, atime: SystemTimeSpec) -> io::Result<()> {
+    fn set_atime<P: AsRef<Utf8Path>>(&self, path: P, atime: SystemTimeSpec) -> io::Result<()> {
         let path = from_utf8(path)?;
         set_times(
             &self.as_filelike_view::<std::fs::File>(),
@@ -868,7 +874,7 @@ impl DirExtUtf8 for cap_std::fs_utf8::Dir {
     }
 
     #[inline]
-    fn set_mtime<P: AsRef<str>>(&self, path: P, mtime: SystemTimeSpec) -> io::Result<()> {
+    fn set_mtime<P: AsRef<Utf8Path>>(&self, path: P, mtime: SystemTimeSpec) -> io::Result<()> {
         let path = from_utf8(path)?;
         set_times(
             &self.as_filelike_view::<std::fs::File>(),
@@ -879,7 +885,7 @@ impl DirExtUtf8 for cap_std::fs_utf8::Dir {
     }
 
     #[inline]
-    fn set_times<P: AsRef<str>>(
+    fn set_times<P: AsRef<Utf8Path>>(
         &self,
         path: P,
         atime: Option<SystemTimeSpec>,
@@ -895,7 +901,7 @@ impl DirExtUtf8 for cap_std::fs_utf8::Dir {
     }
 
     #[inline]
-    fn set_symlink_times<P: AsRef<str>>(
+    fn set_symlink_times<P: AsRef<Utf8Path>>(
         &self,
         path: P,
         atime: Option<SystemTimeSpec>,
@@ -912,25 +918,33 @@ impl DirExtUtf8 for cap_std::fs_utf8::Dir {
 
     #[cfg(not(windows))]
     #[inline]
-    fn symlink<P: AsRef<str>, Q: AsRef<str>>(&self, src: P, dst: Q) -> io::Result<()> {
+    fn symlink<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(&self, src: P, dst: Q) -> io::Result<()> {
         Self::symlink(self, src, dst)
     }
 
     #[cfg(not(windows))]
     #[inline]
-    fn symlink_file<P: AsRef<str>, Q: AsRef<str>>(&self, src: P, dst: Q) -> io::Result<()> {
+    fn symlink_file<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(
+        &self,
+        src: P,
+        dst: Q,
+    ) -> io::Result<()> {
         Self::symlink(self, src, dst)
     }
 
     #[cfg(not(windows))]
     #[inline]
-    fn symlink_dir<P: AsRef<str>, Q: AsRef<str>>(&self, src: P, dst: Q) -> io::Result<()> {
+    fn symlink_dir<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(
+        &self,
+        src: P,
+        dst: Q,
+    ) -> io::Result<()> {
         Self::symlink(self, src, dst)
     }
 
     #[cfg(windows)]
     #[inline]
-    fn symlink<P: AsRef<str>, Q: AsRef<str>>(&self, src: P, dst: Q) -> io::Result<()> {
+    fn symlink<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(&self, src: P, dst: Q) -> io::Result<()> {
         if self.metadata(src.as_ref())?.is_dir() {
             Self::symlink_dir(self, src, dst)
         } else {
@@ -940,18 +954,26 @@ impl DirExtUtf8 for cap_std::fs_utf8::Dir {
 
     #[cfg(windows)]
     #[inline]
-    fn symlink_file<P: AsRef<str>, Q: AsRef<str>>(&self, src: P, dst: Q) -> io::Result<()> {
+    fn symlink_file<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(
+        &self,
+        src: P,
+        dst: Q,
+    ) -> io::Result<()> {
         Self::symlink_file(self, src, dst)
     }
 
     #[cfg(windows)]
     #[inline]
-    fn symlink_dir<P: AsRef<str>, Q: AsRef<str>>(&self, src: P, dst: Q) -> io::Result<()> {
+    fn symlink_dir<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(
+        &self,
+        src: P,
+        dst: Q,
+    ) -> io::Result<()> {
         Self::symlink_dir(self, src, dst)
     }
 
     #[inline]
-    fn open_dir_nofollow<P: AsRef<str>>(&self, path: P) -> io::Result<Self> {
+    fn open_dir_nofollow<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<Self> {
         match open_dir_nofollow(
             &self.as_filelike_view::<std::fs::File>(),
             path.as_ref().as_ref(),
@@ -963,13 +985,13 @@ impl DirExtUtf8 for cap_std::fs_utf8::Dir {
 
     #[cfg(not(windows))]
     #[inline]
-    fn remove_file_or_symlink<P: AsRef<str>>(&self, path: P) -> io::Result<()> {
+    fn remove_file_or_symlink<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<()> {
         self.remove_file(path.as_ref())
     }
 
     #[cfg(windows)]
     #[inline]
-    fn remove_file_or_symlink<P: AsRef<str>>(&self, path: P) -> io::Result<()> {
+    fn remove_file_or_symlink<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<()> {
         use crate::{FollowSymlinks, OpenOptionsFollowExt};
         use cap_primitives::fs::_WindowsByHandle;
         use cap_std::fs::OpenOptions;
@@ -1007,7 +1029,7 @@ impl DirExtUtf8 for cap_std::fs_utf8::Dir {
 #[async_trait]
 impl AsyncDirExtUtf8 for cap_async_std::fs_utf8::Dir {
     #[inline]
-    async fn set_atime<P: AsRef<str> + Send>(
+    async fn set_atime<P: AsRef<Utf8Path> + Send>(
         &self,
         path: P,
         atime: SystemTimeSpec,
@@ -1026,7 +1048,7 @@ impl AsyncDirExtUtf8 for cap_async_std::fs_utf8::Dir {
     }
 
     #[inline]
-    async fn set_mtime<P: AsRef<str> + Send>(
+    async fn set_mtime<P: AsRef<Utf8Path> + Send>(
         &self,
         path: P,
         mtime: SystemTimeSpec,
@@ -1045,7 +1067,7 @@ impl AsyncDirExtUtf8 for cap_async_std::fs_utf8::Dir {
     }
 
     #[inline]
-    async fn set_times<P: AsRef<str> + Send>(
+    async fn set_times<P: AsRef<Utf8Path> + Send>(
         &self,
         path: P,
         atime: Option<SystemTimeSpec>,
@@ -1065,7 +1087,7 @@ impl AsyncDirExtUtf8 for cap_async_std::fs_utf8::Dir {
     }
 
     #[inline]
-    async fn set_symlink_times<P: AsRef<str> + Send>(
+    async fn set_symlink_times<P: AsRef<Utf8Path> + Send>(
         &self,
         path: P,
         atime: Option<SystemTimeSpec>,
@@ -1086,7 +1108,7 @@ impl AsyncDirExtUtf8 for cap_async_std::fs_utf8::Dir {
 
     #[cfg(not(windows))]
     #[inline]
-    async fn symlink<P: AsRef<str> + Send, Q: AsRef<str> + Send>(
+    async fn symlink<P: AsRef<Utf8Path> + Send, Q: AsRef<Utf8Path> + Send>(
         &self,
         src: P,
         dst: Q,
@@ -1100,7 +1122,7 @@ impl AsyncDirExtUtf8 for cap_async_std::fs_utf8::Dir {
 
     #[cfg(not(windows))]
     #[inline]
-    async fn symlink_file<P: AsRef<str> + Send, Q: AsRef<str> + Send>(
+    async fn symlink_file<P: AsRef<Utf8Path> + Send, Q: AsRef<Utf8Path> + Send>(
         &self,
         src: P,
         dst: Q,
@@ -1110,7 +1132,7 @@ impl AsyncDirExtUtf8 for cap_async_std::fs_utf8::Dir {
 
     #[cfg(not(windows))]
     #[inline]
-    async fn symlink_dir<P: AsRef<str> + Send, Q: AsRef<str> + Send>(
+    async fn symlink_dir<P: AsRef<Utf8Path> + Send, Q: AsRef<Utf8Path> + Send>(
         &self,
         src: P,
         dst: Q,
@@ -1120,7 +1142,7 @@ impl AsyncDirExtUtf8 for cap_async_std::fs_utf8::Dir {
 
     #[cfg(windows)]
     #[inline]
-    async fn symlink<P: AsRef<str> + Send, Q: AsRef<str> + Send>(
+    async fn symlink<P: AsRef<Utf8Path> + Send, Q: AsRef<Utf8Path> + Send>(
         &self,
         src: P,
         dst: Q,
@@ -1154,7 +1176,7 @@ impl AsyncDirExtUtf8 for cap_async_std::fs_utf8::Dir {
 
     #[cfg(windows)]
     #[inline]
-    async fn symlink_file<P: AsRef<str> + Send, Q: AsRef<str> + Send>(
+    async fn symlink_file<P: AsRef<Utf8Path> + Send, Q: AsRef<Utf8Path> + Send>(
         &self,
         src: P,
         dst: Q,
@@ -1168,7 +1190,7 @@ impl AsyncDirExtUtf8 for cap_async_std::fs_utf8::Dir {
 
     #[cfg(windows)]
     #[inline]
-    async fn symlink_dir<P: AsRef<str> + Send, Q: AsRef<str> + Send>(
+    async fn symlink_dir<P: AsRef<Utf8Path> + Send, Q: AsRef<Utf8Path> + Send>(
         &self,
         src: P,
         dst: Q,
@@ -1181,7 +1203,7 @@ impl AsyncDirExtUtf8 for cap_async_std::fs_utf8::Dir {
     }
 
     #[inline]
-    async fn open_dir_nofollow<P: AsRef<str> + Send>(&self, path: P) -> io::Result<Self> {
+    async fn open_dir_nofollow<P: AsRef<Utf8Path> + Send>(&self, path: P) -> io::Result<Self> {
         let path = from_utf8(path)?;
         let clone = self.clone();
         spawn_blocking(move || {
@@ -1195,13 +1217,13 @@ impl AsyncDirExtUtf8 for cap_async_std::fs_utf8::Dir {
 
     #[cfg(not(windows))]
     #[inline]
-    async fn remove_file_or_symlink<P: AsRef<str> + Send>(&self, path: P) -> io::Result<()> {
+    async fn remove_file_or_symlink<P: AsRef<Utf8Path> + Send>(&self, path: P) -> io::Result<()> {
         self.remove_file(path).await
     }
 
     #[cfg(windows)]
     #[inline]
-    async fn remove_file_or_symlink<P: AsRef<str> + Send>(&self, path: P) -> io::Result<()> {
+    async fn remove_file_or_symlink<P: AsRef<Utf8Path> + Send>(&self, path: P) -> io::Result<()> {
         use crate::{FollowSymlinks, OpenOptionsFollowExt};
         use cap_primitives::fs::_WindowsByHandle;
         use cap_std::fs::OpenOptions;
@@ -1236,7 +1258,7 @@ impl AsyncDirExtUtf8 for cap_async_std::fs_utf8::Dir {
 }
 
 #[cfg(all(any(feature = "std", feature = "async_std"), feature = "fs_utf8"))]
-fn from_utf8<P: AsRef<str>>(path: P) -> std::io::Result<std::path::PathBuf> {
+fn from_utf8<P: AsRef<Utf8Path>>(path: P) -> std::io::Result<std::path::PathBuf> {
     #[cfg(not(windows))]
     let path = {
         #[cfg(unix)]
@@ -1244,12 +1266,12 @@ fn from_utf8<P: AsRef<str>>(path: P) -> std::io::Result<std::path::PathBuf> {
         #[cfg(target_os = "wasi")]
         use std::{ffi::OsString, os::wasi::ffi::OsStringExt};
 
-        let string = arf_strings::str_to_host(path.as_ref())?;
+        let string = arf_strings::str_to_host(path.as_ref().as_str())?;
         OsString::from_vec(string.into_bytes())
     };
 
     #[cfg(windows)]
-    let path = arf_strings::str_to_host(path.as_ref())?;
+    let path = arf_strings::str_to_host(path.as_ref().as_str())?;
 
     Ok(path.into())
 }

--- a/cap-std/Cargo.toml
+++ b/cap-std/Cargo.toml
@@ -21,13 +21,14 @@ cap-primitives = { path = "../cap-primitives", version = "^0.18.1-alpha.0"}
 ipnet = "2.3.0"
 unsafe-io = "0.9.1"
 io-lifetimes = { version = "0.3.0", default-features = false }
+camino = { version = "1.0.5", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
 rsix = "0.20.0"
 
 [features]
 default = []
-fs_utf8 = ["arf-strings"]
+fs_utf8 = ["arf-strings", "camino"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/cap-std/src/fs_utf8/dir.rs
+++ b/cap-std/src/fs_utf8/dir.rs
@@ -2,6 +2,7 @@ use crate::fs::{OpenOptions, Permissions};
 use crate::fs_utf8::{from_utf8, to_utf8, DirBuilder, File, Metadata, ReadDir};
 #[cfg(unix)]
 use crate::os::unix::net::{UnixDatagram, UnixListener, UnixStream};
+use camino::{Utf8Path, Utf8PathBuf};
 use cap_primitives::{ambient_authority, AmbientAuthority};
 #[cfg(not(windows))]
 use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
@@ -57,7 +58,7 @@ impl Dir {
     /// This corresponds to [`std::fs::File::open`], but only accesses paths
     /// relative to `self`.
     #[inline]
-    pub fn open<P: AsRef<str>>(&self, path: P) -> io::Result<File> {
+    pub fn open<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<File> {
         let path = from_utf8(path)?;
         self.cap_std.open(path).map(File::from_cap_std)
     }
@@ -69,7 +70,11 @@ impl Dir {
     /// Instead of being a method on `OpenOptions`, this is a method on `Dir`,
     /// and it only accesses paths relative to `self`.
     #[inline]
-    pub fn open_with<P: AsRef<str>>(&self, path: P, options: &OpenOptions) -> io::Result<File> {
+    pub fn open_with<P: AsRef<Utf8Path>>(
+        &self,
+        path: P,
+        options: &OpenOptions,
+    ) -> io::Result<File> {
         let path = from_utf8(path)?;
         self.cap_std
             .open_with(path, options)
@@ -78,7 +83,7 @@ impl Dir {
 
     /// Attempts to open a directory.
     #[inline]
-    pub fn open_dir<P: AsRef<str>>(&self, path: P) -> io::Result<Self> {
+    pub fn open_dir<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<Self> {
         let path = from_utf8(path)?;
         self.cap_std.open_dir(path).map(Self::from_cap_std)
     }
@@ -88,7 +93,7 @@ impl Dir {
     /// This corresponds to [`std::fs::create_dir`], but only accesses paths
     /// relative to `self`.
     #[inline]
-    pub fn create_dir<P: AsRef<str>>(&self, path: P) -> io::Result<()> {
+    pub fn create_dir<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<()> {
         let path = from_utf8(path)?;
         self.cap_std.create_dir(path)
     }
@@ -99,7 +104,7 @@ impl Dir {
     /// This corresponds to [`std::fs::create_dir_all`], but only accesses
     /// paths relative to `self`.
     #[inline]
-    pub fn create_dir_all<P: AsRef<str>>(&self, path: P) -> io::Result<()> {
+    pub fn create_dir_all<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<()> {
         let path = from_utf8(path)?;
         self.cap_std.create_dir_all(path)
     }
@@ -109,7 +114,7 @@ impl Dir {
     ///
     /// This corresponds to [`std::fs::DirBuilder::create`].
     #[inline]
-    pub fn create_dir_with<P: AsRef<str>>(
+    pub fn create_dir_with<P: AsRef<Utf8Path>>(
         &self,
         path: P,
         dir_builder: &DirBuilder,
@@ -123,7 +128,7 @@ impl Dir {
     /// This corresponds to [`std::fs::File::create`], but only accesses paths
     /// relative to `self`.
     #[inline]
-    pub fn create<P: AsRef<str>>(&self, path: P) -> io::Result<File> {
+    pub fn create<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<File> {
         let path = from_utf8(path)?;
         self.cap_std.create(path).map(File::from_cap_std)
     }
@@ -135,7 +140,7 @@ impl Dir {
     /// an absolute path, returns a path relative to the directory
     /// represented by `self`.
     #[inline]
-    pub fn canonicalize<P: AsRef<str>>(&self, path: P) -> io::Result<String> {
+    pub fn canonicalize<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<Utf8PathBuf> {
         let path = from_utf8(path)?;
         self.cap_std.canonicalize(path).and_then(to_utf8)
     }
@@ -147,7 +152,7 @@ impl Dir {
     /// This corresponds to [`std::fs::copy`], but only accesses paths
     /// relative to `self`.
     #[inline]
-    pub fn copy<P: AsRef<str>, Q: AsRef<str>>(
+    pub fn copy<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(
         &self,
         from: P,
         to_dir: &Self,
@@ -163,7 +168,7 @@ impl Dir {
     /// This corresponds to [`std::fs::hard_link`], but only accesses paths
     /// relative to `self`.
     #[inline]
-    pub fn hard_link<P: AsRef<str>, Q: AsRef<str>>(
+    pub fn hard_link<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(
         &self,
         src: P,
         dst_dir: &Self,
@@ -180,7 +185,7 @@ impl Dir {
     /// This corresponds to [`std::fs::metadata`], but only accesses paths
     /// relative to `self`.
     #[inline]
-    pub fn metadata<P: AsRef<str>>(&self, path: P) -> io::Result<Metadata> {
+    pub fn metadata<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<Metadata> {
         let path = from_utf8(path)?;
         self.cap_std.metadata(path)
     }
@@ -196,7 +201,7 @@ impl Dir {
     /// This corresponds to [`std::fs::read_dir`], but only accesses paths
     /// relative to `self`.
     #[inline]
-    pub fn read_dir<P: AsRef<str>>(&self, path: P) -> io::Result<ReadDir> {
+    pub fn read_dir<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<ReadDir> {
         let path = from_utf8(path)?;
         self.cap_std.read_dir(path).map(ReadDir::from_cap_std)
     }
@@ -206,7 +211,7 @@ impl Dir {
     /// This corresponds to [`std::fs::read`], but only accesses paths
     /// relative to `self`.
     #[inline]
-    pub fn read<P: AsRef<str>>(&self, path: P) -> io::Result<Vec<u8>> {
+    pub fn read<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<Vec<u8>> {
         let path = from_utf8(path)?;
         self.cap_std.read(path)
     }
@@ -216,7 +221,7 @@ impl Dir {
     /// This corresponds to [`std::fs::read_link`], but only accesses paths
     /// relative to `self`.
     #[inline]
-    pub fn read_link<P: AsRef<str>>(&self, path: P) -> io::Result<String> {
+    pub fn read_link<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<Utf8PathBuf> {
         let path = from_utf8(path)?;
         self.cap_std.read_link(path).and_then(to_utf8)
     }
@@ -226,7 +231,7 @@ impl Dir {
     /// This corresponds to [`std::fs::read_to_string`], but only accesses
     /// paths relative to `self`.
     #[inline]
-    pub fn read_to_string<P: AsRef<str>>(&self, path: P) -> io::Result<String> {
+    pub fn read_to_string<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<String> {
         let path = from_utf8(path)?;
         self.cap_std.read_to_string(path)
     }
@@ -236,7 +241,7 @@ impl Dir {
     /// This corresponds to [`std::fs::remove_dir`], but only accesses paths
     /// relative to `self`.
     #[inline]
-    pub fn remove_dir<P: AsRef<str>>(&self, path: P) -> io::Result<()> {
+    pub fn remove_dir<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<()> {
         let path = from_utf8(path)?;
         self.cap_std.remove_dir(path)
     }
@@ -247,7 +252,7 @@ impl Dir {
     /// This corresponds to [`std::fs::remove_dir_all`], but only accesses
     /// paths relative to `self`.
     #[inline]
-    pub fn remove_dir_all<P: AsRef<str>>(&self, path: P) -> io::Result<()> {
+    pub fn remove_dir_all<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<()> {
         let path = from_utf8(path)?;
         self.cap_std.remove_dir_all(path)
     }
@@ -278,7 +283,7 @@ impl Dir {
     /// This corresponds to [`std::fs::remove_file`], but only accesses paths
     /// relative to `self`.
     #[inline]
-    pub fn remove_file<P: AsRef<str>>(&self, path: P) -> io::Result<()> {
+    pub fn remove_file<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<()> {
         let path = from_utf8(path)?;
         self.cap_std.remove_file(path)
     }
@@ -289,7 +294,7 @@ impl Dir {
     /// This corresponds to [`std::fs::rename`], but only accesses paths
     /// relative to `self`.
     #[inline]
-    pub fn rename<P: AsRef<str>, Q: AsRef<str>>(
+    pub fn rename<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(
         &self,
         from: P,
         to_dir: &Self,
@@ -306,7 +311,11 @@ impl Dir {
     /// paths relative to `self`. Also, on some platforms, this function
     /// may fail if the file or directory cannot be opened for reading or
     /// writing first.
-    pub fn set_permissions<P: AsRef<str>>(&self, path: P, perm: Permissions) -> io::Result<()> {
+    pub fn set_permissions<P: AsRef<Utf8Path>>(
+        &self,
+        path: P,
+        perm: Permissions,
+    ) -> io::Result<()> {
         let path = from_utf8(path)?;
         self.cap_std.set_permissions(path, perm)
     }
@@ -316,7 +325,7 @@ impl Dir {
     /// This corresponds to [`std::fs::symlink_metadata`], but only accesses
     /// paths relative to `self`.
     #[inline]
-    pub fn symlink_metadata<P: AsRef<str>>(&self, path: P) -> io::Result<Metadata> {
+    pub fn symlink_metadata<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<Metadata> {
         let path = from_utf8(path)?;
         self.cap_std.symlink_metadata(path)
     }
@@ -326,7 +335,11 @@ impl Dir {
     /// This corresponds to [`std::fs::write`], but only accesses paths
     /// relative to `self`.
     #[inline]
-    pub fn write<P: AsRef<str>, C: AsRef<[u8]>>(&self, path: P, contents: C) -> io::Result<()> {
+    pub fn write<P: AsRef<Utf8Path>, C: AsRef<[u8]>>(
+        &self,
+        path: P,
+        contents: C,
+    ) -> io::Result<()> {
         let path = from_utf8(path)?;
         self.cap_std.write(path, contents)
     }
@@ -339,7 +352,11 @@ impl Dir {
     /// [`std::os::unix::fs::symlink`]: https://doc.rust-lang.org/std/os/unix/fs/fn.symlink.html
     #[cfg(not(windows))]
     #[inline]
-    pub fn symlink<P: AsRef<str>, Q: AsRef<str>>(&self, src: P, dst: Q) -> io::Result<()> {
+    pub fn symlink<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(
+        &self,
+        src: P,
+        dst: Q,
+    ) -> io::Result<()> {
         let src = from_utf8(src)?;
         let dst = from_utf8(dst)?;
         self.cap_std.symlink(src, dst)
@@ -353,7 +370,11 @@ impl Dir {
     /// [`std::os::windows::fs::symlink_file`]: https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_file.html
     #[cfg(windows)]
     #[inline]
-    pub fn symlink_file<P: AsRef<str>, Q: AsRef<str>>(&self, src: P, dst: Q) -> io::Result<()> {
+    pub fn symlink_file<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(
+        &self,
+        src: P,
+        dst: Q,
+    ) -> io::Result<()> {
         let src = from_utf8(src)?;
         let dst = from_utf8(dst)?;
         self.cap_std.symlink_file(src, dst)
@@ -367,7 +388,11 @@ impl Dir {
     /// [`std::os::windows::fs::symlink_dir`]: https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_dir.html
     #[cfg(windows)]
     #[inline]
-    pub fn symlink_dir<P: AsRef<str>, Q: AsRef<str>>(&self, src: P, dst: Q) -> io::Result<()> {
+    pub fn symlink_dir<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(
+        &self,
+        src: P,
+        dst: Q,
+    ) -> io::Result<()> {
         let src = from_utf8(src)?;
         let dst = from_utf8(dst)?;
         self.cap_std.symlink_dir(src, dst)
@@ -383,7 +408,7 @@ impl Dir {
     /// [`std::os::unix::net::UnixListener::bind`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixListener.html#method.bind
     #[cfg(unix)]
     #[inline]
-    pub fn bind_unix_listener<P: AsRef<str>>(&self, path: P) -> io::Result<UnixListener> {
+    pub fn bind_unix_listener<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<UnixListener> {
         let path = from_utf8(path)?;
         self.cap_std.bind_unix_listener(path)
     }
@@ -398,7 +423,7 @@ impl Dir {
     /// [`std::os::unix::net::UnixStream::connect`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixStream.html#method.connect
     #[cfg(unix)]
     #[inline]
-    pub fn connect_unix_stream<P: AsRef<str>>(&self, path: P) -> io::Result<UnixStream> {
+    pub fn connect_unix_stream<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<UnixStream> {
         let path = from_utf8(path)?;
         self.cap_std.connect_unix_stream(path)
     }
@@ -413,7 +438,7 @@ impl Dir {
     /// [`std::os::unix::net::UnixDatagram::bind`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.bind
     #[cfg(unix)]
     #[inline]
-    pub fn bind_unix_datagram<P: AsRef<str>>(&self, path: P) -> io::Result<UnixDatagram> {
+    pub fn bind_unix_datagram<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<UnixDatagram> {
         let path = from_utf8(path)?;
         self.cap_std.bind_unix_datagram(path)
     }
@@ -428,7 +453,7 @@ impl Dir {
     /// [`std::os::unix::net::UnixDatagram::connect`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.connect
     #[cfg(unix)]
     #[inline]
-    pub fn connect_unix_datagram<P: AsRef<str>>(
+    pub fn connect_unix_datagram<P: AsRef<Utf8Path>>(
         &self,
         unix_datagram: &UnixDatagram,
         path: P,
@@ -447,7 +472,7 @@ impl Dir {
     /// [`std::os::unix::net::UnixDatagram::send_to`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.send_to
     #[cfg(unix)]
     #[inline]
-    pub fn send_to_unix_datagram_addr<P: AsRef<str>>(
+    pub fn send_to_unix_datagram_addr<P: AsRef<Utf8Path>>(
         &self,
         unix_datagram: &UnixDatagram,
         buf: &[u8],
@@ -472,7 +497,7 @@ impl Dir {
     /// This corresponds to [`std::path::Path::exists`], but only
     /// accesses paths relative to `self`.
     #[inline]
-    pub fn exists<P: AsRef<str>>(&self, path: P) -> bool {
+    pub fn exists<P: AsRef<Utf8Path>>(&self, path: P) -> bool {
         match from_utf8(path) {
             Ok(path) => self.cap_std.exists(path),
             Err(_) => false,
@@ -485,7 +510,7 @@ impl Dir {
     /// This corresponds to [`std::path::Path::is_file`], but only
     /// accesses paths relative to `self`.
     #[inline]
-    pub fn is_file<P: AsRef<str>>(&self, path: P) -> bool {
+    pub fn is_file<P: AsRef<Utf8Path>>(&self, path: P) -> bool {
         match from_utf8(path) {
             Ok(path) => self.cap_std.is_file(path),
             Err(_) => false,
@@ -499,7 +524,7 @@ impl Dir {
     /// traverse symbolic links to query information about the destination
     /// file. In case of broken symbolic links, this will return `false`.
     #[inline]
-    pub fn is_dir<P: AsRef<str>>(&self, path: P) -> bool {
+    pub fn is_dir<P: AsRef<Utf8Path>>(&self, path: P) -> bool {
         match from_utf8(path) {
             Ok(path) => self.cap_std.is_dir(path),
             Err(_) => false,
@@ -514,7 +539,7 @@ impl Dir {
     /// This function is not sandboxed and may access any path that the host
     /// process has access to.
     #[inline]
-    pub fn open_ambient_dir<P: AsRef<str>>(
+    pub fn open_ambient_dir<P: AsRef<Utf8Path>>(
         path: P,
         ambient_authority: AmbientAuthority,
     ) -> io::Result<Self> {

--- a/cap-std/src/fs_utf8/dir_entry.rs
+++ b/cap-std/src/fs_utf8/dir_entry.rs
@@ -85,7 +85,7 @@ impl DirEntry {
     pub fn file_name(&self) -> String {
         // Unwrap because we can assume that paths coming from the OS don't
         // have embedded NULs.
-        to_utf8(self.cap_std.file_name()).unwrap()
+        to_utf8(self.cap_std.file_name()).unwrap().into()
     }
 }
 

--- a/cap-std/src/fs_utf8/file.rs
+++ b/cap-std/src/fs_utf8/file.rs
@@ -1,5 +1,6 @@
 use crate::fs::{Metadata, OpenOptions, Permissions};
 use crate::fs_utf8::from_utf8;
+use camino::Utf8Path;
 use cap_primitives::{ambient_authority, AmbientAuthority};
 #[cfg(not(windows))]
 use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
@@ -125,7 +126,7 @@ impl File {
     /// This function is not sandboxed and may access any path that the host
     /// process has access to.
     #[inline]
-    pub fn open_ambient<P: AsRef<str>>(
+    pub fn open_ambient<P: AsRef<Utf8Path>>(
         path: P,
         ambient_authority: AmbientAuthority,
     ) -> io::Result<Self> {
@@ -145,7 +146,7 @@ impl File {
     /// This function is not sandboxed and may access any path that the host
     /// process has access to.
     #[inline]
-    pub fn open_ambient_with<P: AsRef<str>>(
+    pub fn open_ambient_with<P: AsRef<Utf8Path>>(
         path: P,
         options: &OpenOptions,
         ambient_authority: AmbientAuthority,
@@ -506,13 +507,16 @@ impl std::os::wasi::fs::FileExt for File {
     }
 
     #[inline]
-    fn create_directory<P: AsRef<str>>(&self, dir: P) -> std::result::Result<(), std::io::Error> {
+    fn create_directory<P: AsRef<Utf8Path>>(
+        &self,
+        dir: P,
+    ) -> std::result::Result<(), std::io::Error> {
         let path = from_utf8(path)?;
         self.cap_std.create_directory(dir)
     }
 
     #[inline]
-    fn read_link<P: AsRef<str>>(
+    fn read_link<P: AsRef<Utf8Path>>(
         &self,
         path: P,
     ) -> std::result::Result<std::path::PathBuf, std::io::Error> {
@@ -521,7 +525,7 @@ impl std::os::wasi::fs::FileExt for File {
     }
 
     #[inline]
-    fn metadata_at<P: AsRef<str>>(
+    fn metadata_at<P: AsRef<Utf8Path>>(
         &self,
         lookup_flags: u32,
         path: P,
@@ -531,13 +535,16 @@ impl std::os::wasi::fs::FileExt for File {
     }
 
     #[inline]
-    fn remove_file<P: AsRef<str>>(&self, path: P) -> std::result::Result<(), std::io::Error> {
+    fn remove_file<P: AsRef<Utf8Path>>(&self, path: P) -> std::result::Result<(), std::io::Error> {
         let path = from_utf8(path)?;
         self.cap_std.remove_file(path)
     }
 
     #[inline]
-    fn remove_directory<P: AsRef<str>>(&self, path: P) -> std::result::Result<(), std::io::Error> {
+    fn remove_directory<P: AsRef<Utf8Path>>(
+        &self,
+        path: P,
+    ) -> std::result::Result<(), std::io::Error> {
         let path = from_utf8(path)?;
         self.cap_std.remove_directory(path)
     }

--- a/cap-std/src/fs_utf8/mod.rs
+++ b/cap-std/src/fs_utf8/mod.rs
@@ -1,7 +1,8 @@
 //! A fully UTF-8 filesystem API modeled after [`cap_std::fs`].
 //!
 //! Where `cap_std::fs` would use `Path` and `PathBuf`, this `fs_utf8` module
-//! uses `str` and `String`, meaning that all paths are valid UTF-8.
+//! uses [`Utf8Path`] and [`Utf8PathBuf`], meaning that all paths are valid
+//! UTF-8.
 //!
 //! But wait, POSIX doesn't require filenames to be UTF-8! What happens if
 //! there's a file with a non-UTF-8 name? To address this, this module uses
@@ -32,7 +33,9 @@ pub use read_dir::ReadDir;
 // Re-export things from `cap_std::fs` that we can use as-is.
 pub use crate::fs::{DirBuilder, FileType, Metadata, OpenOptions, Permissions};
 
-fn from_utf8<P: AsRef<str>>(path: P) -> std::io::Result<std::path::PathBuf> {
+use camino::{Utf8Path, Utf8PathBuf};
+
+fn from_utf8<P: AsRef<Utf8Path>>(path: P) -> std::io::Result<std::path::PathBuf> {
     #[cfg(not(windows))]
     let path = {
         #[cfg(unix)]
@@ -40,28 +43,30 @@ fn from_utf8<P: AsRef<str>>(path: P) -> std::io::Result<std::path::PathBuf> {
         #[cfg(target_os = "wasi")]
         use std::{ffi::OsString, os::wasi::ffi::OsStringExt};
 
-        let string = arf_strings::str_to_host(path.as_ref())?;
+        let string = arf_strings::str_to_host(path.as_ref().as_str())?;
         OsString::from_vec(string.into_bytes())
     };
 
     #[cfg(windows)]
-    let path = arf_strings::str_to_host(path.as_ref())?;
+    let path = arf_strings::str_to_host(path.as_ref().as_str())?;
 
     Ok(path.into())
 }
 
-fn to_utf8<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<String> {
+fn to_utf8<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<Utf8PathBuf> {
     // For now, for WASI use the same logic as other OS's, but
     // in the future, the idea is we could avoid this.
     let osstr = path.as_ref().as_os_str();
 
     #[cfg(not(windows))]
     {
-        arf_strings::host_os_str_to_str(osstr).map(std::borrow::Cow::into_owned)
+        arf_strings::host_os_str_to_str(osstr)
+            .map(std::borrow::Cow::into_owned)
+            .map(Into::into)
     }
 
     #[cfg(windows)]
     {
-        arf_strings::host_to_str(osstr)
+        arf_strings::host_to_str(osstr).map(Into::into)
     }
 }

--- a/cap-tempfile/Cargo.toml
+++ b/cap-tempfile/Cargo.toml
@@ -15,12 +15,17 @@ edition = "2018"
 [dependencies]
 cap-std = { path = "../cap-std", version = "^0.18.1-alpha.0"}
 uuid = { version = "0.8.1", features = ["v4"] }
+camino = { version = "1.0.5", optional = true }
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
 rand = "0.8.1"
 
 [target.'cfg(windows)'.dev-dependencies]
 winapi = "0.3.9"
+
+[features]
+default = []
+fs_utf8 = ["cap-std/fs_utf8", "camino"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/tests/fs_utf8.rs
+++ b/tests/fs_utf8.rs
@@ -1,0 +1,1455 @@
+// This file is derived from Rust's library/std/src/fs.rs at revision
+// 108e90ca78f052c0c1c49c42a22c85620be19712.
+//
+// This is the contents of the `tests` module, ported to use `cap_std`.
+
+#[macro_use]
+mod sys_common;
+
+use std::io::prelude::*;
+
+use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
+use cap_std::ambient_authority;
+use cap_std::fs_utf8::{self as fs, Dir, OpenOptions};
+use std::io::{self, ErrorKind, SeekFrom};
+use std::str;
+#[cfg(not(racy_asserts))] // racy asserts are racy
+use std::thread;
+use sys_common::io::{tmpdir_utf8 as tmpdir, TempDirUtf8 as TempDir};
+use sys_common::symlink_junction_utf8 as symlink_junction;
+
+use rand::rngs::StdRng;
+use rand::{RngCore, SeedableRng};
+
+#[cfg(not(windows))]
+fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(src: P, tmpdir: &TempDir, dst: Q) -> io::Result<()> {
+    tmpdir.symlink(src, dst)
+}
+#[cfg(not(windows))]
+fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(
+    src: P,
+    tmpdir: &TempDir,
+    dst: Q,
+) -> io::Result<()> {
+    tmpdir.symlink(src, dst)
+}
+#[cfg(windows)]
+fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(src: P, tmpdir: &TempDir, dst: Q) -> io::Result<()> {
+    tmpdir.symlink_dir(src, dst)
+}
+#[cfg(windows)]
+fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(
+    src: P,
+    tmpdir: &TempDir,
+    dst: Q,
+) -> io::Result<()> {
+    tmpdir.symlink_file(src, dst)
+}
+
+// Several test fail on windows if the user does not have permission to
+// create symlinks (the `SeCreateSymbolicLinkPrivilege`). Instead of
+// disabling these test on Windows, use this function to test whether we
+// have permission, and return otherwise. This way, we still don't run these
+// tests most of the time, but at least we do if the user has the right
+// permissions.
+pub fn got_symlink_permission(tmpdir: &TempDir) -> bool {
+    if cfg!(unix) {
+        return true;
+    }
+    let link = "some_hopefully_unique_link_name";
+
+    match symlink_file(r"nonexisting_target", tmpdir, link) {
+        Ok(_) => true,
+        // ERROR_PRIVILEGE_NOT_HELD = 1314
+        Err(ref err) if err.raw_os_error() == Some(1314) => false,
+        Err(_) => true,
+    }
+}
+
+#[test]
+fn file_test_io_smoke_test() {
+    let message = "it's alright. have a good time";
+    let tmpdir = tmpdir();
+    let filename = "file_rt_io_file_test.txt";
+    {
+        let mut write_stream = check!(tmpdir.create(filename));
+        check!(write_stream.write(message.as_bytes()));
+    }
+    {
+        let mut read_stream = check!(tmpdir.open(filename));
+        let mut read_buf = [0; 1028];
+        let read_str = match check!(read_stream.read(&mut read_buf)) {
+            0 => panic!("shouldn't happen"),
+            n => str::from_utf8(&read_buf[..n]).unwrap().to_string(),
+        };
+        assert_eq!(read_str, message);
+    }
+    check!(tmpdir.remove_file(filename));
+}
+
+#[test]
+fn invalid_path_raises() {
+    let tmpdir = tmpdir();
+    let filename = "file_that_does_not_exist.txt";
+    let result = tmpdir.open(filename);
+
+    #[cfg(any(all(unix, not(target_os = "vxworks")), target_os = "wasi"))]
+    error!(result, "No such file or directory");
+    #[cfg(target_os = "vxworks")]
+    error!(result, "no such file or directory");
+    #[cfg(windows)]
+    error!(result, 2); // ERROR_FILE_NOT_FOUND
+}
+
+#[test]
+fn file_test_iounlinking_invalid_path_should_raise_condition() {
+    let tmpdir = tmpdir();
+    let filename = "file_another_file_that_does_not_exist.txt";
+
+    let result = tmpdir.remove_file(filename);
+
+    #[cfg(any(all(unix, not(target_os = "vxworks")), target_os = "wasi"))]
+    error!(result, "No such file or directory");
+    #[cfg(target_os = "vxworks")]
+    error!(result, "no such file or directory");
+    #[cfg(windows)]
+    error!(result, 2); // ERROR_FILE_NOT_FOUND
+}
+
+#[test]
+fn file_test_io_non_positional_read() {
+    let message: &str = "ten-four";
+    let mut read_mem = [0; 8];
+    let tmpdir = tmpdir();
+    let filename = "file_rt_io_file_test_positional.txt";
+    {
+        let mut rw_stream = check!(tmpdir.create(filename));
+        check!(rw_stream.write(message.as_bytes()));
+    }
+    {
+        let mut read_stream = check!(tmpdir.open(filename));
+        {
+            let read_buf = &mut read_mem[0..4];
+            check!(read_stream.read(read_buf));
+        }
+        {
+            let read_buf = &mut read_mem[4..8];
+            check!(read_stream.read(read_buf));
+        }
+    }
+    check!(tmpdir.remove_file(filename));
+    let read_str = str::from_utf8(&read_mem).unwrap();
+    assert_eq!(read_str, message);
+}
+
+#[test]
+fn file_test_io_seek_and_tell_smoke_test() {
+    let message = "ten-four";
+    let mut read_mem = [0; 4];
+    let set_cursor = 4 as u64;
+    let tell_pos_pre_read;
+    let tell_pos_post_read;
+    let tmpdir = tmpdir();
+    let filename = "file_rt_io_file_test_seeking.txt";
+    {
+        let mut rw_stream = check!(tmpdir.create(filename));
+        check!(rw_stream.write(message.as_bytes()));
+    }
+    {
+        let mut read_stream = check!(tmpdir.open(filename));
+        check!(read_stream.seek(SeekFrom::Start(set_cursor)));
+        tell_pos_pre_read = check!(read_stream.seek(SeekFrom::Current(0)));
+        check!(read_stream.read(&mut read_mem));
+        tell_pos_post_read = check!(read_stream.seek(SeekFrom::Current(0)));
+    }
+    check!(tmpdir.remove_file(filename));
+    let read_str = str::from_utf8(&read_mem).unwrap();
+    assert_eq!(read_str, &message[4..8]);
+    assert_eq!(tell_pos_pre_read, set_cursor);
+    assert_eq!(tell_pos_post_read, message.len() as u64);
+}
+
+#[test]
+fn file_test_io_seek_and_write() {
+    let initial_msg = "food-is-yummy";
+    let overwrite_msg = "-the-bar!!";
+    let final_msg = "foo-the-bar!!";
+    let seek_idx = 3;
+    let mut read_mem = [0; 13];
+    let tmpdir = tmpdir();
+    let filename = "file_rt_io_file_test_seek_and_write.txt";
+    {
+        let mut rw_stream = check!(tmpdir.create(filename));
+        check!(rw_stream.write(initial_msg.as_bytes()));
+        check!(rw_stream.seek(SeekFrom::Start(seek_idx)));
+        check!(rw_stream.write(overwrite_msg.as_bytes()));
+    }
+    {
+        let mut read_stream = check!(tmpdir.open(filename));
+        check!(read_stream.read(&mut read_mem));
+    }
+    check!(tmpdir.remove_file(filename));
+    let read_str = str::from_utf8(&read_mem).unwrap();
+    assert!(read_str == final_msg);
+}
+
+#[test]
+fn file_test_io_seek_shakedown() {
+    //                   01234567890123
+    let initial_msg = "qwer-asdf-zxcv";
+    let chunk_one: &str = "qwer";
+    let chunk_two: &str = "asdf";
+    let chunk_three: &str = "zxcv";
+    let mut read_mem = [0; 4];
+    let tmpdir = tmpdir();
+    let filename = "file_rt_io_file_test_seek_shakedown.txt";
+    {
+        let mut rw_stream = check!(tmpdir.create(filename));
+        check!(rw_stream.write(initial_msg.as_bytes()));
+    }
+    {
+        let mut read_stream = check!(tmpdir.open(filename));
+
+        check!(read_stream.seek(SeekFrom::End(-4)));
+        check!(read_stream.read(&mut read_mem));
+        assert_eq!(str::from_utf8(&read_mem).unwrap(), chunk_three);
+
+        check!(read_stream.seek(SeekFrom::Current(-9)));
+        check!(read_stream.read(&mut read_mem));
+        assert_eq!(str::from_utf8(&read_mem).unwrap(), chunk_two);
+
+        check!(read_stream.seek(SeekFrom::Start(0)));
+        check!(read_stream.read(&mut read_mem));
+        assert_eq!(str::from_utf8(&read_mem).unwrap(), chunk_one);
+    }
+    check!(tmpdir.remove_file(filename));
+}
+
+#[test]
+fn file_test_io_eof() {
+    let tmpdir = tmpdir();
+    let filename = "file_rt_io_file_test_eof.txt";
+    let mut buf = [0; 256];
+    {
+        let oo = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .read(true)
+            .clone();
+        let mut rw = check!(tmpdir.open_with(filename, &oo));
+        assert_eq!(check!(rw.read(&mut buf)), 0);
+        assert_eq!(check!(rw.read(&mut buf)), 0);
+    }
+    check!(tmpdir.remove_file(filename));
+}
+
+#[test]
+#[cfg(unix)]
+fn file_test_io_read_write_at() {
+    use std::os::unix::fs::FileExt;
+
+    let tmpdir = tmpdir();
+    let filename = "file_rt_io_file_test_read_write_at.txt";
+    let mut buf = [0; 256];
+    let write1 = "asdf";
+    let write2 = "qwer-";
+    let write3 = "-zxcv";
+    let content = "qwer-asdf-zxcv";
+    {
+        let oo = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .read(true)
+            .clone();
+        let mut rw = check!(tmpdir.open_with(filename, &oo));
+        assert_eq!(check!(rw.write_at(write1.as_bytes(), 5)), write1.len());
+        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 0);
+        assert_eq!(check!(rw.read_at(&mut buf, 5)), write1.len());
+        assert_eq!(str::from_utf8(&buf[..write1.len()]), Ok(write1));
+        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 0);
+        assert_eq!(
+            check!(rw.read_at(&mut buf[..write2.len()], 0)),
+            write2.len()
+        );
+        assert_eq!(str::from_utf8(&buf[..write2.len()]), Ok("\0\0\0\0\0"));
+        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 0);
+        assert_eq!(check!(rw.write(write2.as_bytes())), write2.len());
+        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 5);
+        assert_eq!(check!(rw.read(&mut buf)), write1.len());
+        assert_eq!(str::from_utf8(&buf[..write1.len()]), Ok(write1));
+        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 9);
+        assert_eq!(
+            check!(rw.read_at(&mut buf[..write2.len()], 0)),
+            write2.len()
+        );
+        assert_eq!(str::from_utf8(&buf[..write2.len()]), Ok(write2));
+        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 9);
+        assert_eq!(check!(rw.write_at(write3.as_bytes(), 9)), write3.len());
+        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 9);
+    }
+    {
+        let mut read = check!(tmpdir.open(filename));
+        assert_eq!(check!(read.read_at(&mut buf, 0)), content.len());
+        assert_eq!(str::from_utf8(&buf[..content.len()]), Ok(content));
+        assert_eq!(check!(read.seek(SeekFrom::Current(0))), 0);
+        assert_eq!(check!(read.seek(SeekFrom::End(-5))), 9);
+        assert_eq!(check!(read.read_at(&mut buf, 0)), content.len());
+        assert_eq!(str::from_utf8(&buf[..content.len()]), Ok(content));
+        assert_eq!(check!(read.seek(SeekFrom::Current(0))), 9);
+        assert_eq!(check!(read.read(&mut buf)), write3.len());
+        assert_eq!(str::from_utf8(&buf[..write3.len()]), Ok(write3));
+        assert_eq!(check!(read.seek(SeekFrom::Current(0))), 14);
+        assert_eq!(check!(read.read_at(&mut buf, 0)), content.len());
+        assert_eq!(str::from_utf8(&buf[..content.len()]), Ok(content));
+        assert_eq!(check!(read.seek(SeekFrom::Current(0))), 14);
+        assert_eq!(check!(read.read_at(&mut buf, 14)), 0);
+        assert_eq!(check!(read.read_at(&mut buf, 15)), 0);
+        assert_eq!(check!(read.seek(SeekFrom::Current(0))), 14);
+    }
+    check!(tmpdir.remove_file(filename));
+}
+
+// Darwin doesn't have a way to change the permissions on a file, relative
+// to a directory handle, with no read or write access, without blindly
+// following symlinks.
+#[test]
+#[cfg(unix)]
+#[cfg_attr(any(target_os = "macos", target_os = "ios"), ignore)]
+fn set_get_unix_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmpdir = tmpdir();
+    let filename = "set_get_unix_permissions";
+    check!(tmpdir.create_dir(filename));
+    let mask = 0o7777;
+
+    check!(tmpdir.set_permissions(filename, fs::Permissions::from_mode(0)));
+    let metadata0 = check!(tmpdir.metadata(filename));
+    assert_eq!(mask & metadata0.permissions().mode(), 0);
+
+    check!(tmpdir.set_permissions(filename, fs::Permissions::from_mode(0o1777)));
+    let metadata1 = check!(tmpdir.metadata(filename));
+    #[cfg(any(all(unix, not(target_os = "vxworks")), target_os = "wasi"))]
+    assert_eq!(mask & metadata1.permissions().mode(), 0o1777);
+    #[cfg(target_os = "vxworks")]
+    assert_eq!(mask & metadata1.permissions().mode(), 0o0777);
+}
+
+#[test]
+#[cfg(windows)]
+fn file_test_io_seek_read_write() {
+    use std::os::windows::fs::FileExt;
+
+    let tmpdir = tmpdir();
+    let filename = "file_rt_io_file_test_seek_read_write.txt";
+    let mut buf = [0; 256];
+    let write1 = "asdf";
+    let write2 = "qwer-";
+    let write3 = "-zxcv";
+    let content = "qwer-asdf-zxcv";
+    {
+        let oo = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .read(true)
+            .clone();
+        let mut rw = check!(tmpdir.open_with(filename, &oo));
+        assert_eq!(check!(rw.seek_write(write1.as_bytes(), 5)), write1.len());
+        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 9);
+        assert_eq!(check!(rw.seek_read(&mut buf, 5)), write1.len());
+        assert_eq!(str::from_utf8(&buf[..write1.len()]), Ok(write1));
+        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 9);
+        assert_eq!(check!(rw.seek(SeekFrom::Start(0))), 0);
+        assert_eq!(check!(rw.write(write2.as_bytes())), write2.len());
+        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 5);
+        assert_eq!(check!(rw.read(&mut buf)), write1.len());
+        assert_eq!(str::from_utf8(&buf[..write1.len()]), Ok(write1));
+        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 9);
+        assert_eq!(
+            check!(rw.seek_read(&mut buf[..write2.len()], 0)),
+            write2.len()
+        );
+        assert_eq!(str::from_utf8(&buf[..write2.len()]), Ok(write2));
+        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 5);
+        assert_eq!(check!(rw.seek_write(write3.as_bytes(), 9)), write3.len());
+        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 14);
+    }
+    {
+        let mut read = check!(tmpdir.open(filename));
+        assert_eq!(check!(read.seek_read(&mut buf, 0)), content.len());
+        assert_eq!(str::from_utf8(&buf[..content.len()]), Ok(content));
+        assert_eq!(check!(read.seek(SeekFrom::Current(0))), 14);
+        assert_eq!(check!(read.seek(SeekFrom::End(-5))), 9);
+        assert_eq!(check!(read.seek_read(&mut buf, 0)), content.len());
+        assert_eq!(str::from_utf8(&buf[..content.len()]), Ok(content));
+        assert_eq!(check!(read.seek(SeekFrom::Current(0))), 14);
+        assert_eq!(check!(read.seek(SeekFrom::End(-5))), 9);
+        assert_eq!(check!(read.read(&mut buf)), write3.len());
+        assert_eq!(str::from_utf8(&buf[..write3.len()]), Ok(write3));
+        assert_eq!(check!(read.seek(SeekFrom::Current(0))), 14);
+        assert_eq!(check!(read.seek_read(&mut buf, 0)), content.len());
+        assert_eq!(str::from_utf8(&buf[..content.len()]), Ok(content));
+        assert_eq!(check!(read.seek(SeekFrom::Current(0))), 14);
+        assert_eq!(check!(read.seek_read(&mut buf, 14)), 0);
+        assert_eq!(check!(read.seek_read(&mut buf, 15)), 0);
+    }
+    check!(tmpdir.remove_file(filename));
+}
+
+#[test]
+fn file_test_stat_is_correct_on_is_file() {
+    let tmpdir = tmpdir();
+    let filename = "file_stat_correct_on_is_file.txt";
+    {
+        let mut opts = OpenOptions::new();
+        let mut fs = check!(tmpdir.open_with(filename, opts.read(true).write(true).create(true)));
+        let msg = "hw";
+        fs.write(msg.as_bytes()).unwrap();
+
+        let fstat_res = check!(fs.metadata());
+        assert!(fstat_res.is_file());
+    }
+    let stat_res_fn = check!(tmpdir.metadata(filename));
+    assert!(stat_res_fn.is_file());
+    check!(tmpdir.remove_file(filename));
+}
+
+#[test]
+fn file_test_stat_is_correct_on_is_dir() {
+    let tmpdir = tmpdir();
+    let filename = "file_stat_correct_on_is_dir";
+    check!(tmpdir.create_dir(filename));
+    let stat_res_fn = check!(tmpdir.metadata(filename));
+    assert!(stat_res_fn.is_dir());
+    check!(tmpdir.remove_dir(filename));
+}
+
+#[test]
+fn file_test_fileinfo_false_when_checking_is_file_on_a_directory() {
+    let tmpdir = tmpdir();
+    let dir = "fileinfo_false_on_dir";
+    check!(tmpdir.create_dir(dir));
+    assert!(!tmpdir.is_file(dir));
+    check!(tmpdir.remove_dir(dir));
+}
+
+#[test]
+fn file_test_fileinfo_check_exists_before_and_after_file_creation() {
+    let tmpdir = tmpdir();
+    let file = "fileinfo_check_exists_b_and_a.txt";
+    check!(check!(tmpdir.create(file)).write(b"foo"));
+    assert!(tmpdir.exists(file));
+    check!(tmpdir.remove_file(file));
+    assert!(!tmpdir.exists(file));
+}
+
+#[test]
+fn file_test_directoryinfo_check_exists_before_and_after_mkdir() {
+    let tmpdir = tmpdir();
+    let dir = "before_and_after_dir";
+    assert!(!tmpdir.exists(dir));
+    check!(tmpdir.create_dir(dir));
+    assert!(tmpdir.exists(dir));
+    assert!(tmpdir.is_dir(dir));
+    check!(tmpdir.remove_dir(dir));
+    assert!(!tmpdir.exists(dir));
+}
+
+#[test]
+fn file_test_directoryinfo_readdir() {
+    let tmpdir = tmpdir();
+    let dir = "di_readdir";
+    check!(tmpdir.create_dir(dir));
+    let prefix = "foo";
+    for n in 0..3 {
+        let f = format!("{}.txt", n);
+        let mut w = check!(tmpdir.create(&f));
+        let msg_str = format!("{}{}", prefix, n.to_string());
+        let msg = msg_str.as_bytes();
+        check!(w.write(msg));
+    }
+    let files = check!(tmpdir.read_dir(dir));
+    let mut mem = [0; 4];
+    for f in files {
+        let f = f.unwrap().file_name();
+        {
+            check!(check!(tmpdir.open(&f)).read(&mut mem));
+            let read_str = str::from_utf8(&mem).unwrap();
+            let expected = format!("{}{}", prefix, f.as_str());
+            assert_eq!(expected, read_str);
+        }
+        check!(tmpdir.remove_file(&f));
+    }
+    check!(tmpdir.remove_dir(dir));
+}
+
+#[test]
+fn file_create_new_already_exists_error() {
+    let tmpdir = tmpdir();
+    let file = "file_create_new_error_exists";
+    check!(tmpdir.create(file));
+    let e = tmpdir
+        .open_with(file, &fs::OpenOptions::new().write(true).create_new(true))
+        .unwrap_err();
+    assert_eq!(e.kind(), ErrorKind::AlreadyExists);
+}
+
+#[test]
+fn mkdir_path_already_exists_error() {
+    let tmpdir = tmpdir();
+    let dir = "mkdir_error_twice";
+    check!(tmpdir.create_dir(dir));
+    let e = tmpdir.create_dir(dir).unwrap_err();
+    assert_eq!(e.kind(), ErrorKind::AlreadyExists);
+}
+
+#[test]
+fn recursive_mkdir() {
+    let tmpdir = tmpdir();
+    let dir = "d1/d2";
+    check!(tmpdir.create_dir_all(dir));
+    assert!(tmpdir.is_dir(dir));
+}
+
+#[test]
+fn recursive_mkdir_failure() {
+    let tmpdir = tmpdir();
+    let dir = "d1";
+    let file = "f1";
+
+    check!(tmpdir.create_dir_all(&dir));
+    check!(tmpdir.create(&file));
+
+    let result = tmpdir.create_dir_all(&file);
+
+    assert!(result.is_err());
+}
+
+#[test]
+#[cfg(not(racy_asserts))] // racy asserts are racy
+fn concurrent_recursive_mkdir() {
+    for _ in 0..100 {
+        let dir = tmpdir();
+        let mut name = PathBuf::from("a");
+        for _ in 0..40 {
+            name = name.join("a");
+        }
+        let mut join = vec![];
+        for _ in 0..8 {
+            let dir = check!(dir.try_clone());
+            let name = name.clone();
+            join.push(thread::spawn(move || {
+                check!(dir.create_dir_all(&name));
+            }))
+        }
+
+        // No `Display` on result of `join()`
+        join.drain(..).map(|join| join.join().unwrap()).count();
+    }
+}
+
+#[test]
+fn recursive_mkdir_slash() {
+    let tmpdir = tmpdir();
+    error_contains!(
+        tmpdir.create_dir_all(Path::new("/")),
+        "a path led outside of the filesystem"
+    );
+}
+
+#[test]
+fn recursive_mkdir_dot() {
+    let tmpdir = tmpdir();
+    check!(tmpdir.create_dir_all(Path::new(".")));
+}
+
+#[test]
+fn recursive_mkdir_empty() {
+    let tmpdir = tmpdir();
+    check!(tmpdir.create_dir_all(Path::new("")));
+}
+
+#[test]
+fn recursive_rmdir() {
+    let tmpdir = tmpdir();
+    let d1 = PathBuf::from("d1");
+    let dt = d1.join("t");
+    let dtt = dt.join("t");
+    let d2 = PathBuf::from("d2");
+    let canary = d2.join("do_not_delete");
+    check!(tmpdir.create_dir_all(&dtt));
+    check!(tmpdir.create_dir_all(&d2));
+    check!(check!(tmpdir.create(&canary)).write(b"foo"));
+    check!(symlink_junction(d2, &tmpdir, &dt.join("d2")));
+    let _ = symlink_file(&canary, &tmpdir, &d1.join("canary"));
+    check!(tmpdir.remove_dir_all(&d1));
+
+    assert!(!tmpdir.is_dir(d1));
+    assert!(tmpdir.exists(canary));
+}
+
+#[test]
+fn recursive_rmdir_of_symlink() {
+    // test we do not recursively delete a symlink but only dirs.
+    let tmpdir = tmpdir();
+    let link = "d1";
+    let dir = "d2";
+    let canary = "do_not_delete";
+    check!(tmpdir.create_dir_all(&dir));
+    check!(check!(tmpdir.create(&canary)).write(b"foo"));
+    check!(symlink_junction(&dir, &tmpdir, link));
+    check!(tmpdir.remove_dir_all(link));
+
+    assert!(!tmpdir.is_dir(link));
+    assert!(tmpdir.exists(canary));
+}
+
+#[test]
+// only Windows makes a distinction between file and directory symlinks.
+#[cfg(windows)]
+fn recursive_rmdir_of_file_symlink() {
+    let tmpdir = tmpdir();
+    if !got_symlink_permission(&tmpdir) {
+        return;
+    };
+
+    let f1 = "f1";
+    let f2 = "f2";
+    check!(check!(tmpdir.create(&f1)).write(b"foo"));
+    check!(symlink_file(&f1, &tmpdir, &f2));
+    match tmpdir.remove_dir_all(&f2) {
+        Ok(..) => panic!("wanted a failure"),
+        Err(..) => {}
+    }
+}
+
+#[test]
+fn unicode_path_is_dir() {
+    let tmpdir = tmpdir();
+
+    assert!(tmpdir.is_dir(Path::new(".")));
+    assert!(!tmpdir.is_dir(Path::new("test/stdtest/fs.rs")));
+
+    let mut dirpath = PathBuf::new();
+    dirpath.push("test-가一ー你好");
+    check!(tmpdir.create_dir(&dirpath));
+    assert!(tmpdir.is_dir(&dirpath));
+
+    let mut filepath = dirpath;
+    filepath.push("unicode-file-\u{ac00}\u{4e00}\u{30fc}\u{4f60}\u{597d}.rs");
+    check!(tmpdir.create(&filepath)); // ignore return; touch only
+    assert!(!tmpdir.is_dir(&filepath));
+    assert!(tmpdir.exists(filepath));
+}
+
+#[test]
+fn unicode_path_exists() {
+    let tmpdir = tmpdir();
+
+    assert!(tmpdir.exists(Path::new(".")));
+    assert!(!tmpdir.exists(Path::new("test/nonexistent-bogus-path")));
+
+    let unicode = PathBuf::new();
+    let unicode = unicode.join("test-각丁ー再见");
+    check!(tmpdir.create_dir(&unicode));
+    assert!(tmpdir.exists(unicode));
+    assert!(!tmpdir.exists(Path::new("test/unicode-bogus-path-각丁ー再见")));
+}
+
+#[test]
+fn copy_file_does_not_exist() {
+    let tmpdir = tmpdir();
+    let from = Path::new("test/nonexistent-bogus-path");
+    let to = Path::new("test/other-bogus-path");
+
+    match tmpdir.copy(&from, &tmpdir, &to) {
+        Ok(..) => panic!(),
+        Err(..) => {
+            assert!(!tmpdir.exists(from));
+            assert!(!tmpdir.exists(to));
+        }
+    }
+}
+
+#[test]
+fn copy_src_does_not_exist() {
+    let tmpdir = tmpdir();
+    let from = Path::new("test/nonexistent-bogus-path");
+    let to = "out.txt";
+    check!(check!(tmpdir.create(&to)).write(b"hello"));
+    assert!(tmpdir.copy(&from, &tmpdir, &to).is_err());
+    assert!(!tmpdir.exists(from));
+    let mut v = Vec::new();
+    check!(check!(tmpdir.open(&to)).read_to_end(&mut v));
+    assert_eq!(v, b"hello");
+}
+
+#[test]
+fn copy_file_ok() {
+    let tmpdir = tmpdir();
+    let input = "in.txt";
+    let out = "out.txt";
+
+    check!(check!(tmpdir.create(&input)).write(b"hello"));
+    check!(tmpdir.copy(&input, &tmpdir, &out));
+    let mut v = Vec::new();
+    check!(check!(tmpdir.open(&out)).read_to_end(&mut v));
+    assert_eq!(v, b"hello");
+
+    assert_eq!(
+        check!(tmpdir.metadata(input)).permissions(),
+        check!(tmpdir.metadata(out)).permissions()
+    );
+}
+
+#[test]
+fn copy_file_dst_dir() {
+    let tmpdir = tmpdir();
+    let out = "out";
+
+    check!(tmpdir.create(&out));
+    match tmpdir.copy(&*out, &tmpdir, ".") {
+        Ok(..) => panic!(),
+        Err(..) => {}
+    }
+}
+
+#[test]
+fn copy_file_dst_exists() {
+    let tmpdir = tmpdir();
+    let input = "in";
+    let output = "out";
+
+    check!(check!(tmpdir.create(&input)).write("foo".as_bytes()));
+    check!(check!(tmpdir.create(&output)).write("bar".as_bytes()));
+    check!(tmpdir.copy(&input, &tmpdir, &output));
+
+    let mut v = Vec::new();
+    check!(check!(tmpdir.open(&output)).read_to_end(&mut v));
+    assert_eq!(v, b"foo".to_vec());
+}
+
+#[test]
+fn copy_file_src_dir() {
+    let tmpdir = tmpdir();
+    let out = "out";
+
+    match tmpdir.copy(".", &tmpdir, &out) {
+        Ok(..) => panic!(),
+        Err(..) => {}
+    }
+    assert!(!tmpdir.exists(out));
+}
+
+#[test]
+fn copy_file_preserves_perm_bits() {
+    let tmpdir = tmpdir();
+    let input = "in.txt";
+    let out = "out.txt";
+
+    let attr = check!(check!(tmpdir.create(&input)).metadata());
+    let mut p = attr.permissions();
+    p.set_readonly(true);
+    check!(tmpdir.set_permissions(&input, p));
+    check!(tmpdir.copy(&input, &tmpdir, &out));
+    assert!(check!(tmpdir.metadata(out)).permissions().readonly());
+    check!(tmpdir.set_permissions(&input, attr.permissions()));
+    check!(tmpdir.set_permissions(&out, attr.permissions()));
+}
+
+#[test]
+#[cfg(windows)]
+fn copy_file_preserves_streams() {
+    let tmp = tmpdir();
+    check!(check!(tmp.create("in.txt:bunny")).write("carrot".as_bytes()));
+    assert_eq!(check!(tmp.copy("in.txt", &tmp, "out.txt")), 0);
+    assert_eq!(check!(tmp.metadata("out.txt")).len(), 0);
+    let mut v = Vec::new();
+    check!(check!(tmp.open("out.txt:bunny")).read_to_end(&mut v));
+    assert_eq!(v, b"carrot".to_vec());
+}
+
+#[test]
+fn copy_file_returns_metadata_len() {
+    let tmp = tmpdir();
+    let in_path = "in.txt";
+    let out_path = "out.txt";
+    check!(check!(tmp.create(&in_path)).write(b"lettuce"));
+    #[cfg(windows)]
+    check!(check!(tmp.create("in.txt:bunny")).write(b"carrot"));
+    let copied_len = check!(tmp.copy(&in_path, &tmp, &out_path));
+    assert_eq!(check!(tmp.metadata(out_path)).len(), copied_len);
+}
+
+#[test]
+fn copy_file_follows_dst_symlink() {
+    let tmp = tmpdir();
+    if !got_symlink_permission(&tmp) {
+        return;
+    };
+
+    let in_path = "in.txt";
+    let out_path = "out.txt";
+    let out_path_symlink = "out_symlink.txt";
+
+    check!(tmp.write(&in_path, "foo"));
+    check!(tmp.write(&out_path, "bar"));
+    check!(symlink_file(&out_path, &tmp, &out_path_symlink));
+
+    check!(tmp.copy(&in_path, &tmp, &out_path_symlink));
+
+    assert!(check!(tmp.symlink_metadata(out_path_symlink))
+        .file_type()
+        .is_symlink());
+    assert_eq!(check!(tmp.read(&out_path_symlink)), b"foo".to_vec());
+    assert_eq!(check!(tmp.read(&out_path)), b"foo".to_vec());
+}
+
+#[test]
+fn symlinks_work() {
+    let tmpdir = tmpdir();
+    if !got_symlink_permission(&tmpdir) {
+        return;
+    };
+
+    let input = "in.txt";
+    let out = "out.txt";
+
+    check!(check!(tmpdir.create(&input)).write("foobar".as_bytes()));
+    check!(symlink_file(&input, &tmpdir, &out));
+    assert!(check!(tmpdir.symlink_metadata(out))
+        .file_type()
+        .is_symlink());
+    assert_eq!(
+        check!(tmpdir.metadata(&out)).len(),
+        check!(tmpdir.metadata(&input)).len()
+    );
+    let mut v = Vec::new();
+    check!(check!(tmpdir.open(&out)).read_to_end(&mut v));
+    assert_eq!(v, b"foobar".to_vec());
+}
+
+#[test]
+fn symlink_noexist() {
+    // Symlinks can point to things that don't exist
+    let tmpdir = tmpdir();
+    if !got_symlink_permission(&tmpdir) {
+        return;
+    };
+
+    // Use a relative path for testing. Symlinks get normalized by Windows,
+    // so we may not get the same path back for absolute paths
+    check!(symlink_file(&"foo", &tmpdir, "bar"));
+    assert_eq!(check!(tmpdir.read_link("bar")).as_str(), "foo");
+}
+
+#[test]
+fn read_link() {
+    if cfg!(windows) {
+        // directory symlink
+        let root = Dir::open_ambient_dir(r"C:\", ambient_authority()).unwrap();
+        error_contains!(
+            root.read_link(r"Users\All Users"),
+            "a path led outside of the filesystem"
+        );
+        // junction
+        error_contains!(
+            root.read_link(r"Users\Default User"),
+            "a path led outside of the filesystem"
+        );
+        // junction with special permissions
+        error_contains!(
+            root.read_link(r"Documents and Settings\"),
+            "a path led outside of the filesystem"
+        );
+    }
+    let tmpdir = tmpdir();
+    let link = "link";
+    if !got_symlink_permission(&tmpdir) {
+        return;
+    };
+    check!(symlink_file(&"foo", &tmpdir, &link));
+    assert_eq!(check!(tmpdir.read_link(&link)).as_str(), "foo");
+}
+
+#[test]
+fn readlink_not_symlink() {
+    let tmpdir = tmpdir();
+    match tmpdir.read_link(".") {
+        Ok(..) => panic!("wanted a failure"),
+        Err(..) => {}
+    }
+}
+
+#[test]
+fn links_work() {
+    let tmpdir = tmpdir();
+    let input = "in.txt";
+    let out = "out.txt";
+
+    check!(check!(tmpdir.create(&input)).write("foobar".as_bytes()));
+    check!(tmpdir.hard_link(&input, &tmpdir, &out));
+    assert_eq!(
+        check!(tmpdir.metadata(&out)).len(),
+        check!(tmpdir.metadata(&input)).len()
+    );
+    assert_eq!(
+        check!(tmpdir.metadata(&out)).len(),
+        check!(tmpdir.metadata(input)).len()
+    );
+    let mut v = Vec::new();
+    check!(check!(tmpdir.open(&out)).read_to_end(&mut v));
+    assert_eq!(v, b"foobar".to_vec());
+
+    // can't link to yourself
+    match tmpdir.hard_link(&input, &tmpdir, &input) {
+        Ok(..) => panic!("wanted a failure"),
+        Err(..) => {}
+    }
+    // can't link to something that doesn't exist
+    match tmpdir.hard_link("foo", &tmpdir, "bar") {
+        Ok(..) => panic!("wanted a failure"),
+        Err(..) => {}
+    }
+}
+
+#[test]
+fn chmod_works() {
+    let tmpdir = tmpdir();
+    let file = "in.txt";
+
+    check!(tmpdir.create(&file));
+    let attr = check!(tmpdir.metadata(&file));
+    assert!(!attr.permissions().readonly());
+    let mut p = attr.permissions();
+    p.set_readonly(true);
+    check!(tmpdir.set_permissions(&file, p.clone()));
+    let attr = check!(tmpdir.metadata(&file));
+    assert!(attr.permissions().readonly());
+
+    match tmpdir.set_permissions("foo", p.clone()) {
+        Ok(..) => panic!("wanted an error"),
+        Err(..) => {}
+    }
+
+    p.set_readonly(false);
+    check!(tmpdir.set_permissions(&file, p));
+}
+
+#[test]
+fn fchmod_works() {
+    let tmpdir = tmpdir();
+    let path = "in.txt";
+
+    let file = check!(tmpdir.create(&path));
+    let attr = check!(tmpdir.metadata(&path));
+    assert!(!attr.permissions().readonly());
+    let mut p = attr.permissions();
+    p.set_readonly(true);
+    check!(file.set_permissions(p.clone()));
+    let attr = check!(tmpdir.metadata(&path));
+    assert!(attr.permissions().readonly());
+
+    p.set_readonly(false);
+    check!(file.set_permissions(p));
+}
+
+#[test]
+fn sync_doesnt_kill_anything() {
+    let tmpdir = tmpdir();
+    let path = "in.txt";
+
+    let mut file = check!(tmpdir.create(&path));
+    check!(file.sync_all());
+    check!(file.sync_data());
+    check!(file.write(b"foo"));
+    check!(file.sync_all());
+    check!(file.sync_data());
+}
+
+#[test]
+fn truncate_works() {
+    let tmpdir = tmpdir();
+    let path = "in.txt";
+
+    let mut file = check!(tmpdir.create(&path));
+    check!(file.write(b"foo"));
+    check!(file.sync_all());
+
+    // Do some simple things with truncation
+    assert_eq!(check!(file.metadata()).len(), 3);
+    check!(file.set_len(10));
+    assert_eq!(check!(file.metadata()).len(), 10);
+    check!(file.write(b"bar"));
+    check!(file.sync_all());
+    assert_eq!(check!(file.metadata()).len(), 10);
+
+    let mut v = Vec::new();
+    check!(check!(tmpdir.open(&path)).read_to_end(&mut v));
+    assert_eq!(v, b"foobar\0\0\0\0".to_vec());
+
+    // Truncate to a smaller length, don't seek, and then write something.
+    // Ensure that the intermediate zeroes are all filled in (we have `seek`ed
+    // past the end of the file).
+    check!(file.set_len(2));
+    assert_eq!(check!(file.metadata()).len(), 2);
+    check!(file.write(b"wut"));
+    check!(file.sync_all());
+    assert_eq!(check!(file.metadata()).len(), 9);
+    let mut v = Vec::new();
+    check!(check!(tmpdir.open(&path)).read_to_end(&mut v));
+    assert_eq!(v, b"fo\0\0\0\0wut".to_vec());
+}
+
+#[test]
+fn open_flavors() {
+    use cap_std::fs::OpenOptions as OO;
+    fn c<T: Clone>(t: &T) -> T {
+        t.clone()
+    }
+
+    let tmpdir = tmpdir();
+
+    let mut r = OO::new();
+    r.read(true);
+    let mut w = OO::new();
+    w.write(true);
+    let mut rw = OO::new();
+    rw.read(true).write(true);
+    let mut a = OO::new();
+    a.append(true);
+    let mut ra = OO::new();
+    ra.read(true).append(true);
+
+    #[cfg(windows)]
+    let invalid_options = 87; // ERROR_INVALID_PARAMETER
+    #[cfg(any(all(unix, not(target_os = "vxworks")), target_os = "wasi"))]
+    let invalid_options = "Invalid argument";
+    #[cfg(target_os = "vxworks")]
+    let invalid_options = "invalid argument";
+
+    // Test various combinations of creation modes and access modes.
+    //
+    // Allowed:
+    // creation mode           | read  | write | read-write | append | read-append
+    // | :-----------------------|:-----:|:-----:|:----------:|:------:|:
+    // -----------:| not set (open existing) |   X   |   X   |     X      |   X
+    // |      X      | create                  |       |   X   |     X      |
+    // X    |      X      | truncate                |       |   X   |     X
+    // |        |             | create and truncate     |       |   X   |     X
+    // |        |             | create_new              |       |   X   |     X
+    // |   X    |      X      |
+    //
+    // tested in reverse order, so 'create_new' creates the file, and 'open
+    // existing' opens it.
+
+    // write-only
+    check!(tmpdir.open_with("a", c(&w).create_new(true)));
+    check!(tmpdir.open_with("a", c(&w).create(true).truncate(true)));
+    check!(tmpdir.open_with("a", c(&w).truncate(true)));
+    check!(tmpdir.open_with("a", c(&w).create(true)));
+    check!(tmpdir.open_with("a", &c(&w)));
+
+    // read-only
+    error!(
+        tmpdir.open_with("b", c(&r).create_new(true)),
+        invalid_options
+    );
+    error!(
+        tmpdir.open_with("b", c(&r).create(true).truncate(true)),
+        invalid_options
+    );
+    error!(tmpdir.open_with("b", c(&r).truncate(true)), invalid_options);
+    error!(tmpdir.open_with("b", c(&r).create(true)), invalid_options);
+    check!(tmpdir.open_with("a", &c(&r))); // try opening the file created with write_only
+
+    // read-write
+    check!(tmpdir.open_with("c", c(&rw).create_new(true)));
+    check!(tmpdir.open_with("c", c(&rw).create(true).truncate(true)));
+    check!(tmpdir.open_with("c", c(&rw).truncate(true)));
+    check!(tmpdir.open_with("c", c(&rw).create(true)));
+    check!(tmpdir.open_with("c", &c(&rw)));
+
+    // append
+    check!(tmpdir.open_with("d", c(&a).create_new(true)));
+    error!(
+        tmpdir.open_with("d", c(&a).create(true).truncate(true)),
+        invalid_options
+    );
+    error!(tmpdir.open_with("d", c(&a).truncate(true)), invalid_options);
+    check!(tmpdir.open_with("d", c(&a).create(true)));
+    check!(tmpdir.open_with("d", &c(&a)));
+
+    // read-append
+    check!(tmpdir.open_with("e", c(&ra).create_new(true)));
+    error!(
+        tmpdir.open_with("e", c(&ra).create(true).truncate(true)),
+        invalid_options
+    );
+    error!(
+        tmpdir.open_with("e", c(&ra).truncate(true)),
+        invalid_options
+    );
+    check!(tmpdir.open_with("e", c(&ra).create(true)));
+    check!(tmpdir.open_with("e", &c(&ra)));
+
+    // Test opening a file without setting an access mode
+    let mut blank = OO::new();
+    error!(tmpdir.open_with("f", blank.create(true)), invalid_options);
+
+    // Test write works
+    check!(check!(tmpdir.create("h")).write("foobar".as_bytes()));
+
+    // Test write fails for read-only
+    check!(tmpdir.open_with("h", &r));
+    {
+        let mut f = check!(tmpdir.open_with("h", &r));
+        assert!(f.write("wut".as_bytes()).is_err());
+    }
+
+    // Test write overwrites
+    {
+        let mut f = check!(tmpdir.open_with("h", &c(&w)));
+        check!(f.write("baz".as_bytes()));
+    }
+    {
+        let mut f = check!(tmpdir.open_with("h", &c(&r)));
+        let mut b = vec![0; 6];
+        check!(f.read(&mut b));
+        assert_eq!(b, "bazbar".as_bytes());
+    }
+
+    // Test truncate works
+    {
+        let mut f = check!(tmpdir.open_with("h", c(&w).truncate(true)));
+        check!(f.write("foo".as_bytes()));
+    }
+    assert_eq!(check!(tmpdir.metadata("h")).len(), 3);
+
+    // Test append works
+    assert_eq!(check!(tmpdir.metadata("h")).len(), 3);
+    {
+        let mut f = check!(tmpdir.open_with("h", &c(&a)));
+        check!(f.write("bar".as_bytes()));
+    }
+    assert_eq!(check!(tmpdir.metadata("h")).len(), 6);
+
+    // Test .append(true) equals .write(true).append(true)
+    {
+        let mut f = check!(tmpdir.open_with("h", c(&w).append(true)));
+        check!(f.write("baz".as_bytes()));
+    }
+    assert_eq!(check!(tmpdir.metadata("h")).len(), 9);
+}
+
+#[test]
+fn _assert_send_sync() {
+    fn _assert_send_sync<T: Send + Sync>() {}
+    _assert_send_sync::<OpenOptions>();
+}
+
+#[test]
+fn binary_file() {
+    let mut bytes = [0; 1024];
+    StdRng::from_entropy().fill_bytes(&mut bytes);
+
+    let tmpdir = tmpdir();
+
+    check!(check!(tmpdir.create("test")).write(&bytes));
+    let mut v = Vec::new();
+    check!(check!(tmpdir.open("test")).read_to_end(&mut v));
+    assert!(v == &bytes[..]);
+}
+
+#[test]
+fn write_then_read() {
+    let mut bytes = [0; 1024];
+    StdRng::from_entropy().fill_bytes(&mut bytes);
+
+    let tmpdir = tmpdir();
+
+    check!(tmpdir.write("test", &bytes[..]));
+    let v = check!(tmpdir.read("test"));
+    assert!(v == &bytes[..]);
+
+    check!(tmpdir.write("not-utf8", &[0xFF]));
+    error_contains!(
+        tmpdir.read_to_string("not-utf8"),
+        "stream did not contain valid UTF-8"
+    );
+
+    let s = "𐁁𐀓𐀠𐀴𐀍";
+    check!(tmpdir.write("utf8", s.as_bytes()));
+    let string = check!(tmpdir.read_to_string("utf8"));
+    assert_eq!(string, s);
+}
+
+#[test]
+fn file_try_clone() {
+    let tmpdir = tmpdir();
+
+    let mut f1 = check!(tmpdir.open_with(
+        "test",
+        OpenOptions::new().read(true).write(true).create(true)
+    ));
+    let mut f2 = check!(f1.try_clone());
+
+    check!(f1.write_all(b"hello world"));
+    check!(f1.seek(SeekFrom::Start(2)));
+
+    let mut buf = vec![];
+    check!(f2.read_to_end(&mut buf));
+    assert_eq!(buf, b"llo world");
+    drop(f2);
+
+    check!(f1.write_all(b"!"));
+}
+
+#[test]
+#[cfg(not(windows))]
+fn unlink_readonly() {
+    let tmpdir = tmpdir();
+    let path = "file";
+    check!(tmpdir.create(&path));
+    let mut perm = check!(tmpdir.metadata(&path)).permissions();
+    perm.set_readonly(true);
+    check!(tmpdir.set_permissions(&path, perm));
+    check!(tmpdir.remove_file(&path));
+}
+
+#[test]
+fn mkdir_trailing_slash() {
+    let tmpdir = tmpdir();
+    let path = PathBuf::from("file");
+    check!(tmpdir.create_dir_all(&path.join("a/")));
+}
+
+#[test]
+fn canonicalize_works_simple() {
+    let tmpdir = tmpdir();
+    let file = Path::new("test");
+    tmpdir.create(&file).unwrap();
+    assert_eq!(tmpdir.canonicalize(&file).unwrap(), file);
+}
+
+#[test]
+fn realpath_works() {
+    let tmpdir = tmpdir();
+    if !got_symlink_permission(&tmpdir) {
+        return;
+    };
+
+    let file = PathBuf::from("test");
+    let dir = PathBuf::from("test2");
+    let link = dir.join("link");
+    let linkdir = PathBuf::from("test3");
+
+    tmpdir.create(&file).unwrap();
+    tmpdir.create_dir(&dir).unwrap();
+    symlink_file(Path::new("..").join(&file), &tmpdir, &link).unwrap();
+    symlink_dir(&dir, &tmpdir, &linkdir).unwrap();
+
+    assert!(tmpdir
+        .symlink_metadata(&link)
+        .unwrap()
+        .file_type()
+        .is_symlink());
+
+    assert_eq!(tmpdir.canonicalize(".").unwrap(), PathBuf::from("."));
+    assert_eq!(tmpdir.canonicalize(&file).unwrap(), file);
+    assert_eq!(tmpdir.canonicalize(&link).unwrap(), file);
+    assert_eq!(tmpdir.canonicalize(&linkdir).unwrap(), dir);
+    assert_eq!(tmpdir.canonicalize(&linkdir.join("link")).unwrap(), file);
+}
+
+#[test]
+fn realpath_works_tricky() {
+    let tmpdir = tmpdir();
+    if !got_symlink_permission(&tmpdir) {
+        return;
+    };
+
+    let a = PathBuf::from("a");
+    let b = a.join("b");
+    let c = b.join("c");
+    let d = a.join("d");
+    let e = d.join("e");
+    let f = a.join("f");
+
+    tmpdir.create_dir_all(&b).unwrap();
+    tmpdir.create_dir_all(&d).unwrap();
+    tmpdir.create(&f).unwrap();
+    if cfg!(not(windows)) {
+        symlink_file("../d/e", &tmpdir, &c).unwrap();
+        symlink_file("../f", &tmpdir, &e).unwrap();
+    }
+    if cfg!(windows) {
+        symlink_file(r"..\d\e", &tmpdir, &c).unwrap();
+        symlink_file(r"..\f", &tmpdir, &e).unwrap();
+    }
+
+    assert_eq!(tmpdir.canonicalize(&c).unwrap(), f);
+    assert_eq!(tmpdir.canonicalize(&e).unwrap(), f);
+}
+
+#[test]
+fn dir_entry_methods() {
+    let tmpdir = tmpdir();
+
+    tmpdir.create_dir_all("a").unwrap();
+    tmpdir.create("b").unwrap();
+
+    for file in tmpdir.read_dir(".").unwrap().map(|f| f.unwrap()) {
+        let fname = file.file_name();
+        match fname.as_str() {
+            "a" => {
+                assert!(file.file_type().unwrap().is_dir());
+                assert!(file.metadata().unwrap().is_dir());
+            }
+            "b" => {
+                assert!(file.file_type().unwrap().is_file());
+                assert!(file.metadata().unwrap().is_file());
+            }
+            f => panic!("unknown file name: {:?}", f),
+        }
+    }
+}
+
+#[test]
+fn dir_entry_debug() {
+    let tmpdir = tmpdir();
+    tmpdir.create("b").unwrap();
+    let mut read_dir = tmpdir.read_dir(".").unwrap();
+    let dir_entry = read_dir.next().unwrap().unwrap();
+    let actual = format!("{:?}", dir_entry);
+    let expected = format!("DirEntry({:?})", dir_entry.file_name());
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn read_dir_not_found() {
+    let tmpdir = tmpdir();
+    let res = tmpdir.read_dir("path/that/does/not/exist");
+    assert_eq!(res.err().unwrap().kind(), ErrorKind::NotFound);
+}
+
+#[test]
+fn create_dir_all_with_junctions() {
+    let tmpdir = tmpdir();
+    let target = "target";
+
+    let junction = PathBuf::from("junction");
+    let b = junction.join("a/b");
+
+    let link = PathBuf::from("link");
+    let d = link.join("c/d");
+
+    tmpdir.create_dir(&target).unwrap();
+
+    check!(symlink_junction(&target, &tmpdir, &junction));
+    check!(tmpdir.create_dir_all(&b));
+    // the junction itself is not a directory, but `is_dir()` on a Path
+    // follows links
+    assert!(tmpdir.is_dir(junction));
+    assert!(tmpdir.exists(b));
+
+    if !got_symlink_permission(&tmpdir) {
+        return;
+    };
+    check!(symlink_dir(&target, &tmpdir, &link));
+    check!(tmpdir.create_dir_all(&d));
+    assert!(tmpdir.is_dir(link));
+    assert!(tmpdir.exists(d));
+}
+
+#[test]
+fn metadata_access_times() {
+    let tmpdir = tmpdir();
+
+    let b = "b";
+    tmpdir.create(&b).unwrap();
+
+    let a = check!(tmpdir.metadata("."));
+    let b = check!(tmpdir.metadata(&b));
+
+    assert_eq!(check!(a.accessed()), check!(a.accessed()));
+    assert_eq!(check!(a.modified()), check!(a.modified()));
+    // This assert from std's testsuite is racy.
+    //assert_eq!(check!(b.accessed()), check!(b.modified()));
+
+    if cfg!(target_os = "macos") || cfg!(target_os = "windows") {
+        check!(a.created());
+        check!(b.created());
+    }
+
+    if cfg!(any(target_os = "android", target_os = "linux")) {
+        // Not always available
+        match (a.created(), b.created()) {
+            (Ok(t1), Ok(t2)) => assert!(t1 <= t2),
+            (Err(e1), Err(e2))
+                if e1.kind() == ErrorKind::Other && e2.kind() == ErrorKind::Other => {}
+            (a, b) => panic!(
+                "creation time must be always supported or not supported: {:?} {:?}",
+                a, b,
+            ),
+        }
+    }
+}
+
+/// Test creating hard links to symlinks.
+#[test]
+fn symlink_hard_link() {
+    let tmpdir = tmpdir();
+    if !got_symlink_permission(&tmpdir) {
+        return;
+    }
+
+    // Create "file", a file.
+    check!(tmpdir.create("file"));
+
+    // Create "symlink", a symlink to "file".
+    check!(symlink_file("file", &tmpdir, "symlink"));
+
+    // Create "hard_link", a hard link to "symlink".
+    check!(tmpdir.hard_link("symlink", &tmpdir, "hard_link"));
+
+    // "hard_link" should appear as a symlink.
+    assert!(check!(tmpdir.symlink_metadata("hard_link"))
+        .file_type()
+        .is_symlink());
+
+    // We sould be able to open "file" via any of the above names.
+    let _ = check!(tmpdir.open("file"));
+    assert!(tmpdir.open("file.renamed").is_err());
+    let _ = check!(tmpdir.open("symlink"));
+    let _ = check!(tmpdir.open("hard_link"));
+
+    // Rename "file" to "file.renamed".
+    check!(tmpdir.rename("file", &tmpdir, "file.renamed"));
+
+    // Now, the symlink and the hard link should be dangling.
+    assert!(tmpdir.open("file").is_err());
+    let _ = check!(tmpdir.open("file.renamed"));
+    assert!(tmpdir.open("symlink").is_err());
+    assert!(tmpdir.open("hard_link").is_err());
+
+    // The symlink and the hard link should both still point to "file".
+    assert!(tmpdir.read_link("file").is_err());
+    assert!(tmpdir.read_link("file.renamed").is_err());
+    assert_eq!(check!(tmpdir.read_link("symlink")), Path::new("file"));
+    assert_eq!(check!(tmpdir.read_link("hard_link")), Path::new("file"));
+
+    // Remove "file.renamed".
+    check!(tmpdir.remove_file("file.renamed"));
+
+    // Now, we can't open the file by any name.
+    assert!(tmpdir.open("file").is_err());
+    assert!(tmpdir.open("file.renamed").is_err());
+    assert!(tmpdir.open("symlink").is_err());
+    assert!(tmpdir.open("hard_link").is_err());
+
+    // "hard_link" should still appear as a symlink.
+    assert!(check!(tmpdir.symlink_metadata("hard_link"))
+        .file_type()
+        .is_symlink());
+}

--- a/tests/sys_common/io.rs
+++ b/tests/sys_common/io.rs
@@ -1,10 +1,24 @@
 use cap_tempfile::tempdir;
 
+#[cfg(feature = "fs_utf8")]
+pub use cap_tempfile::utf8::TempDir as TempDirUtf8;
 pub use cap_tempfile::TempDir;
 
 #[allow(unused)]
 pub fn tmpdir() -> TempDir {
     use cap_tempfile::ambient_authority;
+
+    // It's ok to call `ambient_authority()` here, rather than take an
+    // `AmbientAuthority` argument, because this function is only used
+    // by tests.
+    tempdir(ambient_authority()).expect("expected to be able to create a temporary directory")
+}
+
+#[cfg(feature = "fs_utf8")]
+#[allow(unused)]
+pub fn tmpdir_utf8() -> TempDirUtf8 {
+    use cap_tempfile::ambient_authority;
+    use cap_tempfile::utf8::tempdir;
 
     // It's ok to call `ambient_authority()` here, rather than take an
     // `AmbientAuthority` argument, because this function is only used

--- a/tests/sys_common/symlink_junction.rs
+++ b/tests/sys_common/symlink_junction.rs
@@ -2,6 +2,8 @@
 // library/std/src/sys/windows/fs.rs at revision
 // 108e90ca78f052c0c1c49c42a22c85620be19712.
 
+#[cfg(feature = "fs_utf8")]
+use camino::Utf8Path;
 use cap_std::fs::Dir;
 use std::io;
 use std::path::Path;
@@ -24,6 +26,28 @@ pub fn symlink_junction<P: AsRef<Path>, Q: AsRef<Path>>(
     dst: Q,
 ) -> io::Result<()> {
     symlink_junction_inner(src.as_ref(), dst_dir, dst.as_ref())
+}
+
+#[cfg(feature = "fs_utf8")]
+#[cfg(not(windows))]
+#[allow(dead_code)]
+pub fn symlink_junction_utf8<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(
+    src: P,
+    dst_dir: &cap_std::fs_utf8::Dir,
+    dst: Q,
+) -> io::Result<()> {
+    dst_dir.symlink(src, dst)
+}
+
+#[cfg(feature = "fs_utf8")]
+#[cfg(windows)]
+#[allow(dead_code)]
+pub fn symlink_junction_utf8<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(
+    src: P,
+    dst_dir: &cap_std::fs_utf8::Dir,
+    dst: Q,
+) -> io::Result<()> {
+    symlink_junction_inner_utf8(src.as_ref(), dst_dir, dst.as_ref())
 }
 
 #[cfg(windows)]
@@ -58,6 +82,67 @@ pub fn cvt(i: winapi::shared::minwindef::BOOL) -> io::Result<winapi::shared::min
 #[cfg(windows)]
 #[allow(dead_code)]
 fn symlink_junction_inner(target: &Path, dir: &Dir, junction: &Path) -> io::Result<()> {
+    use cap_std::fs::OpenOptions;
+    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::fs::OpenOptionsExt;
+    use std::os::windows::io::AsRawHandle;
+    use std::ptr;
+
+    dir.create_dir(junction)?;
+
+    let mut opts = OpenOptions::new();
+    opts.write(true);
+    opts.custom_flags(
+        winapi::um::winbase::FILE_FLAG_OPEN_REPARSE_POINT
+            | winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS,
+    );
+    let f = dir.open_with(junction, &opts)?;
+    let h = f.as_raw_handle();
+
+    unsafe {
+        let mut data = [0_u8; winapi::um::winnt::MAXIMUM_REPARSE_DATA_BUFFER_SIZE as usize];
+        let db = data.as_mut_ptr() as *mut REPARSE_MOUNTPOINT_DATA_BUFFER;
+        let buf = &mut (*db).ReparseTarget as *mut winapi::um::winnt::WCHAR;
+        let mut i = 0;
+        // FIXME: this conversion is very hacky
+        let v = br"\??\";
+        let v = v.iter().map(|x| *x as u16);
+        for c in v.chain(target.as_os_str().encode_wide()) {
+            *buf.offset(i) = c;
+            i += 1;
+        }
+        *buf.offset(i) = 0;
+        i += 1;
+        (*db).ReparseTag = winapi::um::winnt::IO_REPARSE_TAG_MOUNT_POINT;
+        (*db).ReparseTargetMaximumLength = (i * 2) as winapi::shared::minwindef::WORD;
+        (*db).ReparseTargetLength = ((i - 1) * 2) as winapi::shared::minwindef::WORD;
+        (*db).ReparseDataLength =
+            (*db).ReparseTargetLength as winapi::shared::minwindef::DWORD + 12;
+
+        let mut ret = 0;
+        cvt(winapi::um::ioapiset::DeviceIoControl(
+            h as *mut _,
+            winapi::um::winioctl::FSCTL_SET_REPARSE_POINT,
+            data.as_ptr() as *mut _,
+            (*db).ReparseDataLength + 8,
+            ptr::null_mut(),
+            0,
+            &mut ret,
+            ptr::null_mut(),
+        ))
+        .map(drop)
+    }
+}
+
+/// Same as above, but for fs_utf8.
+#[cfg(feature = "fs_utf8")]
+#[cfg(windows)]
+#[allow(dead_code)]
+fn symlink_junction_inner_utf8(
+    target: &Utf8Path,
+    dir: &cap_std::fs_utf8::Dir,
+    junction: &Utf8Path,
+) -> io::Result<()> {
     use cap_std::fs::OpenOptions;
     use std::os::windows::ffi::OsStrExt;
     use std::os::windows::fs::OpenOptionsExt;


### PR DESCRIPTION
camino provides Utf8Path and Utf8PathBuf, which are UTF-8 correspondents
to Path and PathBuf which enforce UTF-8, which makes them a better fit for
fs_utf8 than str/String.