### PR TITLE
Add features corresponding to Rust 1.58's new filesystem features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ cap-tempfile = { path = "cap-tempfile", version = "^0.22.2-alpha.0"}
 rand = "0.8.1"
 tempfile = "3.1.0"
 camino = "1.0.5"
+libc = "0.2.100"
 
 [target.'cfg(not(windows))'.dev-dependencies]
 rustix = "0.31.0"

--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,7 @@ fn main() {
     use_feature_or_nothing("clamp"); // https://github.com/rust-lang/rust/issues/44095
     use_feature_or_nothing("extend_one"); // https://github.com/rust-lang/rust/issues/72631
     use_feature_or_nothing("io_error_more"); // https://github.com/rust-lang/rust/issues/86442
+    use_feature_or_nothing("io_error_uncategorized");
     use_feature_or_nothing("pattern"); // https://github.com/rust-lang/rust/issues/27721
     use_feature_or_nothing("seek_convenience"); // https://github.com/rust-lang/rust/issues/59359
     use_feature_or_nothing("shrink_to"); // https://github.com/rust-lang/rust/issues/56431

--- a/cap-async-std/src/fs/file.rs
+++ b/cap-async-std/src/fs/file.rs
@@ -149,6 +149,15 @@ impl File {
             .await
             .map(|f| Self::from_std(f.into()))
     }
+
+    /// Returns a new `OpenOptions` object.
+    ///
+    /// This corresponds to [`async_std::fs::File::options`].
+    #[must_use]
+    #[inline]
+    pub fn options() -> OpenOptions {
+        OpenOptions::new()
+    }
 }
 
 #[cfg(not(target_os = "wasi"))]

--- a/cap-async-std/src/fs_utf8/file.rs
+++ b/cap-async-std/src/fs_utf8/file.rs
@@ -142,6 +142,15 @@ impl File {
             .await
             .map(Self::from_cap_std)
     }
+
+    /// Returns a new `OpenOptions` object.
+    ///
+    /// This corresponds to [`async_std::fs::File::options`].
+    #[must_use]
+    #[inline]
+    pub fn options() -> OpenOptions {
+        OpenOptions::new()
+    }
 }
 
 #[cfg(not(windows))]

--- a/cap-primitives/build.rs
+++ b/cap-primitives/build.rs
@@ -6,6 +6,7 @@ fn main() {
                                                  // https://doc.rust-lang.org/unstable-book/library-features/windows-file-type-ext.html
     use_feature_or_nothing("windows_file_type_ext");
     use_feature_or_nothing("io_error_more"); // https://github.com/rust-lang/rust/issues/86442
+    use_feature_or_nothing("io_error_uncategorized");
 
     // Don't rerun this on changes other than build.rs, as we only depend on
     // the rustc version.

--- a/cap-primitives/src/fs/metadata.rs
+++ b/cap-primitives/src/fs/metadata.rs
@@ -105,6 +105,14 @@ impl Metadata {
         self.file_type.is_file()
     }
 
+    /// Returns `true` if this metadata is for a symbolic link.
+    ///
+    /// This corresponds to [`std::fs::Metadata::is_symlink`].
+    #[inline]
+    pub fn is_symlink(&self) -> bool {
+        self.file_type.is_symlink()
+    }
+
     /// Returns the size of the file, in bytes, this metadata is for.
     ///
     /// This corresponds to [`std::fs::Metadata::len`].

--- a/cap-primitives/src/fs/metadata.rs
+++ b/cap-primitives/src/fs/metadata.rs
@@ -134,12 +134,24 @@ impl Metadata {
     /// This corresponds to [`std::fs::Metadata::modified`].
     #[inline]
     pub fn modified(&self) -> io::Result<SystemTime> {
-        self.modified.ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                "modified time metadata not available on this platform",
-            )
-        })
+        #[cfg(io_error_uncategorized)]
+        {
+            self.modified.ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "modified time metadata not available on this platform",
+                )
+            })
+        }
+        #[cfg(not(io_error_uncategorized))]
+        {
+            self.modified.ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    "modified time metadata not available on this platform",
+                )
+            })
+        }
     }
 
     /// Returns the last access time of this metadata.
