### PR TITLE
Remove `AmbientAuthority` arguments from `from_std` functions.

### DIFF
--- a/cap-async-std/src/fs/dir_entry.rs
+++ b/cap-async-std/src/fs/dir_entry.rs
@@ -4,7 +4,6 @@ use async_std::io;
 use async_std::os::unix::fs::DirEntryExt;
 #[cfg(target_os = "wasi")]
 use async_std::os::wasi::fs::DirEntryExt;
-use cap_primitives::ambient_authority;
 use std::ffi::OsString;
 use std::fmt;
 
@@ -34,21 +33,21 @@ impl DirEntry {
     #[inline]
     pub fn open(&self) -> io::Result<File> {
         let file = self.inner.open()?.into();
-        Ok(File::from_std(file, ambient_authority()))
+        Ok(File::from_std(file))
     }
 
     /// Open the file with the given options.
     #[inline]
     pub fn open_with(&self, options: &OpenOptions) -> io::Result<File> {
         let file = self.inner.open_with(options)?.into();
-        Ok(File::from_std(file, ambient_authority()))
+        Ok(File::from_std(file))
     }
 
     /// Open the entry as a directory.
     #[inline]
     pub fn open_dir(&self) -> io::Result<Dir> {
         let file = self.inner.open_dir()?.into();
-        Ok(Dir::from_std_file(file, ambient_authority()))
+        Ok(Dir::from_std_file(file))
     }
 
     /// Removes the file from its filesystem.

--- a/cap-async-std/src/fs_utf8/dir.rs
+++ b/cap-async-std/src/fs_utf8/dir.rs
@@ -2,7 +2,7 @@ use crate::fs::{OpenOptions, Permissions};
 use crate::fs_utf8::{from_utf8, to_utf8, DirBuilder, File, Metadata, ReadDir};
 use async_std::{fs, io};
 use camino::{Utf8Path, Utf8PathBuf};
-use cap_primitives::{ambient_authority, AmbientAuthority};
+use cap_primitives::AmbientAuthority;
 #[cfg(not(windows))]
 use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 #[cfg(windows)]
@@ -41,13 +41,11 @@ impl Dir {
     /// To prevent race conditions on Windows, the file must be opened without
     /// `FILE_SHARE_DELETE`.
     ///
-    /// # Ambient Authority
-    ///
-    /// `async_std::fs::File` is not sandboxed and may access any path that the
-    /// host process has access to.
+    /// This grants access the resources the `async_std::fs::File` instance
+    /// already has access to.
     #[inline]
-    pub fn from_std_file(std_file: fs::File, ambient_authority: AmbientAuthority) -> Self {
-        Self::from_cap_std(crate::fs::Dir::from_std_file(std_file, ambient_authority))
+    pub fn from_std_file(std_file: fs::File) -> Self {
+        Self::from_cap_std(crate::fs::Dir::from_std_file(std_file))
     }
 
     /// Constructs a new instance of `Self` from the given `cap_std::fs::Dir`.
@@ -602,7 +600,7 @@ impl Dir {
 impl FromRawFd for Dir {
     #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self::from_std_file(fs::File::from_raw_fd(fd), ambient_authority())
+        Self::from_std_file(fs::File::from_raw_fd(fd))
     }
 }
 
@@ -610,7 +608,7 @@ impl FromRawFd for Dir {
 impl FromFd for Dir {
     #[inline]
     fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std_file(fs::File::from_fd(fd), ambient_authority())
+        Self::from_std_file(fs::File::from_fd(fd))
     }
 }
 
@@ -620,7 +618,7 @@ impl FromRawHandle for Dir {
     /// without `FILE_SHARE_DELETE`.
     #[inline]
     unsafe fn from_raw_handle(handle: RawHandle) -> Self {
-        Self::from_std_file(fs::File::from_raw_handle(handle), ambient_authority())
+        Self::from_std_file(fs::File::from_raw_handle(handle))
     }
 }
 
@@ -628,7 +626,7 @@ impl FromRawHandle for Dir {
 impl FromHandle for Dir {
     #[inline]
     fn from_handle(handle: OwnedHandle) -> Self {
-        Self::from_std_file(fs::File::from_handle(handle), ambient_authority())
+        Self::from_std_file(fs::File::from_handle(handle))
     }
 }
 

--- a/cap-async-std/src/fs_utf8/file.rs
+++ b/cap-async-std/src/fs_utf8/file.rs
@@ -8,7 +8,7 @@ use async_std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use async_std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use async_std::task::{Context, Poll};
 use camino::Utf8Path;
-use cap_primitives::{ambient_authority, AmbientAuthority};
+use cap_primitives::AmbientAuthority;
 #[cfg(not(windows))]
 use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 #[cfg(windows)]
@@ -40,13 +40,11 @@ impl File {
     /// Constructs a new instance of `Self` from the given
     /// `async_std::fs::File`.
     ///
-    /// # Ambient Authority
-    ///
-    /// `async_std::fs::File` is not sandboxed and may access any path that the
-    /// host process has access to.
+    /// This grants access the resources the `async_std::fs::File` instance
+    /// already has access to.
     #[inline]
-    pub fn from_std(std: fs::File, ambient_authority: AmbientAuthority) -> Self {
-        Self::from_cap_std(crate::fs::File::from_std(std, ambient_authority))
+    pub fn from_std(std: fs::File) -> Self {
+        Self::from_cap_std(crate::fs::File::from_std(std))
     }
 
     /// Constructs a new instance of `Self` from the given `cap_std::fs::File`.
@@ -150,7 +148,7 @@ impl File {
 impl FromRawFd for File {
     #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self::from_std(fs::File::from_raw_fd(fd), ambient_authority())
+        Self::from_std(fs::File::from_raw_fd(fd))
     }
 }
 
@@ -158,7 +156,7 @@ impl FromRawFd for File {
 impl FromFd for File {
     #[inline]
     fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(fs::File::from_fd(fd), ambient_authority())
+        Self::from_std(fs::File::from_fd(fd))
     }
 }
 
@@ -166,7 +164,7 @@ impl FromFd for File {
 impl FromRawHandle for File {
     #[inline]
     unsafe fn from_raw_handle(handle: RawHandle) -> Self {
-        Self::from_std(fs::File::from_raw_handle(handle), ambient_authority())
+        Self::from_std(fs::File::from_raw_handle(handle))
     }
 }
 
@@ -174,7 +172,7 @@ impl FromRawHandle for File {
 impl FromHandle for File {
     #[inline]
     fn from_handle(handle: OwnedHandle) -> Self {
-        Self::from_std(fs::File::from_handle(handle), ambient_authority())
+        Self::from_std(fs::File::from_handle(handle))
     }
 }
 

--- a/cap-async-std/src/net/incoming.rs
+++ b/cap-async-std/src/net/incoming.rs
@@ -2,7 +2,6 @@ use crate::net::TcpStream;
 use async_std::stream::Stream;
 use async_std::task::{Context, Poll};
 use async_std::{io, net};
-use cap_primitives::{ambient_authority, AmbientAuthority};
 use std::fmt;
 use std::pin::Pin;
 
@@ -19,12 +18,10 @@ impl<'a> Incoming<'a> {
     /// Constructs a new instance of `Self` from the given
     /// `async_std::net::Incoming`.
     ///
-    /// # Ambient Authority
-    ///
-    /// `async_std::net::Incoming` is not sandboxed and may access any address
-    /// that the host process has access to.
+    /// This grants access the resources the `async_std::net::Incoming`
+    /// instance already has access to.
     #[inline]
-    pub fn from_std(std: net::Incoming<'a>, _: AmbientAuthority) -> Self {
+    pub fn from_std(std: net::Incoming<'a>) -> Self {
         Self { std }
     }
 }
@@ -37,7 +34,7 @@ impl<'a> Stream for Incoming<'a> {
         Stream::poll_next(Pin::new(&mut self.std), cx).map(|poll| {
             poll.map(|result| {
                 let tcp_stream = result?;
-                Ok(TcpStream::from_std(tcp_stream, ambient_authority()))
+                Ok(TcpStream::from_std(tcp_stream))
             })
         })
     }

--- a/cap-async-std/src/net/pool.rs
+++ b/cap-async-std/src/net/pool.rs
@@ -1,12 +1,12 @@
 use crate::net::{TcpListener, TcpStream, ToSocketAddrs, UdpSocket};
 use async_std::{io, net};
 use cap_primitives::net::NO_SOCKET_ADDRS;
-use cap_primitives::{ambient_authority, AmbientAuthority};
+use cap_primitives::AmbientAuthority;
 
 /// A pool of network addresses.
 ///
-/// This does not directly correspond to anything in `std`, however its methods
-/// correspond to the several functions in [`std::net`].
+/// This does not directly correspond to anything in `async_std`, however its
+/// methods correspond to the several functions in [`async_std::net`].
 #[derive(Clone)]
 pub struct Pool {
     cap: cap_primitives::net::Pool,
@@ -60,9 +60,7 @@ impl Pool {
             self.cap.check_addr(&addr)?;
             // TODO: when compiling for WASI, use WASI-specific methods instead
             match net::TcpListener::bind(addr).await {
-                Ok(tcp_listener) => {
-                    return Ok(TcpListener::from_std(tcp_listener, ambient_authority()))
-                }
+                Ok(tcp_listener) => return Ok(TcpListener::from_std(tcp_listener)),
                 Err(e) => last_err = Some(e),
             }
         }
@@ -84,7 +82,7 @@ impl Pool {
             self.cap.check_addr(&addr)?;
             // TODO: when compiling for WASI, use WASI-specific methods instead
             match net::TcpStream::connect(addr).await {
-                Ok(tcp_stream) => return Ok(TcpStream::from_std(tcp_stream, ambient_authority())),
+                Ok(tcp_stream) => return Ok(TcpStream::from_std(tcp_stream)),
                 Err(e) => last_err = Some(e),
             }
         }
@@ -107,7 +105,7 @@ impl Pool {
         for addr in addrs {
             self.cap.check_addr(&addr)?;
             match net::UdpSocket::bind(addr).await {
-                Ok(udp_socket) => return Ok(UdpSocket::from_std(udp_socket, ambient_authority())),
+                Ok(udp_socket) => return Ok(UdpSocket::from_std(udp_socket)),
                 Err(e) => last_err = Some(e),
             }
         }

--- a/cap-async-std/src/net/tcp_stream.rs
+++ b/cap-async-std/src/net/tcp_stream.rs
@@ -4,7 +4,6 @@ use async_std::net;
 #[cfg(unix)]
 use async_std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use async_std::task::{Context, Poll};
-use cap_primitives::{ambient_authority, AmbientAuthority};
 #[cfg(not(windows))]
 use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 #[cfg(windows)]
@@ -36,12 +35,10 @@ impl TcpStream {
     /// Constructs a new instance of `Self` from the given
     /// `async_std::net::TcpStream`.
     ///
-    /// # Ambient Authority
-    ///
-    /// `async_std::net::TcpStream` is not sandboxed and may access any address
-    /// that the host process has access to.
+    /// This grants access the resources the `async_std::net::TcpStream`
+    /// instance already has access to.
     #[inline]
-    pub fn from_std(std: net::TcpStream, _: AmbientAuthority) -> Self {
+    pub fn from_std(std: net::TcpStream) -> Self {
         Self { std }
     }
 
@@ -129,7 +126,7 @@ impl TcpStream {
 impl FromRawFd for TcpStream {
     #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self::from_std(net::TcpStream::from_raw_fd(fd), ambient_authority())
+        Self::from_std(net::TcpStream::from_raw_fd(fd))
     }
 }
 
@@ -137,7 +134,7 @@ impl FromRawFd for TcpStream {
 impl FromFd for TcpStream {
     #[inline]
     fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(net::TcpStream::from_fd(fd), ambient_authority())
+        Self::from_std(net::TcpStream::from_fd(fd))
     }
 }
 
@@ -145,7 +142,7 @@ impl FromFd for TcpStream {
 impl FromRawSocket for TcpStream {
     #[inline]
     unsafe fn from_raw_socket(socket: RawSocket) -> Self {
-        Self::from_std(net::TcpStream::from_raw_socket(socket), ambient_authority())
+        Self::from_std(net::TcpStream::from_raw_socket(socket))
     }
 }
 
@@ -153,7 +150,7 @@ impl FromRawSocket for TcpStream {
 impl FromSocket for TcpStream {
     #[inline]
     fn from_socket(socket: OwnedSocket) -> Self {
-        Self::from_std(net::TcpStream::from_socket(socket), ambient_authority())
+        Self::from_std(net::TcpStream::from_socket(socket))
     }
 }
 

--- a/cap-async-std/src/net/udp_socket.rs
+++ b/cap-async-std/src/net/udp_socket.rs
@@ -2,7 +2,6 @@ use crate::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 #[cfg(unix)]
 use async_std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use async_std::{io, net};
-use cap_primitives::{ambient_authority, AmbientAuthority};
 #[cfg(not(windows))]
 use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 #[cfg(windows)]
@@ -37,12 +36,10 @@ impl UdpSocket {
     /// Constructs a new instance of `Self` from the given
     /// `async_std::net::UdpSocket`.
     ///
-    /// # Ambient Authority
-    ///
-    /// `async_std::net::UdpSocket` is not sandboxed and may access any address
-    /// that the host process has access to.
+    /// This grants access the resources the `async_std::net::UdpSocket`
+    /// instance already has access to.
     #[inline]
-    pub fn from_std(std: net::UdpSocket, _: AmbientAuthority) -> Self {
+    pub fn from_std(std: net::UdpSocket) -> Self {
         Self { std }
     }
 
@@ -231,7 +228,7 @@ impl UdpSocket {
 impl FromRawFd for UdpSocket {
     #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self::from_std(net::UdpSocket::from_raw_fd(fd), ambient_authority())
+        Self::from_std(net::UdpSocket::from_raw_fd(fd))
     }
 }
 
@@ -239,7 +236,7 @@ impl FromRawFd for UdpSocket {
 impl FromFd for UdpSocket {
     #[inline]
     fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(net::UdpSocket::from_fd(fd), ambient_authority())
+        Self::from_std(net::UdpSocket::from_fd(fd))
     }
 }
 
@@ -247,7 +244,7 @@ impl FromFd for UdpSocket {
 impl FromRawSocket for UdpSocket {
     #[inline]
     unsafe fn from_raw_socket(socket: RawSocket) -> Self {
-        Self::from_std(net::UdpSocket::from_raw_socket(socket), ambient_authority())
+        Self::from_std(net::UdpSocket::from_raw_socket(socket))
     }
 }
 
@@ -255,7 +252,7 @@ impl FromRawSocket for UdpSocket {
 impl FromSocket for UdpSocket {
     #[inline]
     fn from_socket(socket: OwnedSocket) -> Self {
-        Self::from_std(net::UdpSocket::from_socket(socket), ambient_authority())
+        Self::from_std(net::UdpSocket::from_socket(socket))
     }
 }
 

--- a/cap-async-std/src/os/unix/net/incoming.rs
+++ b/cap-async-std/src/os/unix/net/incoming.rs
@@ -3,7 +3,6 @@ use async_std::io;
 use async_std::os::unix;
 use async_std::stream::Stream;
 use async_std::task::{Context, Poll};
-use cap_primitives::{ambient_authority, AmbientAuthority};
 use std::fmt;
 use std::pin::Pin;
 
@@ -21,12 +20,11 @@ impl<'a> Incoming<'a> {
     /// Constructs a new instance of `Self` from the given
     /// `async_std::os::unix::net::Incoming`.
     ///
-    /// # Ambient Authority
-    ///
-    /// `async_std::net::Incoming` is not sandboxed and may access any address
-    /// that the host process has access to.
+    /// This grants access the resources the
+    /// `async_std::os::unix::net::Incoming` instance already has access to,
+    /// without any sandboxing.
     #[inline]
-    pub fn from_std(std: unix::net::Incoming<'a>, _: AmbientAuthority) -> Self {
+    pub fn from_std(std: unix::net::Incoming<'a>) -> Self {
         Self { std }
     }
 }
@@ -39,7 +37,7 @@ impl<'a> Stream for Incoming<'a> {
         Stream::poll_next(Pin::new(&mut self.std), cx).map(|poll| {
             poll.map(|result| {
                 let unix_stream = result?;
-                Ok(UnixStream::from_std(unix_stream, ambient_authority()))
+                Ok(UnixStream::from_std(unix_stream))
             })
         })
     }

--- a/cap-async-std/src/os/unix/net/unix_listener.rs
+++ b/cap-async-std/src/os/unix/net/unix_listener.rs
@@ -2,7 +2,6 @@ use crate::os::unix::net::{Incoming, SocketAddr, UnixStream};
 use async_std::io;
 use async_std::os::unix;
 use async_std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
-use cap_primitives::{ambient_authority, AmbientAuthority};
 use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 use std::fmt;
 
@@ -25,12 +24,11 @@ impl UnixListener {
     /// Constructs a new instance of `Self` from the given
     /// `async_std::os::unix::net::UnixListener`.
     ///
-    /// # Ambient Authority
-    ///
-    /// `async_std::os::unix::net::UnixListener` is not sandboxed and may
-    /// access any address that the host process has access to.
+    /// This grants access the resources the
+    /// `async_std::os::unix::net::UnixListener` instance already has access
+    /// to.
     #[inline]
-    pub fn from_std(std: unix::net::UnixListener, _: AmbientAuthority) -> Self {
+    pub fn from_std(std: unix::net::UnixListener) -> Self {
         Self { std }
     }
 
@@ -41,9 +39,10 @@ impl UnixListener {
     /// [`async_std::os::unix::net::UnixListener::accept`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixListener.html#method.accept
     #[inline]
     pub async fn accept(&self) -> io::Result<(UnixStream, SocketAddr)> {
-        self.std.accept().await.map(|(unix_stream, addr)| {
-            (UnixStream::from_std(unix_stream, ambient_authority()), addr)
-        })
+        self.std
+            .accept()
+            .await
+            .map(|(unix_stream, addr)| (UnixStream::from_std(unix_stream), addr))
     }
 
     // async_std doesn't have `try_clone`.
@@ -72,24 +71,21 @@ impl UnixListener {
     #[inline]
     pub fn incoming(&self) -> Incoming {
         let incoming = self.std.incoming();
-        Incoming::from_std(incoming, ambient_authority())
+        Incoming::from_std(incoming)
     }
 }
 
 impl FromRawFd for UnixListener {
     #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self::from_std(
-            unix::net::UnixListener::from_raw_fd(fd),
-            ambient_authority(),
-        )
+        Self::from_std(unix::net::UnixListener::from_raw_fd(fd))
     }
 }
 
 impl FromFd for UnixListener {
     #[inline]
     fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(unix::net::UnixListener::from_fd(fd), ambient_authority())
+        Self::from_std(unix::net::UnixListener::from_fd(fd))
     }
 }
 

--- a/cap-fs-ext/src/dir_ext.rs
+++ b/cap-fs-ext/src/dir_ext.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "fs_utf8")]
 use camino::Utf8Path;
-use cap_primitives::ambient_authority;
 #[cfg(not(windows))]
 use cap_primitives::fs::symlink;
 use cap_primitives::fs::{open_dir_nofollow, set_times, set_times_nofollow};
@@ -520,7 +519,7 @@ impl DirExt for cap_std::fs::Dir {
     #[inline]
     fn open_dir_nofollow<P: AsRef<Path>>(&self, path: P) -> io::Result<Self> {
         match open_dir_nofollow(&self.as_filelike_view::<std::fs::File>(), path.as_ref()) {
-            Ok(file) => Ok(Self::from_std_file(file, ambient_authority())),
+            Ok(file) => Ok(Self::from_std_file(file)),
             Err(e) => Err(e),
         }
     }
@@ -806,7 +805,7 @@ impl AsyncDirExt for cap_async_std::fs::Dir {
         let clone = self.clone();
         spawn_blocking(move || {
             match open_dir_nofollow(&clone.as_filelike_view::<std::fs::File>(), path.as_ref()) {
-                Ok(file) => Ok(Self::from_std_file(file.into(), ambient_authority())),
+                Ok(file) => Ok(Self::from_std_file(file.into())),
                 Err(e) => Err(e),
             }
         })
@@ -979,7 +978,7 @@ impl DirExtUtf8 for cap_std::fs_utf8::Dir {
             &self.as_filelike_view::<std::fs::File>(),
             path.as_ref().as_ref(),
         ) {
-            Ok(file) => Ok(Self::from_std_file(file.into(), ambient_authority())),
+            Ok(file) => Ok(Self::from_std_file(file.into())),
             Err(e) => Err(e),
         }
     }
@@ -1209,7 +1208,7 @@ impl AsyncDirExtUtf8 for cap_async_std::fs_utf8::Dir {
         let clone = self.clone();
         spawn_blocking(move || {
             match open_dir_nofollow(&clone.as_filelike_view::<std::fs::File>(), path.as_ref()) {
-                Ok(file) => Ok(Self::from_std_file(file.into(), ambient_authority())),
+                Ok(file) => Ok(Self::from_std_file(file.into())),
                 Err(e) => Err(e),
             }
         })

--- a/cap-fs-ext/src/reopen.rs
+++ b/cap-fs-ext/src/reopen.rs
@@ -1,4 +1,3 @@
-use cap_primitives::ambient_authority;
 use cap_primitives::fs::{reopen, OpenOptions};
 #[cfg(any(feature = "std", feature = "async_std"))]
 use io_lifetimes::AsFilelike;
@@ -44,7 +43,7 @@ impl Reopen for cap_std::fs::File {
             &AsFilelike::as_filelike_view::<std::fs::File>(self),
             options,
         )?;
-        Ok(Self::from_std(file, ambient_authority()))
+        Ok(Self::from_std(file))
     }
 }
 
@@ -53,7 +52,7 @@ impl Reopen for cap_std::fs_utf8::File {
     #[inline]
     fn reopen(&self, options: &OpenOptions) -> io::Result<Self> {
         let file = reopen(&self.as_filelike_view::<std::fs::File>(), options)?;
-        Ok(Self::from_std(file, ambient_authority()))
+        Ok(Self::from_std(file))
     }
 }
 
@@ -72,7 +71,7 @@ impl Reopen for cap_async_std::fs::File {
     fn reopen(&self, options: &OpenOptions) -> io::Result<Self> {
         let file = reopen(&self.as_filelike_view::<std::fs::File>(), options)?;
         let std = async_std::fs::File::from_into_filelike(file);
-        Ok(Self::from_std(std, ambient_authority()))
+        Ok(Self::from_std(std))
     }
 }
 
@@ -82,6 +81,6 @@ impl Reopen for cap_async_std::fs_utf8::File {
     fn reopen(&self, options: &OpenOptions) -> io::Result<Self> {
         let file = reopen(&self.as_filelike_view::<std::fs::File>(), options)?;
         let std = async_std::fs::File::from_into_filelike(file);
-        Ok(Self::from_std(std, ambient_authority()))
+        Ok(Self::from_std(std))
     }
 }

--- a/cap-std/src/fs/dir_entry.rs
+++ b/cap-std/src/fs/dir_entry.rs
@@ -1,5 +1,4 @@
 use crate::fs::{Dir, File, FileType, Metadata, OpenOptions};
-use cap_primitives::ambient_authority;
 #[cfg(not(windows))]
 use rustix::fs::DirEntryExt;
 use std::ffi::OsString;
@@ -29,21 +28,21 @@ impl DirEntry {
     #[inline]
     pub fn open(&self) -> io::Result<File> {
         let file = self.inner.open()?;
-        Ok(File::from_std(file, ambient_authority()))
+        Ok(File::from_std(file))
     }
 
     /// Open the file with the given options.
     #[inline]
     pub fn open_with(&self, options: &OpenOptions) -> io::Result<File> {
         let file = self.inner.open_with(options)?;
-        Ok(File::from_std(file, ambient_authority()))
+        Ok(File::from_std(file))
     }
 
     /// Open the entry as a directory.
     #[inline]
     pub fn open_dir(&self) -> io::Result<Dir> {
         let dir = self.inner.open_dir()?;
-        Ok(Dir::from_std_file(dir, ambient_authority()))
+        Ok(Dir::from_std_file(dir))
     }
 
     /// Removes the file from its filesystem.

--- a/cap-std/src/fs_utf8/dir.rs
+++ b/cap-std/src/fs_utf8/dir.rs
@@ -3,7 +3,7 @@ use crate::fs_utf8::{from_utf8, to_utf8, DirBuilder, File, Metadata, ReadDir};
 #[cfg(unix)]
 use crate::os::unix::net::{UnixDatagram, UnixListener, UnixStream};
 use camino::{Utf8Path, Utf8PathBuf};
-use cap_primitives::{ambient_authority, AmbientAuthority};
+use cap_primitives::AmbientAuthority;
 #[cfg(not(windows))]
 use io_extras::os::rustix::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(not(windows))]
@@ -37,13 +37,11 @@ impl Dir {
     /// To prevent race conditions on Windows, the file must be opened without
     /// `FILE_SHARE_DELETE`.
     ///
-    /// # Ambient Authority
-    ///
-    /// `std::fs::File` is not sandboxed and may access any path that the host
-    /// process has access to.
+    /// This grants access the resources the `std::fs::File` instance already
+    /// has access to.
     #[inline]
-    pub fn from_std_file(std_file: fs::File, ambient_authority: AmbientAuthority) -> Self {
-        Self::from_cap_std(crate::fs::Dir::from_std_file(std_file, ambient_authority))
+    pub fn from_std_file(std_file: fs::File) -> Self {
+        Self::from_cap_std(crate::fs::Dir::from_std_file(std_file))
     }
 
     /// Constructs a new instance of `Self` from the given `cap_std::fs::Dir`.
@@ -584,7 +582,7 @@ impl Dir {
 impl FromRawFd for Dir {
     #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self::from_std_file(fs::File::from_raw_fd(fd), ambient_authority())
+        Self::from_std_file(fs::File::from_raw_fd(fd))
     }
 }
 
@@ -592,7 +590,7 @@ impl FromRawFd for Dir {
 impl FromFd for Dir {
     #[inline]
     fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std_file(fs::File::from_fd(fd), ambient_authority())
+        Self::from_std_file(fs::File::from_fd(fd))
     }
 }
 
@@ -602,7 +600,7 @@ impl FromRawHandle for Dir {
     /// without `FILE_SHARE_DELETE`.
     #[inline]
     unsafe fn from_raw_handle(handle: RawHandle) -> Self {
-        Self::from_std_file(fs::File::from_raw_handle(handle), ambient_authority())
+        Self::from_std_file(fs::File::from_raw_handle(handle))
     }
 }
 
@@ -612,7 +610,7 @@ impl FromHandle for Dir {
     /// without `FILE_SHARE_DELETE`.
     #[inline]
     fn from_handle(handle: OwnedHandle) -> Self {
-        Self::from_std_file(fs::File::from_handle(handle), ambient_authority())
+        Self::from_std_file(fs::File::from_handle(handle))
     }
 }
 

--- a/cap-std/src/fs_utf8/file.rs
+++ b/cap-std/src/fs_utf8/file.rs
@@ -1,7 +1,7 @@
 use crate::fs::{Metadata, OpenOptions, Permissions};
 use crate::fs_utf8::from_utf8;
 use camino::Utf8Path;
-use cap_primitives::{ambient_authority, AmbientAuthority};
+use cap_primitives::AmbientAuthority;
 #[cfg(not(windows))]
 use io_extras::os::rustix::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(not(windows))]
@@ -36,13 +36,11 @@ pub struct File {
 impl File {
     /// Constructs a new instance of `Self` from the given [`std::fs::File`].
     ///
-    /// # Ambient Authority
-    ///
-    /// [`std::fs::File`] is not sandboxed and may access any path that the
-    /// host process has access to.
+    /// This grants access the resources the `std::fs::File` instance
+    /// already has access to.
     #[inline]
-    pub fn from_std(std: fs::File, ambient_authority: AmbientAuthority) -> Self {
-        Self::from_cap_std(crate::fs::File::from_std(std, ambient_authority))
+    pub fn from_std(std: fs::File) -> Self {
+        Self::from_cap_std(crate::fs::File::from_std(std))
     }
 
     /// Constructs a new instance of `Self` from the given `cap_std::fs::File`.
@@ -163,7 +161,7 @@ impl File {
 impl FromRawFd for File {
     #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self::from_std(fs::File::from_raw_fd(fd), ambient_authority())
+        Self::from_std(fs::File::from_raw_fd(fd))
     }
 }
 
@@ -171,7 +169,7 @@ impl FromRawFd for File {
 impl FromFd for File {
     #[inline]
     fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(fs::File::from_fd(fd), ambient_authority())
+        Self::from_std(fs::File::from_fd(fd))
     }
 }
 
@@ -179,7 +177,7 @@ impl FromFd for File {
 impl FromRawHandle for File {
     #[inline]
     unsafe fn from_raw_handle(handle: RawHandle) -> Self {
-        Self::from_std(fs::File::from_raw_handle(handle), ambient_authority())
+        Self::from_std(fs::File::from_raw_handle(handle))
     }
 }
 
@@ -187,7 +185,7 @@ impl FromRawHandle for File {
 impl FromHandle for File {
     #[inline]
     fn from_handle(handle: OwnedHandle) -> Self {
-        Self::from_std(fs::File::from_handle(handle), ambient_authority())
+        Self::from_std(fs::File::from_handle(handle))
     }
 }
 

--- a/cap-std/src/net/incoming.rs
+++ b/cap-std/src/net/incoming.rs
@@ -1,5 +1,4 @@
 use crate::net::TcpStream;
-use cap_primitives::{ambient_authority, AmbientAuthority};
 use std::{fmt, io, net};
 
 /// An iterator that infinitely `accept`s connections on a [`TcpListener`].
@@ -15,12 +14,10 @@ impl<'a> Incoming<'a> {
     /// Constructs a new instance of `Self` from the given
     /// `std::net::Incoming`.
     ///
-    /// # Ambient Authority
-    ///
-    /// `std::net::Incoming` is not sandboxed and may access any address that
-    /// the host process has access to.
+    /// This grants access the resources the `std::net::Incoming` instance
+    /// already has access to.
     #[inline]
-    pub fn from_std(std: net::Incoming<'a>, _: AmbientAuthority) -> Self {
+    pub fn from_std(std: net::Incoming<'a>) -> Self {
         Self { std }
     }
 }
@@ -32,7 +29,7 @@ impl<'a> Iterator for Incoming<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.std.next().map(|result| {
             let tcp_stream = result?;
-            Ok(TcpStream::from_std(tcp_stream, ambient_authority()))
+            Ok(TcpStream::from_std(tcp_stream))
         })
     }
 

--- a/cap-std/src/net/pool.rs
+++ b/cap-std/src/net/pool.rs
@@ -1,6 +1,6 @@
 use crate::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs, UdpSocket};
 use cap_primitives::net::NO_SOCKET_ADDRS;
-use cap_primitives::{ambient_authority, AmbientAuthority};
+use cap_primitives::AmbientAuthority;
 use std::time::Duration;
 use std::{io, net};
 
@@ -61,9 +61,7 @@ impl Pool {
             self.cap.check_addr(&addr)?;
             // TODO: when compiling for WASI, use WASI-specific methods instead
             match net::TcpListener::bind(addr) {
-                Ok(tcp_listener) => {
-                    return Ok(TcpListener::from_std(tcp_listener, ambient_authority()))
-                }
+                Ok(tcp_listener) => return Ok(TcpListener::from_std(tcp_listener)),
                 Err(e) => last_err = Some(e),
             }
         }
@@ -85,7 +83,7 @@ impl Pool {
             self.cap.check_addr(&addr)?;
             // TODO: when compiling for WASI, use WASI-specific methods instead
             match net::TcpStream::connect(addr) {
-                Ok(tcp_stream) => return Ok(TcpStream::from_std(tcp_stream, ambient_authority())),
+                Ok(tcp_stream) => return Ok(TcpStream::from_std(tcp_stream)),
                 Err(e) => last_err = Some(e),
             }
         }
@@ -106,7 +104,7 @@ impl Pool {
     ) -> io::Result<TcpStream> {
         self.cap.check_addr(addr)?;
         let tcp_stream = net::TcpStream::connect_timeout(addr, timeout)?;
-        Ok(TcpStream::from_std(tcp_stream, ambient_authority()))
+        Ok(TcpStream::from_std(tcp_stream))
     }
 
     /// Creates a UDP socket from the given address.
@@ -120,7 +118,7 @@ impl Pool {
         for addr in addrs {
             self.cap.check_addr(&addr)?;
             match net::UdpSocket::bind(addr) {
-                Ok(udp_socket) => return Ok(UdpSocket::from_std(udp_socket, ambient_authority())),
+                Ok(udp_socket) => return Ok(UdpSocket::from_std(udp_socket)),
                 Err(e) => last_err = Some(e),
             }
         }

--- a/cap-std/src/net/tcp_stream.rs
+++ b/cap-std/src/net/tcp_stream.rs
@@ -1,5 +1,4 @@
 use crate::net::{Shutdown, SocketAddr};
-use cap_primitives::{ambient_authority, AmbientAuthority};
 #[cfg(not(windows))]
 use io_extras::os::rustix::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(not(windows))]
@@ -33,12 +32,10 @@ impl TcpStream {
     /// Constructs a new instance of `Self` from the given
     /// `std::net::TcpStream`.
     ///
-    /// # Ambient Authority
-    ///
-    /// `std::net::TcpStream` is not sandboxed and may access any address that
-    /// the host process has access to.
+    /// This grants access the resources the `std::net::TcpStream` instance
+    /// already has access to.
     #[inline]
-    pub fn from_std(std: net::TcpStream, _: AmbientAuthority) -> Self {
+    pub fn from_std(std: net::TcpStream) -> Self {
         Self { std }
     }
 
@@ -72,7 +69,7 @@ impl TcpStream {
     #[inline]
     pub fn try_clone(&self) -> io::Result<Self> {
         let tcp_stream = self.std.try_clone()?;
-        Ok(Self::from_std(tcp_stream, ambient_authority()))
+        Ok(Self::from_std(tcp_stream))
     }
 
     /// Sets the read timeout to the timeout specified.
@@ -169,7 +166,7 @@ impl TcpStream {
 impl FromRawFd for TcpStream {
     #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self::from_std(net::TcpStream::from_raw_fd(fd), ambient_authority())
+        Self::from_std(net::TcpStream::from_raw_fd(fd))
     }
 }
 
@@ -177,7 +174,7 @@ impl FromRawFd for TcpStream {
 impl FromFd for TcpStream {
     #[inline]
     fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(net::TcpStream::from_fd(fd), ambient_authority())
+        Self::from_std(net::TcpStream::from_fd(fd))
     }
 }
 
@@ -185,7 +182,7 @@ impl FromFd for TcpStream {
 impl FromRawSocket for TcpStream {
     #[inline]
     unsafe fn from_raw_socket(socket: RawSocket) -> Self {
-        Self::from_std(net::TcpStream::from_raw_socket(socket), ambient_authority())
+        Self::from_std(net::TcpStream::from_raw_socket(socket))
     }
 }
 
@@ -193,7 +190,7 @@ impl FromRawSocket for TcpStream {
 impl FromSocket for TcpStream {
     #[inline]
     fn from_socket(socket: OwnedSocket) -> Self {
-        Self::from_std(net::TcpStream::from_socket(socket), ambient_authority())
+        Self::from_std(net::TcpStream::from_socket(socket))
     }
 }
 

--- a/cap-std/src/net/udp_socket.rs
+++ b/cap-std/src/net/udp_socket.rs
@@ -1,5 +1,4 @@
 use crate::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
-use cap_primitives::{ambient_authority, AmbientAuthority};
 #[cfg(not(windows))]
 use io_extras::os::rustix::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(not(windows))]
@@ -37,12 +36,10 @@ impl UdpSocket {
     /// Constructs a new instance of `Self` from the given
     /// `std::net::UdpSocket`.
     ///
-    /// # Ambient Authority
-    ///
-    /// `std::net::UdpSocket` is not sandboxed and may access any address that
-    /// the host process has access to.
+    /// This grants access the resources the `std::net::UdpSocket` instance
+    /// already has access to.
     #[inline]
-    pub fn from_std(std: net::UdpSocket, _: AmbientAuthority) -> Self {
+    pub fn from_std(std: net::UdpSocket) -> Self {
         Self { std }
     }
 
@@ -86,7 +83,7 @@ impl UdpSocket {
     #[inline]
     pub fn try_clone(&self) -> io::Result<Self> {
         let udp_socket = self.std.try_clone()?;
-        Ok(Self::from_std(udp_socket, ambient_authority()))
+        Ok(Self::from_std(udp_socket))
     }
 
     /// Sets the read timeout to the timeout specified.
@@ -285,7 +282,7 @@ impl UdpSocket {
 impl FromRawFd for UdpSocket {
     #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self::from_std(net::UdpSocket::from_raw_fd(fd), ambient_authority())
+        Self::from_std(net::UdpSocket::from_raw_fd(fd))
     }
 }
 
@@ -293,7 +290,7 @@ impl FromRawFd for UdpSocket {
 impl FromFd for UdpSocket {
     #[inline]
     fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(net::UdpSocket::from_fd(fd), ambient_authority())
+        Self::from_std(net::UdpSocket::from_fd(fd))
     }
 }
 
@@ -301,7 +298,7 @@ impl FromFd for UdpSocket {
 impl FromRawSocket for UdpSocket {
     #[inline]
     unsafe fn from_raw_socket(socket: RawSocket) -> Self {
-        Self::from_std(net::UdpSocket::from_raw_socket(socket), ambient_authority())
+        Self::from_std(net::UdpSocket::from_raw_socket(socket))
     }
 }
 
@@ -309,7 +306,7 @@ impl FromRawSocket for UdpSocket {
 impl FromSocket for UdpSocket {
     #[inline]
     fn from_socket(socket: OwnedSocket) -> Self {
-        Self::from_std(net::UdpSocket::from_socket(socket), ambient_authority())
+        Self::from_std(net::UdpSocket::from_socket(socket))
     }
 }
 

--- a/cap-std/src/os/unix/net/incoming.rs
+++ b/cap-std/src/os/unix/net/incoming.rs
@@ -1,5 +1,4 @@
 use crate::os::unix::net::UnixStream;
-use cap_primitives::{ambient_authority, AmbientAuthority};
 use std::os::unix;
 use std::{fmt, io};
 
@@ -17,12 +16,10 @@ impl<'a> Incoming<'a> {
     /// Constructs a new instance of `Self` from the given
     /// `std::os::unix::net::Incoming`.
     ///
-    /// # Ambient Authority
-    ///
-    /// `std::net::Incoming` is not sandboxed and may access any address that
-    /// the host process has access to.
+    /// This grants access the resources the `std::os::unix::net::Incoming`
+    /// instance already has access to.
     #[inline]
-    pub fn from_std(std: unix::net::Incoming<'a>, _: AmbientAuthority) -> Self {
+    pub fn from_std(std: unix::net::Incoming<'a>) -> Self {
         Self { std }
     }
 }
@@ -34,7 +31,7 @@ impl<'a> Iterator for Incoming<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.std.next().map(|result| {
             let unix_stream = result?;
-            Ok(UnixStream::from_std(unix_stream, ambient_authority()))
+            Ok(UnixStream::from_std(unix_stream))
         })
     }
 


### PR DESCRIPTION
Originally, the `from_std` functions had `AmbientAuthority` functions to
reflect the fact that `std` types had constructors that implied ambient
authorities, such as `std::fs::File::open`, so passing in a
`std::fs::File`, as opposed to a `cap_std::fs::File`, indicated that the
code may have used `std::fs::File::open` to acquire it.

However now that there's a [clippy config] which can scan for uses of
functions like `std::fs::File::open`, that's a better solution for use
cases where this is important.

This also fixes an inconsistency, where using `from_std` required an
`AmbientAuthority` but `from_fd` didn't. See #201 for discussion.

[clippy config]: https://github.com/sunfishcode/ambient-authority/blob/main/clippy.toml