### PR TITLE
Minor code cleanups.

### DIFF
--- a/cap-primitives/src/fs/file_path_by_searching.rs
+++ b/cap-primitives/src/fs/file_path_by_searching.rs
@@ -13,7 +13,7 @@ pub(crate) fn file_path_by_searching(file: &fs::File) -> Option<PathBuf> {
     // Iterate with `..` until we reach the root directory.
     'next_component: loop {
         // Open `..`.
-        let mut iter = read_dir_unchecked(&base, Component::ParentDir.as_os_str().as_ref()).ok()?;
+        let mut iter = read_dir_unchecked(&base, Component::ParentDir.as_ref()).ok()?;
         let metadata = Metadata::from_file(&*base).ok()?;
 
         // Search the children until we find one with matching metadata, and
@@ -24,7 +24,7 @@ pub(crate) fn file_path_by_searching(file: &fs::File) -> Option<PathBuf> {
                 // Found a match. Record the name and continue to the next component.
                 components.push(child.file_name());
                 base = MaybeOwnedFile::owned_noassert(
-                    open_dir_unchecked(&base, Component::ParentDir.as_os_str().as_ref()).ok()?,
+                    open_dir_unchecked(&base, Component::ParentDir.as_ref()).ok()?,
                 );
                 continue 'next_component;
             }

--- a/cap-primitives/src/fs/manually/open.rs
+++ b/cap-primitives/src/fs/manually/open.rs
@@ -168,7 +168,7 @@ impl<'start> Context<'start> {
             )?)
         }
         #[cfg(windows)]
-        open_dir_unchecked(&self.base, Component::CurDir.as_os_str().as_ref()).map(|_| ())
+        open_dir_unchecked(&self.base, Component::CurDir.as_ref()).map(|_| ())
     }
 
     /// Handle a "." path component.
@@ -440,7 +440,7 @@ pub(super) fn internal_open<'start>(
         }
         ctx.base = MaybeOwnedFile::owned(open_unchecked(
             &ctx.base,
-            Component::CurDir.as_os_str().as_ref(),
+            Component::CurDir.as_ref(),
             options,
         )?);
     }

--- a/cap-primitives/src/rustix/fs/remove_dir_all_impl.rs
+++ b/cap-primitives/src/rustix/fs/remove_dir_all_impl.rs
@@ -19,10 +19,7 @@ pub(crate) fn remove_dir_all_impl(start: &fs::File, path: &Path) -> io::Result<(
 }
 
 pub(crate) fn remove_open_dir_all_impl(dir: fs::File) -> io::Result<()> {
-    remove_dir_all_recursive(read_dir_unchecked(
-        &dir,
-        Component::CurDir.as_os_str().as_ref(),
-    )?)?;
+    remove_dir_all_recursive(read_dir_unchecked(&dir, Component::CurDir.as_ref())?)?;
     remove_open_dir(dir)
 }
 

--- a/cap-primitives/src/rustix/fs/remove_open_dir_by_searching.rs
+++ b/cap-primitives/src/rustix/fs/remove_open_dir_by_searching.rs
@@ -7,7 +7,7 @@ use std::{fs, io};
 /// available.
 pub(crate) fn remove_open_dir_by_searching(dir: fs::File) -> io::Result<()> {
     let metadata = Metadata::from_file(&dir)?;
-    let mut iter = read_dir_unchecked(&dir, Component::ParentDir.as_os_str().as_ref())?;
+    let mut iter = read_dir_unchecked(&dir, Component::ParentDir.as_ref())?;
     while let Some(child) = iter.next() {
         let child = child?;
         if child.is_same_file(&metadata)? {

--- a/cap-primitives/src/windows/fs/read_dir_inner.rs
+++ b/cap-primitives/src/windows/fs/read_dir_inner.rs
@@ -10,11 +10,11 @@ pub(crate) struct ReadDirInner {
 impl ReadDirInner {
     pub(crate) fn new(start: &fs::File, path: &Path) -> io::Result<Self> {
         let dir = open_dir(start, path)?;
-        Self::new_unchecked(&dir, Component::CurDir.as_os_str().as_ref())
+        Self::new_unchecked(&dir, Component::CurDir.as_ref())
     }
 
     pub(crate) fn read_base_dir(start: &fs::File) -> io::Result<Self> {
-        Self::new_unchecked(&start, Component::CurDir.as_os_str().as_ref())
+        Self::new_unchecked(&start, Component::CurDir.as_ref())
     }
 
     pub(crate) fn new_unchecked(start: &fs::File, path: &Path) -> io::Result<Self> {

--- a/cap-primitives/src/windows/fs/remove_dir_all_impl.rs
+++ b/cap-primitives/src/windows/fs/remove_dir_all_impl.rs
@@ -23,7 +23,7 @@ pub(crate) fn remove_dir_all_impl(start: &fs::File, path: &Path) -> io::Result<(
 }
 
 pub(crate) fn remove_open_dir_all_impl(dir: fs::File) -> io::Result<()> {
-    remove_dir_all_recursive(&dir, Component::CurDir.as_os_str().as_ref())?;
+    remove_dir_all_recursive(&dir, Component::CurDir.as_ref())?;
     remove_open_dir(dir)
 }
 


### PR DESCRIPTION
Simplify `CurDir.as_os_str().as_ref()` to `CurDir.as_ref()`.