### PR TITLE
Make usage of arf-strings in fs_utf8 optional, and off by default.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,15 @@ async_std_fs_utf8 = [
     "cap-async-std/fs_utf8",
     "cap-fs-ext/async_std_fs_utf8"
 ]
+arf_strings = [
+    "cap-std/arf_strings",
+    "cap-fs-ext/arf_strings",
+    "cap-tempfile/arf_strings",
+]
+async_std_arf_strings = [
+    "cap-async-std/arf_strings",
+    "cap-fs-ext/async_std_arf_strings"
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/README.md
+++ b/README.md
@@ -181,11 +181,14 @@ cases, though it's not yet very sophisticated.
 
 ## What is `cap_std::fs_utf8`?
 
-It's an experiment in what an API with UTF-8 filesystem paths (but which still
-allow you to access any file with any byte-sequence name) might look like. For
-more information on the technique, see the [`arf-strings` package]. To try it,
-opt in by enabling the `fs_utf8` feature and using `std::fs_utf8` in place of
-`std::fs`.
+It's similar to `cap_std::fs`, but uses [`camino`] for its `Path` types, so
+paths are always valid UTF-8. To use it, opt in by enabling the `fs_utf8`
+feature and using `std::fs_utf8` in place of `std::fs`.
+
+There's also an experimental extension to `fs_utf8` which allows losslessly
+encoding arbitrary host byte sequences within UTF-8 strings, using the
+[`arf-strings`] technique. To try this experiment, opt in by enabling the
+`arf_strings` feature.
 
 ## Similar crates
 
@@ -209,7 +212,8 @@ It's not mature yet, and it doesn't support Windows. It does support
 `openat2`-like features such as `RESOLVE_NO_XDEV`, `RESOLVE_NO_SYMLINKS`,
 and `RESOLVE_IN_ROOT`, including emulation when `openat2` isn't available.
 
-[`arf-strings` package]: https://github.com/bytecodealliance/arf-strings/
+[`arf-strings`]: https://github.com/bytecodealliance/arf-strings/
 [`openat`]: https://crates.io/crates/openat
 [`pathrs`]: https://crates.io/crates/pathrs
 [`obnth`]: https://crates.io/crates/obnth
+[`camino`]: https://crates.io/crates/camino

--- a/cap-async-std/Cargo.toml
+++ b/cap-async-std/Cargo.toml
@@ -27,7 +27,8 @@ rsix = "0.22.4"
 
 [features]
 default = []