@@ -147,12 +159,24 @@ impl Metadata {
     /// This corresponds to [`std::fs::Metadata::accessed`].
     #[inline]
     pub fn accessed(&self) -> io::Result<SystemTime> {
-        self.accessed.ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                "accessed time metadata not available on this platform",
-            )
-        })
+        #[cfg(io_error_uncategorized)]
+        {
+            self.accessed.ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "accessed time metadata not available on this platform",
+                )
+            })
+        }
+        #[cfg(not(io_error_uncategorized))]
+        {
+            self.accessed.ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    "accessed time metadata not available on this platform",
+                )
+            })
+        }
     }
 
     /// Returns the creation time listed in this metadata.
@@ -160,12 +184,24 @@ impl Metadata {
     /// This corresponds to [`std::fs::Metadata::created`].
     #[inline]
     pub fn created(&self) -> io::Result<SystemTime> {
-        self.created.ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                "created time metadata not available on this platform",
-            )
-        })
+        #[cfg(io_error_uncategorized)]
+        {
+            self.created.ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "created time metadata not available on this platform",
+                )
+            })
+        }
+        #[cfg(not(io_error_uncategorized))]
+        {
+            self.created.ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    "created time metadata not available on this platform",
+                )
+            })
+        }
     }
 
     /// Determine if `self` and `other` refer to the same inode on the same

--- a/cap-primitives/src/lib.rs
+++ b/cap-primitives/src/lib.rs
@@ -13,6 +13,7 @@
 )]
 #![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
 #![cfg_attr(io_error_more, feature(io_error_more))]
+#![cfg_attr(io_error_uncategorized, feature(io_error_uncategorized))]
 
 #[cfg(not(windows))]
 mod rustix;

--- a/cap-std/src/fs/file.rs
+++ b/cap-std/src/fs/file.rs
@@ -146,6 +146,15 @@ impl File {
         let std = open_ambient(path.as_ref(), options, ambient_authority)?;
         Ok(Self::from_std(std))
     }
+
+    /// Returns a new `OpenOptions` object.
+    ///
+    /// This corresponds to [`std::fs::File::options`].
+    #[must_use]
+    #[inline]
+    pub fn options() -> OpenOptions {
+        OpenOptions::new()
+    }
 }
 
 #[inline]

--- a/cap-std/src/fs_utf8/file.rs
+++ b/cap-std/src/fs_utf8/file.rs
@@ -155,6 +155,15 @@ impl File {
             ambient_authority,
         )?))
     }
