### PR TITLE
Update fuzzing checks for the io-error-more feature on Rust nightly.

### DIFF
--- a/cap-primitives/build.rs
+++ b/cap-primitives/build.rs
@@ -7,6 +7,7 @@ fn main() {
             "can_vector",         // https://github.com/rust-lang/rust/issues/69941
             "clamp",              // https://github.com/rust-lang/rust/issues/44095
             "extend_one",         // https://github.com/rust-lang/rust/issues/72631
+            "io_error_more",      // https://github.com/rust-lang/rust/issues/86442
             "pattern",            // https://github.com/rust-lang/rust/issues/27721
             "seek_convenience",   // https://github.com/rust-lang/rust/issues/59359
             "shrink_to",          // https://github.com/rust-lang/rust/issues/56431

--- a/cap-primitives/src/fs/remove_file.rs
+++ b/cap-primitives/src/fs/remove_file.rs
@@ -103,7 +103,10 @@ fn check_remove_file(
             path.display()
         ),
         (Err(e), Ok(unchecked_metadata)) => match e.kind() {
+            #[cfg(io_error_more)]
+            io::ErrorKind::IsADirectory => assert!(unchecked_metadata.is_dir()),
             io::ErrorKind::PermissionDenied => (),
+            #[cfg(not(io_error_more))]
             io::ErrorKind::Other if unchecked_metadata.is_dir() => (),
             _ => panic!(
                 "unexpected error removing file start='{:?}', path='{}': {:?}",

--- a/cap-primitives/src/lib.rs
+++ b/cap-primitives/src/lib.rs
@@ -12,6 +12,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/bytecodealliance/cap-std/main/media/cap-std.ico"
 )]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
+#![cfg_attr(io_error_more, feature(io_error_more))]
 
 #[cfg(not(windows))]
 mod rustix;


### PR DESCRIPTION
With io-error-more, some I/O errors which were previously reported as
Other are now reported as specific error codes.