-fs_utf8 = ["arf-strings", "camino"]
+fs_utf8 = ["camino"]
+arf_strings = ["fs_utf8", "arf-strings"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/cap-async-std/src/fs_utf8/dir_entry.rs
+++ b/cap-async-std/src/fs_utf8/dir_entry.rs
@@ -82,12 +82,16 @@ impl DirEntry {
     /// Returns the bare file name of this directory entry without any other
     /// leading path component.
     ///
+    /// This function returns an `Err` in the case that the file name isn't
+    /// encodable as UTF-8.
+    ///
+    /// If the `arf_strings` feature is enabled, unencodable names are
+    /// translated to UTF-8 using `arf-strings`.
+    ///
     /// This corresponds to [`async_std::fs::DirEntry::file_name`].
     #[inline]
-    pub fn file_name(&self) -> String {
-        // Unwrap because we can assume that paths coming from the OS don't
-        // have embedded NULs.
-        to_utf8(self.cap_std.file_name()).unwrap().into()
+    pub fn file_name(&self) -> io::Result<String> {
+        Ok(to_utf8(self.cap_std.file_name())?.into())
     }
 }
 

--- a/cap-async-std/src/fs_utf8/mod.rs
+++ b/cap-async-std/src/fs_utf8/mod.rs
@@ -37,37 +37,53 @@ use camino::{Utf8Path, Utf8PathBuf};
 pub use crate::fs::{DirBuilder, FileType, Metadata, OpenOptions, Permissions};
 
 fn from_utf8<P: AsRef<Utf8Path>>(path: P) -> std::io::Result<async_std::path::PathBuf> {
-    #[cfg(not(windows))]
-    let path = {
-        #[cfg(unix)]
-        use std::{ffi::OsString, os::unix::ffi::OsStringExt};
-        #[cfg(target_os = "wasi")]
-        use std::{ffi::OsString, os::wasi::ffi::OsStringExt};
+    #[cfg(not(feature = "arf_strings"))]
+    {
+        Ok(path.as_ref().as_std_path())
+    }
 
-        let string = arf_strings::str_to_host(path.as_ref().as_str())?;
-        OsString::from_vec(string.into_bytes())
-    };
+    #[cfg(feature = "arf_strings")]
+    {
+        #[cfg(not(windows))]
+        let path = {
+            #[cfg(unix)]
+            use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+            #[cfg(target_os = "wasi")]
+            use std::{ffi::OsString, os::wasi::ffi::OsStringExt};
 
-    #[cfg(windows)]
-    let path = arf_strings::str_to_host(path.as_ref().as_str())?;
+            let string = arf_strings::str_to_host(path.as_ref().as_str())?;
+            OsString::from_vec(string.into_bytes())
+        };
 
-    Ok(path.into())
+        #[cfg(windows)]
+        let path = arf_strings::str_to_host(path.as_ref().as_str())?;
+
+        Ok(path.into())
+    }
 }
 
 fn to_utf8<P: AsRef<async_std::path::Path>>(path: P) -> std::io::Result<Utf8PathBuf> {
-    // For now, for WASI use the same logic as other OS's, but
-    // in the future, the idea is we could avoid this.
-    let osstr = path.as_ref().as_os_str();
-
-    #[cfg(not(windows))]
+    #[cfg(not(feature = "arf_strings"))]
     {
-        arf_strings::host_os_str_to_str(osstr)
-            .map(std::borrow::Cow::into_owned)
-            .map(Into::into)
+        Ok(Utf8Path::from_path(path.as_ref()))
     }
 
-    #[cfg(windows)]
+    #[cfg(feature = "arf_strings")]
     {
-        arf_strings::host_to_str(osstr).map(Into::into)
+        // For now, for WASI use the same logic as other OS's, but
+        // in the future, the idea is we could avoid this.
+        let osstr = path.as_ref().as_os_str();
+
+        #[cfg(not(windows))]
+        {
+            arf_strings::host_os_str_to_str(osstr)
+                .map(std::borrow::Cow::into_owned)
+                .map(Into::into)
+        }
+
+        #[cfg(windows)]
+        {
+            arf_strings::host_to_str(osstr).map(Into::into)
+        }
     }
 }

--- a/cap-fs-ext/Cargo.toml
+++ b/cap-fs-ext/Cargo.toml
@@ -28,10 +28,12 @@ camino = { version = "1.0.5", optional = true }
 
 [features]
 default = ["std"]
-fs_utf8 = ["arf-strings", "cap-std/fs_utf8", "camino"]
+fs_utf8 = ["cap-std/fs_utf8", "camino"]
+arf_strings = ["cap-std/arf_strings", "fs_utf8", "arf-strings"]
 std = ["cap-std"]
 async_std = ["cap-async-std", "async-std", "io-lifetimes/async-std", "async-trait"]
-async_std_fs_utf8 = ["arf-strings", "cap-async-std/fs_utf8", "camino"]
+async_std_fs_utf8 = ["cap-async-std/fs_utf8", "camino"]
+async_std_arf_strings = ["cap-async-std/arf_strings", "async_std_fs_utf8", "arf-strings"]
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"

--- a/cap-fs-ext/src/dir_ext.rs
+++ b/cap-fs-ext/src/dir_ext.rs
@@ -1260,19 +1260,27 @@ impl AsyncDirExtUtf8 for cap_async_std::fs_utf8::Dir {
 
 #[cfg(all(any(feature = "std", feature = "async_std"), feature = "fs_utf8"))]
 fn from_utf8<P: AsRef<Utf8Path>>(path: P) -> std::io::Result<std::path::PathBuf> {
-    #[cfg(not(windows))]
-    let path = {
-        #[cfg(unix)]
-        use std::{ffi::OsString, os::unix::ffi::OsStringExt};
-        #[cfg(target_os = "wasi")]
-        use std::{ffi::OsString, os::wasi::ffi::OsStringExt};
+    #[cfg(not(feature = "arf_strings"))]
+    {
+        Ok(path.as_ref().as_std_path().to_path_buf())
+    }
 
-        let string = arf_strings::str_to_host(path.as_ref().as_str())?;
-        OsString::from_vec(string.into_bytes())
-    };
+    #[cfg(feature = "arf_strings")]
+    {
+        #[cfg(not(windows))]
+        let path = {
+            #[cfg(unix)]
+            use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+            #[cfg(target_os = "wasi")]
+            use std::{ffi::OsString, os::wasi::ffi::OsStringExt};
 
-    #[cfg(windows)]
-    let path = arf_strings::str_to_host(path.as_ref().as_str())?;
+            let string = arf_strings::str_to_host(path.as_ref().as_str())?;
+            OsString::from_vec(string.into_bytes())
+        };
 
-    Ok(path.into())
+        #[cfg(windows)]
+        let path = arf_strings::str_to_host(path.as_ref().as_str())?;
+
+        Ok(path.into())
+    }
 }

--- a/cap-std/Cargo.toml
+++ b/cap-std/Cargo.toml
@@ -28,7 +28,8 @@ rsix = "0.22.4"
 
 [features]
 default = []
-fs_utf8 = ["arf-strings", "camino"]
+fs_utf8 = ["camino"]
+arf_strings = ["fs_utf8", "arf-strings"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/cap-std/src/fs_utf8/dir_entry.rs
+++ b/cap-std/src/fs_utf8/dir_entry.rs
@@ -80,12 +80,16 @@ impl DirEntry {
     /// Returns the bare file name of this directory entry without any other
     /// leading path component.
     ///
+    /// This function returns an `Err` in the case that the file name isn't
+    /// encodable as UTF-8.
+    ///
+    /// If the `arf_strings` feature is enabled, unencodable names are
+    /// translated to UTF-8 using `arf-strings`.
+    ///
     /// This corresponds to [`std::fs::DirEntry::file_name`].
     #[inline]
-    pub fn file_name(&self) -> String {
-        // Unwrap because we can assume that paths coming from the OS don't
-        // have embedded NULs.
-        to_utf8(self.cap_std.file_name()).unwrap().into()
+    pub fn file_name(&self) -> io::Result<String> {
+        Ok(to_utf8(self.cap_std.file_name())?.into())
     }
 }
 

--- a/cap-std/src/fs_utf8/mod.rs
+++ b/cap-std/src/fs_utf8/mod.rs
@@ -36,37 +36,55 @@ pub use crate::fs::{DirBuilder, FileType, Metadata, OpenOptions, Permissions};
 use camino::{Utf8Path, Utf8PathBuf};
 
 fn from_utf8<P: AsRef<Utf8Path>>(path: P) -> std::io::Result<std::path::PathBuf> {
-    #[cfg(not(windows))]
-    let path = {
-        #[cfg(unix)]
-        use std::{ffi::OsString, os::unix::ffi::OsStringExt};
-        #[cfg(target_os = "wasi")]
-        use std::{ffi::OsString, os::wasi::ffi::OsStringExt};
+    #[cfg(not(feature = "arf_strings"))]
+    {
+        Ok(path.as_ref().as_std_path().to_path_buf())
+    }
 
-        let string = arf_strings::str_to_host(path.as_ref().as_str())?;
-        OsString::from_vec(string.into_bytes())
-    };
+    #[cfg(feature = "arf_strings")]
+    {
+        #[cfg(not(windows))]
+        let path = {
+            #[cfg(unix)]
+            use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+            #[cfg(target_os = "wasi")]
+            use std::{ffi::OsString, os::wasi::ffi::OsStringExt};
 
-    #[cfg(windows)]
-    let path = arf_strings::str_to_host(path.as_ref().as_str())?;
+            let string = arf_strings::str_to_host(path.as_ref().as_str())?;
+            OsString::from_vec(string.into_bytes())
+        };
 
-    Ok(path.into())
+        #[cfg(windows)]
+        let path = arf_strings::str_to_host(path.as_ref().as_str())?;
+
+        Ok(path.into())
+    }
 }
 
 fn to_utf8<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<Utf8PathBuf> {
-    // For now, for WASI use the same logic as other OS's, but
-    // in the future, the idea is we could avoid this.
-    let osstr = path.as_ref().as_os_str();
-
-    #[cfg(not(windows))]
+    #[cfg(not(feature = "arf_strings"))]
     {
-        arf_strings::host_os_str_to_str(osstr)
-            .map(std::borrow::Cow::into_owned)
-            .map(Into::into)
+        Ok(Utf8Path::from_path(path.as_ref())
+            .ok_or_else(|| ::rsix::io::Error::ILSEQ)?
+            .to_path_buf())
     }
 
-    #[cfg(windows)]
+    #[cfg(feature = "arf_strings")]
     {
-        arf_strings::host_to_str(osstr).map(Into::into)
+        // For now, for WASI use the same logic as other OS's, but
+        // in the future, the idea is we could avoid this.
+        let osstr = path.as_ref().as_os_str();
+
+        #[cfg(not(windows))]
+        {
+            arf_strings::host_os_str_to_str(osstr)
+                .map(std::borrow::Cow::into_owned)
+                .map(Into::into)
+        }
+
+        #[cfg(windows)]
+        {
+            arf_strings::host_to_str(osstr).map(Into::into)
+        }
     }
 }

--- a/cap-tempfile/Cargo.toml
+++ b/cap-tempfile/Cargo.toml
@@ -26,6 +26,7 @@ winapi = "0.3.9"
 [features]
 default = []
 fs_utf8 = ["cap-std/fs_utf8", "camino"]
+arf_strings = ["cap-std/arf_strings"]
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
The main tricky part here is that `fs_utf8::DirEntry::file_name()` now
has to return `io::Result<String>` instead of just `String` so that it
can fail if the name is unencodable.

Fixes #186.