### PR TITLE
Use fine-grained feature detection instead of `rustc_version`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,6 @@ repository = "https://github.com/bytecodealliance/cap-std"
 edition = "2018"
 publish = false
 
-[build-dependencies]
-rustc_version = "0.4.0"
-
 [dev-dependencies]
 async-std = { version = "1.10.0", features = ["attributes"] }
 anyhow = "1.0.37"

--- a/build.rs
+++ b/build.rs
@@ -1,29 +1,58 @@
+use std::env::var;
+use std::io::Write;
+
 fn main() {
-    if let rustc_version::Channel::Nightly = rustc_version::version_meta()
-        .expect("query rustc release channel")
-        .channel
-    {
-        for feature in &[
-            "can_vector",         // https://github.com/rust-lang/rust/issues/69941
-            "clamp",              // https://github.com/rust-lang/rust/issues/44095
-            "extend_one",         // https://github.com/rust-lang/rust/issues/72631
-            "pattern",            // https://github.com/rust-lang/rust/issues/27721
-            "seek_convenience",   // https://github.com/rust-lang/rust/issues/59359
-            "shrink_to",          // https://github.com/rust-lang/rust/issues/56431
-            "toowned_clone_into", // https://github.com/rust-lang/rust/issues/41263
-            "try_reserve",        // https://github.com/rust-lang/rust/issues/56431
-            "unix_socket_peek",   // https://github.com/rust-lang/rust/issues/76923
-            "windows_by_handle",  // https://github.com/rust-lang/rust/issues/63010
-            "with_options",       // https://github.com/rust-lang/rust/issues/65439
-            "write_all_vectored", // https://github.com/rust-lang/rust/issues/70436
-            // https://doc.rust-lang.org/unstable-book/library-features/windows-file-type-ext.html
-            "windows_file_type_ext",
-        ] {
-            println!("cargo:rustc-cfg={}", feature);
-        }
-    }
+    use_feature_or_nothing("can_vector"); // https://github.com/rust-lang/rust/issues/69941
+    use_feature_or_nothing("clamp"); // https://github.com/rust-lang/rust/issues/44095
+    use_feature_or_nothing("extend_one"); // https://github.com/rust-lang/rust/issues/72631
+    use_feature_or_nothing("io_error_more"); // https://github.com/rust-lang/rust/issues/86442
+    use_feature_or_nothing("pattern"); // https://github.com/rust-lang/rust/issues/27721
+    use_feature_or_nothing("seek_convenience"); // https://github.com/rust-lang/rust/issues/59359
+    use_feature_or_nothing("shrink_to"); // https://github.com/rust-lang/rust/issues/56431
+    use_feature_or_nothing("toowned_clone_into"); // https://github.com/rust-lang/rust/issues/41263
+    use_feature_or_nothing("try_reserve"); // https://github.com/rust-lang/rust/issues/56431
+    use_feature_or_nothing("unix_socket_peek"); // https://github.com/rust-lang/rust/issues/76923
+    use_feature_or_nothing("windows_by_handle"); // https://github.com/rust-lang/rust/issues/63010
+    use_feature_or_nothing("with_options"); // https://github.com/rust-lang/rust/issues/65439
+    use_feature_or_nothing("write_all_vectored"); // https://github.com/rust-lang/rust/issues/70436
+                                                  // https://doc.rust-lang.org/unstable-book/library-features/windows-file-type-ext.html
+    use_feature_or_nothing("windows_file_type_ext");
 
     // Don't rerun this on changes other than build.rs, as we only depend on
     // the rustc version.
     println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn use_feature_or_nothing(feature: &str) {
+    if has_feature(feature) {
+        use_feature(feature);
+    }
+}
+
+fn use_feature(feature: &str) {
+    println!("cargo:rustc-cfg={}", feature);
+}
+
+/// Test whether the rustc at `var("RUSTC")` supports the given feature.
+fn has_feature(feature: &str) -> bool {
+    let rustc = var("RUSTC").unwrap();
+
+    #[cfg(not(windows))]
+    let dev_null = "/dev/null";
+    #[cfg(windows)]
+    let dev_null = "NUL";
+
+    let mut child = std::process::Command::new(rustc)
+        .arg("--crate-type=rlib") // Don't require `main`.
+        .arg("--emit=dep-info") // Do as little as possible.
+        .arg("-o")
+        .arg(dev_null) // Don't write an output file.
+        .arg("-") // Read from stdin.
+        .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
+        .spawn()
+        .unwrap();
+
+    writeln!(child.stdin.take().unwrap(), "#![feature({})]", feature).unwrap();
+
+    child.wait().unwrap().success()
 }

--- a/build.rs
+++ b/build.rs
@@ -35,18 +35,14 @@ fn use_feature(feature: &str) {
 
 /// Test whether the rustc at `var("RUSTC")` supports the given feature.
 fn has_feature(feature: &str) -> bool {
+    let out_dir = var("OUT_DIR").unwrap();
     let rustc = var("RUSTC").unwrap();
-
-    #[cfg(not(windows))]
-    let dev_null = "/dev/null";
-    #[cfg(windows)]
-    let dev_null = "NUL";
 
     let mut child = std::process::Command::new(rustc)
         .arg("--crate-type=rlib") // Don't require `main`.
-        .arg("--emit=dep-info") // Do as little as possible.
-        .arg("-o")
-        .arg(dev_null) // Don't write an output file.
+        .arg("--emit=metadata") // Do as little as possible but still parse.
+        .arg("--out-dir")
+        .arg(out_dir) // Put the output somewhere inconsequential.
         .arg("-") // Read from stdin.
         .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
         .spawn()

--- a/cap-fs-ext/Cargo.toml
+++ b/cap-fs-ext/Cargo.toml
@@ -12,9 +12,6 @@ categories = ["filesystem"]
 repository = "https://github.com/bytecodealliance/cap-std"
 edition = "2018"
 
-[build-dependencies]
-rustc_version = "0.4.0"
-
 [dependencies]
 arf-strings = { version = "0.6.2", optional = true }
 cap-async-std = { path = "../cap-async-std", optional = true, version = "^0.21.2-alpha.0"}

--- a/cap-fs-ext/build.rs
+++ b/cap-fs-ext/build.rs
@@ -1,29 +1,44 @@
+use std::env::var;
+use std::io::Write;
+
 fn main() {
-    if let rustc_version::Channel::Nightly = rustc_version::version_meta()
-        .expect("query rustc release channel")
-        .channel
-    {
-        for feature in &[
-            "can_vector",         // https://github.com/rust-lang/rust/issues/69941
-            "clamp",              // https://github.com/rust-lang/rust/issues/44095
-            "extend_one",         // https://github.com/rust-lang/rust/issues/72631
-            "pattern",            // https://github.com/rust-lang/rust/issues/27721
-            "seek_convenience",   // https://github.com/rust-lang/rust/issues/59359
-            "shrink_to",          // https://github.com/rust-lang/rust/issues/56431
-            "toowned_clone_into", // https://github.com/rust-lang/rust/issues/41263
-            "try_reserve",        // https://github.com/rust-lang/rust/issues/56431
-            "unix_socket_peek",   // https://github.com/rust-lang/rust/issues/76923
-            "windows_by_handle",  // https://github.com/rust-lang/rust/issues/63010
-            "with_options",       // https://github.com/rust-lang/rust/issues/65439
-            "write_all_vectored", // https://github.com/rust-lang/rust/issues/70436
-            // https://doc.rust-lang.org/unstable-book/library-features/windows-file-type-ext.html
-            "windows_file_type_ext",
-        ] {
-            println!("cargo:rustc-cfg={}", feature);
-        }
-    }
+    use_feature_or_nothing("windows_by_handle"); // https://github.com/rust-lang/rust/issues/63010
 
     // Don't rerun this on changes other than build.rs, as we only depend on
     // the rustc version.
     println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn use_feature_or_nothing(feature: &str) {
+    if has_feature(feature) {
+        use_feature(feature);
+    }
+}
+
+fn use_feature(feature: &str) {
+    println!("cargo:rustc-cfg={}", feature);
+}
+
+/// Test whether the rustc at `var("RUSTC")` supports the given feature.
+fn has_feature(feature: &str) -> bool {
+    let rustc = var("RUSTC").unwrap();
+
+    #[cfg(not(windows))]
+    let dev_null = "/dev/null";
+    #[cfg(windows)]
+    let dev_null = "NUL";
+
+    let mut child = std::process::Command::new(rustc)
+        .arg("--crate-type=rlib") // Don't require `main`.
+        .arg("--emit=dep-info") // Do as little as possible.
+        .arg("-o")
+        .arg(dev_null) // Don't write an output file.
+        .arg("-") // Read from stdin.
+        .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
+        .spawn()
+        .unwrap();
+
+    writeln!(child.stdin.take().unwrap(), "#![feature({})]", feature).unwrap();
+
+    child.wait().unwrap().success()
 }

--- a/cap-fs-ext/build.rs
+++ b/cap-fs-ext/build.rs
@@ -21,18 +21,14 @@ fn use_feature(feature: &str) {
 
 /// Test whether the rustc at `var("RUSTC")` supports the given feature.
 fn has_feature(feature: &str) -> bool {
+    let out_dir = var("OUT_DIR").unwrap();
     let rustc = var("RUSTC").unwrap();
-
-    #[cfg(not(windows))]
-    let dev_null = "/dev/null";
-    #[cfg(windows)]
-    let dev_null = "NUL";
 
     let mut child = std::process::Command::new(rustc)
         .arg("--crate-type=rlib") // Don't require `main`.
-        .arg("--emit=dep-info") // Do as little as possible.
-        .arg("-o")
-        .arg(dev_null) // Don't write an output file.
+        .arg("--emit=metadata") // Do as little as possible but still parse.
+        .arg("--out-dir")
+        .arg(out_dir) // Put the output somewhere inconsequential.
         .arg("-") // Read from stdin.
         .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
         .spawn()

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -12,9 +12,6 @@ categories = ["filesystem", "network-programming"]
 repository = "https://github.com/bytecodealliance/cap-std"
 edition = "2018"
 
-[build-dependencies]
-rustc_version = "0.4.0"
-
 [dependencies]
 ambient-authority = "0.0.1"
 arbitrary = { version = "1.0.0", optional = true, features = ["derive"] }

--- a/cap-primitives/build.rs
+++ b/cap-primitives/build.rs
@@ -24,18 +24,14 @@ fn use_feature(feature: &str) {
 
 /// Test whether the rustc at `var("RUSTC")` supports the given feature.
 fn has_feature(feature: &str) -> bool {
+    let out_dir = var("OUT_DIR").unwrap();
     let rustc = var("RUSTC").unwrap();
-
-    #[cfg(not(windows))]
-    let dev_null = "/dev/null";
-    #[cfg(windows)]
-    let dev_null = "NUL";
 
     let mut child = std::process::Command::new(rustc)
         .arg("--crate-type=rlib") // Don't require `main`.
-        .arg("--emit=dep-info") // Do as little as possible.
-        .arg("-o")
-        .arg(dev_null) // Don't write an output file.
+        .arg("--emit=metadata") // Do as little as possible but still parse.
+        .arg("--out-dir")
+        .arg(out_dir) // Put the output somewhere inconsequential.
         .arg("-") // Read from stdin.
         .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
         .spawn()

--- a/cap-primitives/build.rs
+++ b/cap-primitives/build.rs
@@ -1,30 +1,47 @@
+use std::env::var;
+use std::io::Write;
+
 fn main() {
-    if let rustc_version::Channel::Nightly = rustc_version::version_meta()
-        .expect("query rustc release channel")
-        .channel
-    {
-        for feature in &[
-            "can_vector",         // https://github.com/rust-lang/rust/issues/69941
-            "clamp",              // https://github.com/rust-lang/rust/issues/44095
-            "extend_one",         // https://github.com/rust-lang/rust/issues/72631
-            "io_error_more",      // https://github.com/rust-lang/rust/issues/86442
-            "pattern",            // https://github.com/rust-lang/rust/issues/27721
-            "seek_convenience",   // https://github.com/rust-lang/rust/issues/59359
-            "shrink_to",          // https://github.com/rust-lang/rust/issues/56431
-            "toowned_clone_into", // https://github.com/rust-lang/rust/issues/41263
-            "try_reserve",        // https://github.com/rust-lang/rust/issues/56431
-            "unix_socket_peek",   // https://github.com/rust-lang/rust/issues/76923
-            "windows_by_handle",  // https://github.com/rust-lang/rust/issues/63010
-            "with_options",       // https://github.com/rust-lang/rust/issues/65439
-            "write_all_vectored", // https://github.com/rust-lang/rust/issues/70436
-            // https://doc.rust-lang.org/unstable-book/library-features/windows-file-type-ext.html
-            "windows_file_type_ext",
-        ] {
-            println!("cargo:rustc-cfg={}", feature);
-        }
-    }
+    use_feature_or_nothing("windows_by_handle"); // https://github.com/rust-lang/rust/issues/63010
+                                                 // https://doc.rust-lang.org/unstable-book/library-features/windows-file-type-ext.html
+    use_feature_or_nothing("windows_file_type_ext");
+    use_feature_or_nothing("io_error_more"); // https://github.com/rust-lang/rust/issues/86442
 
     // Don't rerun this on changes other than build.rs, as we only depend on
     // the rustc version.
     println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn use_feature_or_nothing(feature: &str) {
+    if has_feature(feature) {
+        use_feature(feature);
+    }
+}
+
+fn use_feature(feature: &str) {
+    println!("cargo:rustc-cfg={}", feature);
+}
+
+/// Test whether the rustc at `var("RUSTC")` supports the given feature.
+fn has_feature(feature: &str) -> bool {
+    let rustc = var("RUSTC").unwrap();
+
+    #[cfg(not(windows))]
+    let dev_null = "/dev/null";
+    #[cfg(windows)]
+    let dev_null = "NUL";
+
+    let mut child = std::process::Command::new(rustc)
+        .arg("--crate-type=rlib") // Don't require `main`.
+        .arg("--emit=dep-info") // Do as little as possible.
+        .arg("-o")
+        .arg(dev_null) // Don't write an output file.
+        .arg("-") // Read from stdin.
+        .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
+        .spawn()
+        .unwrap();
+
+    writeln!(child.stdin.take().unwrap(), "#![feature({})]", feature).unwrap();
+
+    child.wait().unwrap().success()
 }

--- a/cap-std/Cargo.toml
+++ b/cap-std/Cargo.toml
@@ -12,9 +12,6 @@ categories = ["filesystem", "network-programming"]
 repository = "https://github.com/bytecodealliance/cap-std"
 edition = "2018"
 
-[build-dependencies]
-rustc_version = "0.4.0"
-
 [dependencies]
 arf-strings = { version = "0.6.2", optional = true }
 cap-primitives = { path = "../cap-primitives", version = "^0.21.2-alpha.0"}

--- a/cap-std/build.rs
+++ b/cap-std/build.rs
@@ -24,18 +24,14 @@ fn use_feature(feature: &str) {
 
 /// Test whether the rustc at `var("RUSTC")` supports the given feature.
 fn has_feature(feature: &str) -> bool {
+    let out_dir = var("OUT_DIR").unwrap();
     let rustc = var("RUSTC").unwrap();
-
-    #[cfg(not(windows))]
-    let dev_null = "/dev/null";
-    #[cfg(windows)]
-    let dev_null = "NUL";
 
     let mut child = std::process::Command::new(rustc)
         .arg("--crate-type=rlib") // Don't require `main`.
-        .arg("--emit=dep-info") // Do as little as possible.
-        .arg("-o")
-        .arg(dev_null) // Don't write an output file.
+        .arg("--emit=metadata") // Do as little as possible but still parse.
+        .arg("--out-dir")
+        .arg(out_dir) // Put the output somewhere inconsequential.
         .arg("-") // Read from stdin.
         .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
         .spawn()

--- a/cap-std/build.rs
+++ b/cap-std/build.rs
@@ -1,29 +1,47 @@
+use std::env::var;
+use std::io::Write;
+
 fn main() {
-    if let rustc_version::Channel::Nightly = rustc_version::version_meta()
-        .expect("query rustc release channel")
-        .channel
-    {
-        for feature in &[
-            "can_vector",         // https://github.com/rust-lang/rust/issues/69941
-            "clamp",              // https://github.com/rust-lang/rust/issues/44095
-            "extend_one",         // https://github.com/rust-lang/rust/issues/72631
-            "pattern",            // https://github.com/rust-lang/rust/issues/27721
-            "seek_convenience",   // https://github.com/rust-lang/rust/issues/59359
-            "shrink_to",          // https://github.com/rust-lang/rust/issues/56431
-            "toowned_clone_into", // https://github.com/rust-lang/rust/issues/41263
-            "try_reserve",        // https://github.com/rust-lang/rust/issues/56431
-            "unix_socket_peek",   // https://github.com/rust-lang/rust/issues/76923
-            "windows_by_handle",  // https://github.com/rust-lang/rust/issues/63010
-            "with_options",       // https://github.com/rust-lang/rust/issues/65439
-            "write_all_vectored", // https://github.com/rust-lang/rust/issues/70436
-            // https://doc.rust-lang.org/unstable-book/library-features/windows-file-type-ext.html
-            "windows_file_type_ext",
-        ] {
-            println!("cargo:rustc-cfg={}", feature);
-        }
-    }
+    use_feature_or_nothing("can_vector"); // https://github.com/rust-lang/rust/issues/69941
+    use_feature_or_nothing("seek_convenience"); // https://github.com/rust-lang/rust/issues/59359
+    use_feature_or_nothing("with_options"); // https://github.com/rust-lang/rust/issues/65439
+    use_feature_or_nothing("write_all_vectored"); // https://github.com/rust-lang/rust/issues/70436
 
     // Don't rerun this on changes other than build.rs, as we only depend on
     // the rustc version.
     println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn use_feature_or_nothing(feature: &str) {
+    if has_feature(feature) {
+        use_feature(feature);
+    }
+}
+
+fn use_feature(feature: &str) {
+    println!("cargo:rustc-cfg={}", feature);
+}
+
+/// Test whether the rustc at `var("RUSTC")` supports the given feature.
+fn has_feature(feature: &str) -> bool {
+    let rustc = var("RUSTC").unwrap();
+
+    #[cfg(not(windows))]
+    let dev_null = "/dev/null";
+    #[cfg(windows)]
+    let dev_null = "NUL";
+
+    let mut child = std::process::Command::new(rustc)
+        .arg("--crate-type=rlib") // Don't require `main`.
+        .arg("--emit=dep-info") // Do as little as possible.
+        .arg("-o")
+        .arg(dev_null) // Don't write an output file.
+        .arg("-") // Read from stdin.
+        .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
+        .spawn()
+        .unwrap();
+
+    writeln!(child.stdin.take().unwrap(), "#![feature({})]", feature).unwrap();
+
+    child.wait().unwrap().success()
 }


### PR DESCRIPTION
Test whether rustc supports specific features, rather than assuming that
Nightly has all the features and Stable doesn't.