### PR TITLE
Fix the CI script to actually test wasm32-wasi cross-check.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,7 +164,7 @@ jobs:
     - run: cargo check --workspace --all-targets --all-features --release -vv --target=riscv64gc-unknown-linux-gnu
     - run: cargo check --workspace --all-targets --all-features --release -vv --target=arm-unknown-linux-gnueabihf
     - run: cargo check --workspace --all-targets --all-features --release -vv --target=aarch64-linux-android
-    - run: cd cap-std && cargo check --features=fs_utf8 --release -vv
+    - run: cd cap-std && cargo check --features=fs_utf8 --release -vv --target=wasm32-wasi
 
   check_cross_nightly_windows:
     name: Check Cross-Compilation on Rust nightly on Windows


### PR DESCRIPTION
b2cf99410c76a4d26c30bf323f17641e9cdc673e add a line to test WASI support
in cap-std, but neglected to add `--target=wasm32-wasi` to the test
command.