+
+    /// Returns a new `OpenOptions` object.
+    ///
+    /// This corresponds to [`std::fs::File::options`].
+    #[must_use]
+    #[inline]
+    pub fn options() -> OpenOptions {
+        OpenOptions::new()
+    }
 }
 
 #[cfg(not(windows))]

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -1400,10 +1400,10 @@ fn metadata_access_times() {
         // Not always available
         match (a.created(), b.created()) {
             (Ok(t1), Ok(t2)) => assert!(t1 <= t2),
-            #[cfg(not(io_error_more))]
+            #[cfg(not(io_error_uncategorized))]
             (Err(e1), Err(e2))
                 if e1.kind() == ErrorKind::Other && e2.kind() == ErrorKind::Other => {}
-            #[cfg(io_error_more)]
+            #[cfg(io_error_uncategorized)]
             (Err(e1), Err(e2))
                 if e1.kind() == ErrorKind::Uncategorized
                     && e2.kind() == ErrorKind::Uncategorized

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -1482,9 +1482,9 @@ fn symlink_hard_link() {
 #[test]
 #[cfg(windows)]
 fn create_dir_long_paths() {
-    use crate::ffi::OsStr;
-    use crate::iter;
-    use crate::os::windows::ffi::OsStrExt;
+    use std::ffi::OsStr;
+    use std::iter;
+    use std::os::windows::ffi::OsStrExt;
     const PATH_LEN: usize = 247;
 
     let tmpdir = tmpdir();
@@ -1512,6 +1512,6 @@ fn create_dir_long_paths() {
     let path = Path::new("");
     assert_eq!(
         tmpdir.canonicalize(path).unwrap_err().kind(),
-        crate::io::ErrorKind::NotFound
+        std::io::ErrorKind::NotFound
     );
 }

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -1,6 +1,8 @@
 // This file is derived from Rust's library/std/src/fs/tests.rs at revision
 // e4b1d5841494d6eb7f4944c91a057e16b0f0a9ea.
 
+#![cfg_attr(io_error_uncategorized, feature(io_error_uncategorized))]
+
 #[macro_use]
 mod sys_common;
 #[macro_use]

--- a/tests/fs_utf8.rs
+++ b/tests/fs_utf8.rs
@@ -1504,11 +1504,15 @@ fn create_dir_long_paths() {
     path.extend(iter::repeat(OsStr::new("a")).take(PATH_LEN - utf16_len));
 
     // This should succeed.
-    tmpdir.create_dir(&path).unwrap();
+    tmpdir
+        .create_dir(&PathBuf::from_path_buf(path.clone().into()).unwrap())
+        .unwrap();
 
     // This will fail if the path isn't converted to verbatim.
     path.push("a");
-    tmpdir.create_dir(&path).unwrap();
+    tmpdir
+        .create_dir(&PathBuf::from_path_buf(path.clone().into()).unwrap())
+        .unwrap();
 
     // #90940: Ensure an empty path returns the "Not Found" error.
     let path = Path::new("");

--- a/tests/fs_utf8.rs
+++ b/tests/fs_utf8.rs
@@ -1,6 +1,7 @@
 // This file is derived from Rust's library/std/src/fs/tests.rs at revision
 // e4b1d5841494d6eb7f4944c91a057e16b0f0a9ea.
 
+#![cfg_attr(io_error_uncategorized, feature(io_error_uncategorized))]
 #![cfg(feature = "fs_utf8")]
 
 #[macro_use]

--- a/tests/fs_utf8.rs
+++ b/tests/fs_utf8.rs
@@ -1,18 +1,22 @@
-// This file is derived from Rust's library/std/src/fs.rs at revision
-// 108e90ca78f052c0c1c49c42a22c85620be19712.
-//
-// This is the contents of the `tests` module, ported to use `cap_std`.
+// This file is derived from Rust's library/std/src/fs/tests.rs at revision
+// e4b1d5841494d6eb7f4944c91a057e16b0f0a9ea.
 
 #![cfg(feature = "fs_utf8")]
 
 #[macro_use]
 mod sys_common;
+#[macro_use]
+mod sys;
 
 use std::io::prelude::*;
 
+#[cfg(target_os = "macos")]
+use crate::sys::weak::weak;
 use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
 use cap_std::ambient_authority;
 use cap_std::fs_utf8::{self as fs, Dir, OpenOptions};
+#[cfg(target_os = "macos")]
+use libc::{c_char, c_int};
 use std::io::{self, ErrorKind, SeekFrom};
 use std::str;
 #[cfg(not(racy_asserts))] // racy asserts are racy
@@ -61,11 +65,21 @@ pub fn got_symlink_permission(tmpdir: &TempDir) -> bool {
     let link = "some_hopefully_unique_link_name";
 
     match symlink_file(r"nonexisting_target", tmpdir, link) {
-        Ok(_) => true,
         // ERROR_PRIVILEGE_NOT_HELD = 1314
         Err(ref err) if err.raw_os_error() == Some(1314) => false,
-        Err(_) => true,
+        Ok(_) | Err(_) => true,
     }
+}
+
+#[cfg(target_os = "macos")]
+fn able_to_not_follow_symlinks_while_hard_linking() -> bool {
+    weak!(fn linkat(c_int, *const c_char, c_int, *const c_char, c_int) -> c_int);
+    linkat.get().is_some()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn able_to_not_follow_symlinks_while_hard_linking() -> bool {
+    return true;
 }
 
 #[test]
@@ -840,7 +854,7 @@ fn symlink_noexist() {
     };
 
     // Use a relative path for testing. Symlinks get normalized by Windows,
-    // so we may not get the same path back for absolute paths
+    // so we might not get the same path back for absolute paths
     check!(symlink_file(&"foo", &tmpdir, "bar"));
     assert_eq!(check!(tmpdir.read_link("bar")).as_str(), "foo");
 }
@@ -1388,8 +1402,15 @@ fn metadata_access_times() {
         // Not always available
         match (a.created(), b.created()) {
             (Ok(t1), Ok(t2)) => assert!(t1 <= t2),
+            #[cfg(not(io_error_more))]
             (Err(e1), Err(e2))
                 if e1.kind() == ErrorKind::Other && e2.kind() == ErrorKind::Other => {}
+            #[cfg(io_error_more)]
+            (Err(e1), Err(e2))
+                if e1.kind() == ErrorKind::Uncategorized
+                    && e2.kind() == ErrorKind::Uncategorized
+                    || e1.kind() == ErrorKind::Unsupported
+                        && e2.kind() == ErrorKind::Unsupported => {}
             (a, b) => panic!(
                 "creation time must be always supported or not supported: {:?} {:?}",
                 a, b,
@@ -1403,6 +1424,9 @@ fn metadata_access_times() {
 fn symlink_hard_link() {
     let tmpdir = tmpdir();
     if !got_symlink_permission(&tmpdir) {
+        return;
+    }
+    if !able_to_not_follow_symlinks_while_hard_linking() {
         return;
     }
 
@@ -1454,6 +1478,44 @@ fn symlink_hard_link() {
     assert!(check!(tmpdir.symlink_metadata("hard_link"))
         .file_type()
         .is_symlink());
+}
+
+/// Ensure `fs::create_dir` works on Windows with longer paths.
+#[test]
+#[cfg(windows)]
+fn create_dir_long_paths() {
+    use crate::ffi::OsStr;
+    use crate::iter;
+    use crate::os::windows::ffi::OsStrExt;
+    const PATH_LEN: usize = 247;
+
+    let tmpdir = tmpdir();
+    let mut path = PathBuf::new();
+    path.push("a");
+    let mut path = path.into_os_string();
+
+    let utf16_len = path.encode_wide().count();
+    if utf16_len >= PATH_LEN {
+        // Skip the test in the unlikely event the local user has a long temp directory
+        // path. This should not affect CI.
+        return;
+    }
+    // Increase the length of the path.
+    path.extend(iter::repeat(OsStr::new("a")).take(PATH_LEN - utf16_len));
+
+    // This should succeed.
+    tmpdir.create_dir(&path).unwrap();
+
+    // This will fail if the path isn't converted to verbatim.
+    path.push("a");
+    tmpdir.create_dir(&path).unwrap();
+
+    // #90940: Ensure an empty path returns the "Not Found" error.
+    let path = Path::new("");
+    assert_eq!(
+        tmpdir.canonicalize(path).unwrap_err().kind(),
+        crate::io::ErrorKind::NotFound
+    );
 }
 
 /// Test creating files with invalid names and reading their parent

--- a/tests/fs_utf8.rs
+++ b/tests/fs_utf8.rs
@@ -1402,10 +1402,10 @@ fn metadata_access_times() {
         // Not always available
         match (a.created(), b.created()) {
             (Ok(t1), Ok(t2)) => assert!(t1 <= t2),
-            #[cfg(not(io_error_more))]
+            #[cfg(not(io_error_uncategorized))]
             (Err(e1), Err(e2))
                 if e1.kind() == ErrorKind::Other && e2.kind() == ErrorKind::Other => {}
-            #[cfg(io_error_more)]
+            #[cfg(io_error_uncategorized)]
             (Err(e1), Err(e2))
                 if e1.kind() == ErrorKind::Uncategorized
                     && e2.kind() == ErrorKind::Uncategorized

--- a/tests/fs_utf8.rs
+++ b/tests/fs_utf8.rs
@@ -1484,9 +1484,9 @@ fn symlink_hard_link() {
 #[test]
 #[cfg(windows)]
 fn create_dir_long_paths() {
-    use crate::ffi::OsStr;
-    use crate::iter;
-    use crate::os::windows::ffi::OsStrExt;
+    use std::ffi::OsStr;
+    use std::iter;
+    use std::os::windows::ffi::OsStrExt;
     const PATH_LEN: usize = 247;
 
     let tmpdir = tmpdir();
@@ -1514,7 +1514,7 @@ fn create_dir_long_paths() {
     let path = Path::new("");
     assert_eq!(
         tmpdir.canonicalize(path).unwrap_err().kind(),
-        crate::io::ErrorKind::NotFound
+        std::io::ErrorKind::NotFound
     );
 }
 

--- a/tests/symlinks.rs
+++ b/tests/symlinks.rs
@@ -17,6 +17,12 @@ fn basic_symlinks() {
 
     check!(tmpdir.create("file"));
     check!(tmpdir.create_dir("dir"));
+    assert!(check!(tmpdir.metadata("file")).is_file());
+    assert!(!check!(tmpdir.metadata("file")).is_dir());
+    assert!(check!(tmpdir.metadata("dir")).is_dir());
+    assert!(!check!(tmpdir.metadata("dir")).is_file());
+    assert!(!check!(tmpdir.metadata("file")).is_symlink());
+    assert!(!check!(tmpdir.metadata("dir")).is_symlink());
 
     check!(tmpdir.symlink_file("file", "file_symlink_file"));
     check!(tmpdir.symlink_dir("dir", "dir_symlink_dir"));
@@ -27,6 +33,29 @@ fn basic_symlinks() {
     assert!(check!(tmpdir.metadata("dir_symlink_dir")).is_dir());
     assert!(check!(tmpdir.metadata("file_symlink")).is_file());
     assert!(check!(tmpdir.metadata("dir_symlink")).is_dir());
+
+    assert!(!check!(tmpdir.metadata("file_symlink_file")).is_symlink());
+    assert!(!check!(tmpdir.metadata("dir_symlink_dir")).is_symlink());
+    assert!(!check!(tmpdir.metadata("file_symlink")).is_symlink());
+    assert!(!check!(tmpdir.metadata("dir_symlink")).is_symlink());
+
+    assert!(check!(tmpdir.symlink_metadata("file_symlink_file")).is_symlink());
+    assert!(check!(tmpdir.symlink_metadata("dir_symlink_dir")).is_symlink());
+    assert!(check!(tmpdir.symlink_metadata("file_symlink")).is_symlink());
+    assert!(check!(tmpdir.symlink_metadata("dir_symlink")).is_symlink());
+
+    assert!(!check!(tmpdir.metadata("file_symlink_file"))
+        .file_type()
+        .is_symlink());
+    assert!(!check!(tmpdir.metadata("dir_symlink_dir"))
+        .file_type()
+        .is_symlink());
+    assert!(!check!(tmpdir.metadata("file_symlink"))
+        .file_type()
+        .is_symlink());
+    assert!(!check!(tmpdir.metadata("dir_symlink"))
+        .file_type()
+        .is_symlink());
 
     assert!(check!(tmpdir.symlink_metadata("file_symlink_file"))
         .file_type()

--- a/tests/sys/mod.rs
+++ b/tests/sys/mod.rs
@@ -1,0 +1,5 @@
+#[cfg(unix)]
+mod unix;
+
+#[cfg(unix)]
+pub use self::unix::*;

--- a/tests/sys/unix/mod.rs
+++ b/tests/sys/unix/mod.rs
@@ -1,0 +1,1 @@
+pub mod weak;

--- a/tests/sys/unix/weak.rs
+++ b/tests/sys/unix/weak.rs
@@ -1,0 +1,223 @@
+//! This file is derived from Rust's library/std/src/sys/unix/weak.rs at
+//! revision e4b1d5841494d6eb7f4944c91a057e16b0f0a9ea.
+//!
+//! Support for "weak linkage" to symbols on Unix
+//!
+//! Some I/O operations we do in libstd require newer versions of OSes but we
+//! need to maintain binary compatibility with older releases for now. In order
+//! to use the new functionality when available we use this module for
+//! detection.
+//!
+//! One option to use here is weak linkage, but that is unfortunately only
+//! really workable with ELF. Otherwise, use dlsym to get the symbol value at
+//! runtime. This is also done for compatibility with older versions of glibc,
+//! and to avoid creating dependencies on GLIBC_PRIVATE symbols. It assumes
+//! that we've been dynamically linked to the library the symbol comes from,
+//! but that is currently always the case for things like libpthread/libc.
+//!
+//! A long time ago this used weak linkage for the __pthread_get_minstack
+//! symbol, but that caused Debian to detect an unnecessarily strict versioned
+//! dependency on libc6 (#23628) because it is GLIBC_PRIVATE. We now use
+//! `dlsym` for a runtime lookup of that symbol to avoid the ELF versioned
+//! dependency.
+
+// There are a variety of `#[cfg]`s controlling which targets are involved in
+// each instance of `weak!` and `syscall!`. Rather than trying to unify all of
+// that, we'll just allow that some unix targets don't use this module at all.
+#![allow(dead_code, unused_macros)]
+
+use std::ffi::CStr;
+use std::marker::PhantomData;
+use std::mem;
+use std::sync::atomic::{self, AtomicUsize, Ordering};
+
+// We can use true weak linkage on ELF targets.
+#[macro_export]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+macro_rules! weak {
+    (fn $name:ident($($t:ty),*) -> $ret:ty) => (
+        let ref $name: ExternWeak<unsafe extern "C" fn($($t),*) -> $ret> = {
+            extern "C" {
+                #[linkage = "extern_weak"]
+                static $name: *const libc::c_void;
+            }
+            #[allow(unused_unsafe)]
+            ExternWeak::new(unsafe { $name })
+        };
+    )
+}
+
+// On non-ELF targets, use the dlsym approximation of weak linkage.
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+pub(crate) use crate::dlsym as weak;
+
+pub(crate) struct ExternWeak<F> {
+    weak_ptr: *const libc::c_void,
+    _marker: PhantomData<F>,
+}
+
+impl<F> ExternWeak<F> {
+    #[inline]
+    pub(crate) fn new(weak_ptr: *const libc::c_void) -> Self {
+        ExternWeak {
+            weak_ptr,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<F> ExternWeak<F> {
+    #[inline]
+    pub(crate) fn get(&self) -> Option<F> {
+        unsafe {
+            if self.weak_ptr.is_null() {
+                None
+            } else {
+                Some(mem::transmute_copy::<*const libc::c_void, F>(
+                    &self.weak_ptr,
+                ))
+            }
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! dlsym {
+    (fn $name:ident($($t:ty),*) -> $ret:ty) => (
+        static DLSYM: $crate::sys::weak::DlsymWeak<unsafe extern "C" fn($($t),*) -> $ret> =
+            $crate::sys::weak::DlsymWeak::new(concat!(stringify!($name), '\0'));
+        let $name = &DLSYM;
+    )
+}
+
+pub(crate) struct DlsymWeak<F> {
+    name: &'static str,
+    addr: AtomicUsize,
+    _marker: PhantomData<F>,
+}
+
+impl<F> DlsymWeak<F> {
+    pub(crate) const fn new(name: &'static str) -> Self {
+        DlsymWeak {
+            name,
+            addr: AtomicUsize::new(1),
+            _marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn get(&self) -> Option<F> {
+        unsafe {
+            // Relaxed is fine here because we fence before reading through the
+            // pointer (see the comment below).
+            match self.addr.load(Ordering::Relaxed) {
+                1 => self.initialize(),
+                0 => None,
+                addr => {
+                    let func = mem::transmute_copy::<usize, F>(&addr);
+                    // The caller is presumably going to read through this value
+                    // (by calling the function we've dlsymed). This means we'd
+                    // need to have loaded it with at least C11's consume
+                    // ordering in order to be guaranteed that the data we read
+                    // from the pointer isn't from before the pointer was
+                    // stored. Rust has no equivalent to memory_order_consume,
+                    // so we use an acquire fence (sorry, ARM).
+                    //
+                    // Now, in practice this likely isn't needed even on CPUs
+                    // where relaxed and consume mean different things. The
+                    // symbols we're loading are probably present (or not) at
+                    // init, and even if they aren't the runtime dynamic loader
+                    // is extremely likely have sufficient barriers internally
+                    // (possibly implicitly, for example the ones provided by
+                    // invoking `mprotect`).
+                    //
+                    // That said, none of that's *guaranteed*, and so we fence.
+                    atomic::fence(Ordering::Acquire);
+                    Some(func)
+                }
+            }
+        }
+    }
+
+    // Cold because it should only happen during first-time initialization.
+    #[cold]
+    unsafe fn initialize(&self) -> Option<F> {
+        assert_eq!(mem::size_of::<F>(), mem::size_of::<usize>());
+
+        let val = fetch(self.name);
+        // This synchronizes with the acquire fence in `get`.
+        self.addr.store(val, Ordering::Release);
+
+        match val {
+            0 => None,
+            addr => Some(mem::transmute_copy::<usize, F>(&addr)),
+        }
+    }
+}
+
+unsafe fn fetch(name: &str) -> usize {
+    let name = match CStr::from_bytes_with_nul(name.as_bytes()) {
+        Ok(cstr) => cstr,
+        Err(..) => return 0,
+    };
+    libc::dlsym(libc::RTLD_DEFAULT, name.as_ptr()) as usize
+}
+
+#[macro_export]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+macro_rules! syscall {
+    (fn $name:ident($($arg_name:ident: $t:ty),*) -> $ret:ty) => (
+        unsafe fn $name($($arg_name: $t),*) -> $ret {
+            weak! { fn $name($($t),*) -> $ret }
+
+            if let Some(fun) = $name.get() {
+                fun($($arg_name),*)
+            } else {
+                super::os::set_errno(libc::ENOSYS);
+                -1
+            }
+        }
+    )
+}
+
+#[macro_export]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+macro_rules! syscall {
+    (fn $name:ident($($arg_name:ident: $t:ty),*) -> $ret:ty) => (
+        unsafe fn $name($($arg_name:$t),*) -> $ret {
+            weak! { fn $name($($t),*) -> $ret }
+
+            // Use a weak symbol from libc when possible, allowing `LD_PRELOAD`
+            // interposition, but if it's not found just use a raw syscall.
+            if let Some(fun) = $name.get() {
+                fun($($arg_name),*)
+            } else {
+                // This looks like a hack, but concat_idents only accepts idents
+                // (not paths).
+                use libc::*;
+
+                syscall(
+                    concat_idents!(SYS_, $name),
+                    $($arg_name),*
+                ) as $ret
+            }
+        }
+    )
+}
+
+#[macro_export]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+macro_rules! raw_syscall {
+    (fn $name:ident($($arg_name:ident: $t:ty),*) -> $ret:ty) => (
+        unsafe fn $name($($arg_name:$t),*) -> $ret {
+            // This looks like a hack, but concat_idents only accepts idents
+            // (not paths).
+            use libc::*;
+
+            syscall(
+                concat_idents!(SYS_, $name),
+                $($arg_name),*
+            ) as $ret
+        }
+    )
+}

--- a/tests/sys_common/mod.rs
+++ b/tests/sys_common/mod.rs
@@ -20,12 +20,14 @@ macro_rules! error {
     ($e:expr, $s:expr) => {
         match $e {
             Ok(_) => panic!("Unexpected success. Should've been: {:?}", $s),
-            Err(ref err) => assert!(
-                err.raw_os_error() == Some($s),
-                "`{}` did not have a code of `{}`",
-                err,
-                $s
-            ),
+            Err(ref err) => {
+                assert!(
+                    err.raw_os_error() == Some($s),
+                    "`{}` did not have a code of `{}`",
+                    err,
+                    $s
+                )
+            }
         }
     };
 }
@@ -43,12 +45,14 @@ macro_rules! error_contains {
     ($e:expr, $s:expr) => {
         match $e {
             Ok(_) => panic!("Unexpected success. Should've been: {:?}", $s),
-            Err(ref err) => assert!(
-                err.to_string().contains($s),
-                "`{}` did not contain `{}`",
-                err,
-                $s
-            ),
+            Err(ref err) => {
+                assert!(
+                    err.to_string().contains($s),
+                    "`{}` did not contain `{}`",
+                    err,
+                    $s
+                )
+            }
         }
     };
 }


### PR DESCRIPTION
Add `Metadata::is_symlink` and `File::options`, corresponding to the new
std features in [Rust 1.58].

This also updates tests/fs.rs and tests/fs_utf8.rs to the latest changes
from upstream Rust.

[Rust 1.58]: https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html