### PR TITLE
Expose cap_std::fs_utf8 on docs.rs

### DIFF
--- a/cap-std/Cargo.toml
+++ b/cap-std/Cargo.toml
@@ -12,9 +12,12 @@ categories = ["filesystem", "network-programming"]
 repository = "https://github.com/bytecodealliance/cap-std"
 edition = "2018"
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--all-features", "--cfg=doc_cfg"]
+
 [dependencies]
 arf-strings = { version = "0.6.3", optional = true }
-cap-primitives = { path = "../cap-primitives", version = "^0.22.2-alpha.0"}
+cap-primitives = { path = "../cap-primitives", version = "^0.22.2-alpha.0" }
 ipnet = "2.3.0"
 io-extras = "0.12.0"
 io-lifetimes = { version = "0.4.0", default-features = false }

--- a/cap-std/src/fs_utf8/mod.rs
+++ b/cap-std/src/fs_utf8/mod.rs
@@ -15,7 +15,10 @@
 //!
 //! TODO: This whole scheme is still under development.
 //!
-//! If you don't want this, use the regular [`cap_std::fs`] module instead.
+//! To use this module, enable the `fs_utf8` cargo feature.
+//!
+//! If you don't want to restrict paths to UTF-8, use the regular
+//! [`cap_std::fs`] module instead.
 //!
 //! [`cap_std::fs`]: ../fs/
 //! [ARF strings]: https://crates.io/crates/arf-strings

--- a/cap-std/src/lib.rs
+++ b/cap-std/src/lib.rs
@@ -23,6 +23,7 @@
 //! [`Pool`]: net::Pool
 
 #![deny(missing_docs)]
+#![cfg_attr(doc_cfg, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(can_vector, feature(can_vector))]
 #![cfg_attr(seek_convenience, feature(seek_convenience))]


### PR DESCRIPTION
I was trying to use `fs_utf8` for some of my code, and docs.rs didn't
have any documentation for it.

I'm not sure if this is desired yet, but I wanted to put this PR up to
solicit feedback.

Also enable doc_cfg + doc_auto_cfg so that docs.rs marks fs_utf8 (and
net) as being conditional.

![image](https://user-images.githubusercontent.com/180618/150242214-ccd805ad-bc13-4893-9da9-a985c5548598.png)
