### PR TITLE
On Android, use an explicit version check to detect `openat2`.

### DIFF
--- a/cap-primitives/src/rsix/linux/fs/open_impl.rs
+++ b/cap-primitives/src/rsix/linux/fs/open_impl.rs
@@ -61,6 +61,23 @@ pub(crate) fn open_beneath(
         Mode::empty()
     };
 
+    // On Android, seccomp kills processes that execute unrecognized system
+    // calls, so we do an explicit version check rather than relying on
+    // getting an `ENOSYS`.
+    #[cfg(target_os = "android")]
+    {
+        static CHECKED: AtomicBool = AtomicBool::new(false);
+
+        if !CHECKED.load(Relaxed) {
+            if !openat2_supported() {
+                INVALID.store(true, Relaxed);
+                return Err(rsix::io::Error::NOSYS.into());
+            }
+
+            CHECKED.store(true, Relaxed);
+        }
+    }
+
     // We know `openat2` needs a `&CStr` internally; to avoid allocating on
     // each iteration of the loop below, allocate the `CString` now.
     path.into_with_c_str(|path_c_str| {
@@ -116,6 +133,54 @@ pub(crate) fn open_beneath(
         rsix::io::Error::XDEV => errors::escape_attempt(),
         err => err.into(),
     })
+}
+
+/// Test whether `openat2` is supported on the currently running OS.
+#[cfg(target_os = "android")]
+fn openat2_supported() -> bool {
+    // `openat2` is supported in Linux 5.6 and later. Parse the current
+    // Linux version from trhe `release` field from `uname` to detect this.
+    let uname = rsix::process::uname();
+    let release = uname.release().to_bytes();
+    if let Some((major, minor)) = linux_major_minor(release) {
+        if major >= 6 || (major == 5 && minor >= 6) {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Extract the major and minor values from a Linux `release` string.
+#[cfg(target_os = "android")]
+fn linux_major_minor(release: &[u8]) -> Option<(u32, u32)> {
+    let mut parts = release.split(|b| *b == b'.');
+    if let Some(major) = parts.next() {
+        if let Ok(major) = std::str::from_utf8(major) {
+            if let Ok(major) = major.parse::<u32>() {
+                if let Some(minor) = parts.next() {
+                    if let Ok(minor) = std::str::from_utf8(minor) {
+                        if let Ok(minor) = minor.parse::<u32>() {
+                            return Some((major, minor));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(target_os = "android")]
+#[test]
+fn test_linux_major_minor() {
+    assert_eq!(linux_major_minor(b"5.11.0-5489-something"), Some((5, 11)));
+    assert_eq!(linux_major_minor(b"5.10.0-9-whatever"), Some((5, 10)));
+    assert_eq!(linux_major_minor(b"5.6.0"), Some((5, 6)));
+    assert_eq!(linux_major_minor(b"2.6.34"), Some((2, 6)));
+    assert_eq!(linux_major_minor(b""), None);
+    assert_eq!(linux_major_minor(b"linux-2.6.32"), None);
 }
 
 #[cfg(racy_asserts)]


### PR DESCRIPTION
On Android, seccomp is configured to kill processes that execute
unsupported system calls, rather than returning `ENOSYS`, which
breaks the auto-detection code. So on Android, use an explicit
version check, using `uname`, to test whether the running kernel
supports `openat2`, before trying to call it.