### PR TITLE
Update to rustix 0.32.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ camino = "1.0.5"
 libc = "0.2.100"
 
 [target.'cfg(not(windows))'.dev-dependencies]
-rustix = "0.31.0"
+rustix = "0.32.0"
 
 [target.'cfg(windows)'.dev-dependencies]
 # nt_version uses internal Windows APIs, however we're only using it

--- a/cap-async-std/Cargo.toml
+++ b/cap-async-std/Cargo.toml
@@ -23,7 +23,7 @@ io-extras = { version = "0.12.0", features = ["use_async_std"] }
 camino = { version = "1.0.5", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = "0.31.0"
+rustix = "0.32.0"
 
 [features]
 default = []

--- a/cap-directories/Cargo.toml
+++ b/cap-directories/Cargo.toml
@@ -17,7 +17,7 @@ cap-std = { path = "../cap-std", version = "^0.22.2-alpha.0"}
 directories-next = "2.0.0"
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = "0.31.0"
+rustix = "0.32.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -17,12 +17,12 @@ ambient-authority = "0.0.1"
 arbitrary = { version = "1.0.0", optional = true, features = ["derive"] }
 ipnet = "2.3.0"
 maybe-owned = "0.3.4"
-fs-set-times = "0.14.0"
+fs-set-times = "0.14.2"
 io-extras = "0.12.0"
 io-lifetimes = { version = "0.4.0", default-features = false }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.31.0", features = ["procfs"] }
+rustix = { version = "0.32.0", features = ["procfs"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 errno = { version = "0.2.8", default-features = false }

--- a/cap-primitives/src/rustix/fs/dir_entry_inner.rs
+++ b/cap-primitives/src/rustix/fs/dir_entry_inner.rs
@@ -45,7 +45,9 @@ impl DirEntryInner {
             rustix::fs::FileType::Directory => FileType::dir(),
             rustix::fs::FileType::RegularFile => FileType::file(),
             rustix::fs::FileType::Symlink => FileType::ext(FileTypeExt::symlink()),
+            #[cfg(not(target_os = "wasi"))]
             rustix::fs::FileType::Fifo => FileType::ext(FileTypeExt::fifo()),
+            #[cfg(not(target_os = "wasi"))]
             rustix::fs::FileType::Socket => FileType::ext(FileTypeExt::socket()),
             rustix::fs::FileType::CharacterDevice => FileType::ext(FileTypeExt::char_device()),
             rustix::fs::FileType::BlockDevice => FileType::ext(FileTypeExt::block_device()),

--- a/cap-primitives/src/rustix/fs/file_type_ext.rs
+++ b/cap-primitives/src/rustix/fs/file_type_ext.rs
@@ -49,11 +49,11 @@ impl FileTypeExt {
             if std.is_fifo() {
                 return FileType::ext(Self::Fifo);
             }
+            #[cfg(not(target_os = "wasi"))]
             if std.is_socket() {
-                FileType::ext(Self::Socket)
-            } else {
-                FileType::unknown()
+                return FileType::ext(Self::Socket);
             }
+            FileType::unknown()
         }
     }
 
@@ -65,9 +65,11 @@ impl FileTypeExt {
             rustix::fs::FileType::RegularFile => FileType::file(),
             rustix::fs::FileType::Directory => FileType::dir(),
             rustix::fs::FileType::Symlink => FileType::ext(Self::symlink()),
+            #[cfg(not(target_os = "wasi"))]
             rustix::fs::FileType::Fifo => FileType::ext(Self::fifo()),
             rustix::fs::FileType::CharacterDevice => FileType::ext(Self::char_device()),
             rustix::fs::FileType::BlockDevice => FileType::ext(Self::block_device()),
+            #[cfg(not(target_os = "wasi"))]
             rustix::fs::FileType::Socket => FileType::ext(Self::socket()),
             _ => FileType::unknown(),
         }

--- a/cap-primitives/src/rustix/fs/times.rs
+++ b/cap-primitives/src/rustix/fs/times.rs
@@ -1,7 +1,7 @@
 use crate::fs::SystemTimeSpec;
 use crate::time::SystemClock;
 use io_lifetimes::BorrowedFd;
-use rustix::fs::{utimensat, AtFlags, UTIME_NOW, UTIME_OMIT};
+use rustix::fs::{utimensat, AtFlags, Timestamps, UTIME_NOW, UTIME_OMIT};
 use rustix::time::Timespec;
 use std::convert::TryInto;
 use std::path::Path;
@@ -40,7 +40,10 @@ pub(crate) fn set_times_nofollow_unchecked(
     atime: Option<SystemTimeSpec>,
     mtime: Option<SystemTimeSpec>,
 ) -> io::Result<()> {
-    let times = [to_timespec(atime)?, to_timespec(mtime)?];
+    let times = Timestamps {
+        last_access: to_timespec(atime)?,
+        last_modification: to_timespec(mtime)?,
+    };
     Ok(utimensat(start, path, &times, AtFlags::SYMLINK_NOFOLLOW)?)
 }
 
@@ -51,6 +54,9 @@ pub(crate) fn set_times_follow_unchecked(
     atime: Option<SystemTimeSpec>,
     mtime: Option<SystemTimeSpec>,
 ) -> io::Result<()> {
-    let times = [to_timespec(atime)?, to_timespec(mtime)?];
+    let times = Timestamps {
+        last_access: to_timespec(atime)?,
+        last_modification: to_timespec(mtime)?,
+    };
     Ok(utimensat(&start, path, &times, AtFlags::empty())?)
 }

--- a/cap-std/Cargo.toml
+++ b/cap-std/Cargo.toml
@@ -21,7 +21,7 @@ io-lifetimes = { version = "0.4.0", default-features = false }
 camino = { version = "1.0.5", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = "0.31.0"
+rustix = "0.32.0"
 
 [features]
 default = []

--- a/cap-time-ext/Cargo.toml
+++ b/cap-time-ext/Cargo.toml
@@ -17,7 +17,7 @@ cap-primitives = { path = "../cap-primitives", version = "^0.22.2-alpha.0"}
 cap-std = { path = "../cap-std", optional = true, version = "^0.22.2-alpha.0"}
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = "0.31.0"
+rustix = "0.32.0"
 
 [target.'cfg(windows)'.dependencies]
 once_cell = "1.5.2"


### PR DESCRIPTION
The one relevant API change in rustix is that `utimensat` now takes a
struct instead of a 2-element array.