### PR TITLE
Make `ambient_authority` arguments slightly tidier in the docs.

### DIFF
--- a/cap-async-std/src/fs/dir.rs
+++ b/cap-async-std/src/fs/dir.rs
@@ -806,8 +806,9 @@ impl Dir {
     #[inline]
     pub async fn create_ambient_dir_all<P: AsRef<Path>>(
         path: P,
-        _ambient_authority: AmbientAuthority,
+        ambient_authority: AmbientAuthority,
     ) -> io::Result<()> {
+        let _ = ambient_authority;
         let path = path.as_ref().to_path_buf();
         fs::create_dir_all(path).await
     }

--- a/cap-async-std/src/fs_utf8/dir.rs
+++ b/cap-async-std/src/fs_utf8/dir.rs
@@ -591,8 +591,9 @@ impl Dir {
     #[inline]
     pub async fn create_ambient_dir_all<P: AsRef<Utf8Path>>(
         path: P,
-        _ambient_authority: AmbientAuthority,
+        ambient_authority: AmbientAuthority,
     ) -> io::Result<()> {
+        let _ = ambient_authority;
         let path = from_utf8(path)?;
         fs::create_dir_all(path).await
     }

--- a/cap-primitives/src/fs/open_dir.rs
+++ b/cap-primitives/src/fs/open_dir.rs
@@ -68,7 +68,8 @@ pub fn open_ambient_dir(path: &Path, ambient_authority: AmbientAuthority) -> io:
 #[inline]
 pub fn open_parent_dir(
     start: &fs::File,
-    _ambient_authority: AmbientAuthority,
+    ambient_authority: AmbientAuthority,
 ) -> io::Result<fs::File> {
+    let _ = ambient_authority;
     open_dir_unchecked(start, Component::ParentDir.as_ref())
 }

--- a/cap-primitives/src/rsix/fs/open_unchecked.rs
+++ b/cap-primitives/src/rsix/fs/open_unchecked.rs
@@ -61,7 +61,8 @@ pub(crate) fn open_unchecked(
 pub(crate) fn open_ambient_impl(
     path: &Path,
     options: &OpenOptions,
-    _ambient_authority: AmbientAuthority,
+    ambient_authority: AmbientAuthority,
 ) -> Result<fs::File, OpenUncheckedError> {
+    let _ = ambient_authority;
     open_unchecked(&cwd().as_filelike_view::<fs::File>(), path, options)
 }

--- a/cap-primitives/src/windows/fs/open_unchecked.rs
+++ b/cap-primitives/src/windows/fs/open_unchecked.rs
@@ -26,8 +26,9 @@ pub(crate) fn open_unchecked(
 pub(crate) fn open_ambient_impl(
     path: &Path,
     options: &OpenOptions,
-    _ambient_authority: AmbientAuthority,
+    ambient_authority: AmbientAuthority,
 ) -> Result<fs::File, OpenUncheckedError> {
+    let _ = ambient_authority;
     let (opts, manually_trunc) = open_options_to_std(options);
     match opts.open(path) {
         Ok(f) => {

--- a/cap-std/src/fs/dir.rs
+++ b/cap-std/src/fs/dir.rs
@@ -603,8 +603,9 @@ impl Dir {
     #[inline]
     pub fn create_ambient_dir_all<P: AsRef<Path>>(
         path: P,
-        _ambient_authority: AmbientAuthority,
+        ambient_authority: AmbientAuthority,
     ) -> io::Result<()> {
+        let _ = ambient_authority;
         fs::create_dir_all(path)
     }
 }

--- a/cap-std/src/fs_utf8/dir.rs
+++ b/cap-std/src/fs_utf8/dir.rs
@@ -573,8 +573,9 @@ impl Dir {
     #[inline]
     pub fn create_ambient_dir_all<P: AsRef<Utf8Path>>(
         path: P,
-        _ambient_authority: AmbientAuthority,
+        ambient_authority: AmbientAuthority,
     ) -> io::Result<()> {
+        let _ = ambient_authority;
         let path = from_utf8(path)?;
         fs::create_dir_all(path)
     }


### PR DESCRIPTION
Use `let _ = ambient_authority;` to disable the unused-variable
warning instead of naming public parameters `_ambient_authority`,
because the latter is reflected in the public docs.