### PR TITLE
Simplify `concatentate_or_return_absolute` to only concatenate.

### DIFF
--- a/cap-primitives/src/windows/fs/copy.rs
+++ b/cap-primitives/src/windows/fs/copy.rs
@@ -1,4 +1,5 @@
-use super::get_path::concatenate_or_return_absolute;
+use super::get_path::get_path;
+use crate::fs::{open, OpenOptions};
 use std::path::Path;
 use std::{fs, io};
 
@@ -8,7 +9,11 @@ pub(crate) fn copy_impl(
     to_start: &fs::File,
     to_path: &Path,
 ) -> io::Result<u64> {
-    let from_full_path = concatenate_or_return_absolute(from_start, from_path)?;
-    let to_full_path = concatenate_or_return_absolute(to_start, to_path)?;
-    fs::copy(from_full_path, to_full_path)
+    let from = open(from_start, from_path, OpenOptions::new().read(true))?;
+    let to = open(
+        to_start,
+        to_path,
+        OpenOptions::new().create(true).truncate(true).write(true),
+    )?;
+    fs::copy(get_path(&from)?, get_path(&to)?)
 }

--- a/cap-primitives/src/windows/fs/create_dir_unchecked.rs
+++ b/cap-primitives/src/windows/fs/create_dir_unchecked.rs
@@ -1,4 +1,4 @@
-use super::get_path::concatenate_or_return_absolute;
+use super::get_path::concatenate;
 use crate::fs::DirOptions;
 use std::path::Path;
 use std::{fs, io};
@@ -13,6 +13,6 @@ pub(crate) fn create_dir_unchecked(
     path: &Path,
     _options: &DirOptions,
 ) -> io::Result<()> {
-    let out_path = concatenate_or_return_absolute(start, path)?;
+    let out_path = concatenate(start, path)?;
     fs::create_dir(out_path)
 }

--- a/cap-primitives/src/windows/fs/get_path.rs
+++ b/cap-primitives/src/windows/fs/get_path.rs
@@ -24,13 +24,8 @@ pub(crate) fn get_path(file: &fs::File) -> io::Result<PathBuf> {
 }
 
 /// Convenience function for calling `get_path` and concatenating the result
-/// with `path`. This function also checks if `path` is absolute in which case,
-/// it emulates POSIX and returns the absolute path unmodified instead.
-pub(super) fn concatenate_or_return_absolute(file: &fs::File, path: &Path) -> io::Result<PathBuf> {
-    if path.is_absolute() {
-        return Ok(path.into());
-    }
-
+/// with `path`.
+pub(super) fn concatenate(file: &fs::File, path: &Path) -> io::Result<PathBuf> {
     let file_path = get_path(file)?;
     Ok(file_path.join(path))
 }

--- a/cap-primitives/src/windows/fs/hard_link_unchecked.rs
+++ b/cap-primitives/src/windows/fs/hard_link_unchecked.rs
@@ -1,4 +1,4 @@
-use super::get_path::concatenate_or_return_absolute;
+use super::get_path::concatenate;
 use std::path::Path;
 use std::{fs, io};
 
@@ -10,7 +10,7 @@ pub(crate) fn hard_link_unchecked(
     new_start: &fs::File,
     new_path: &Path,
 ) -> io::Result<()> {
-    let old_full_path = concatenate_or_return_absolute(old_start, old_path)?;
-    let new_full_path = concatenate_or_return_absolute(new_start, new_path)?;
+    let old_full_path = concatenate(old_start, old_path)?;
+    let new_full_path = concatenate(new_start, new_path)?;
     fs::hard_link(old_full_path, new_full_path)
 }

--- a/cap-primitives/src/windows/fs/open_unchecked.rs
+++ b/cap-primitives/src/windows/fs/open_unchecked.rs
@@ -1,4 +1,4 @@
-use super::get_path::concatenate_or_return_absolute;
+use super::get_path::concatenate;
 use super::open_options_to_std;
 use crate::fs::{errors, FollowSymlinks, OpenOptions, OpenUncheckedError, SymlinkKind};
 use crate::{ambient_authority, AmbientAuthority};
@@ -16,8 +16,7 @@ pub(crate) fn open_unchecked(
     path: &Path,
     options: &OpenOptions,
 ) -> Result<fs::File, OpenUncheckedError> {
-    let full_path =
-        concatenate_or_return_absolute(start, path).map_err(OpenUncheckedError::Other)?;
+    let full_path = concatenate(start, path).map_err(OpenUncheckedError::Other)?;
     open_ambient_impl(&full_path, options, ambient_authority())
 }
 

--- a/cap-primitives/src/windows/fs/read_dir_inner.rs
+++ b/cap-primitives/src/windows/fs/read_dir_inner.rs
@@ -1,4 +1,4 @@
-use super::get_path::concatenate_or_return_absolute;
+use super::get_path::concatenate;
 use crate::fs::{open_dir, DirEntryInner, FollowSymlinks};
 use std::path::{Component, Path};
 use std::{fmt, fs, io};
@@ -23,7 +23,7 @@ impl ReadDirInner {
     }
 
     pub(crate) fn new_unchecked(start: &fs::File, path: &Path) -> io::Result<Self> {
-        let full_path = concatenate_or_return_absolute(start, path)?;
+        let full_path = concatenate(start, path)?;
         Ok(Self {
             std: fs::read_dir(full_path)?,
         })

--- a/cap-primitives/src/windows/fs/read_link_unchecked.rs
+++ b/cap-primitives/src/windows/fs/read_link_unchecked.rs
@@ -1,4 +1,4 @@
-use super::get_path::concatenate_or_return_absolute;
+use super::get_path::concatenate;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
@@ -9,6 +9,6 @@ pub(crate) fn read_link_unchecked(
     path: &Path,
     _reuse: PathBuf,
 ) -> io::Result<PathBuf> {
-    let full_path = concatenate_or_return_absolute(start, path)?;
+    let full_path = concatenate(start, path)?;
     fs::read_link(full_path)
 }

--- a/cap-primitives/src/windows/fs/remove_dir_unchecked.rs
+++ b/cap-primitives/src/windows/fs/remove_dir_unchecked.rs
@@ -1,10 +1,10 @@
-use super::get_path::concatenate_or_return_absolute;
+use super::get_path::concatenate;
 use std::path::Path;
 use std::{fs, io};
 
 /// *Unsandboxed* function similar to `remove_dir`, but which does not perform
 /// sandboxing.
 pub(crate) fn remove_dir_unchecked(start: &fs::File, path: &Path) -> io::Result<()> {
-    let full_path = concatenate_or_return_absolute(start, path)?;
+    let full_path = concatenate(start, path)?;
     fs::remove_dir(full_path)
 }

--- a/cap-primitives/src/windows/fs/remove_file_unchecked.rs
+++ b/cap-primitives/src/windows/fs/remove_file_unchecked.rs
@@ -1,10 +1,10 @@
-use super::get_path::concatenate_or_return_absolute;
+use super::get_path::concatenate;
 use std::path::Path;
 use std::{fs, io};
 
 /// *Unsandboxed* function similar to `remove_file`, but which does not perform
 /// sandboxing.
 pub(crate) fn remove_file_unchecked(start: &fs::File, path: &Path) -> io::Result<()> {
-    let full_path = concatenate_or_return_absolute(start, path)?;
+    let full_path = concatenate(start, path)?;
     fs::remove_file(full_path)
 }

--- a/cap-primitives/src/windows/fs/rename_unchecked.rs
+++ b/cap-primitives/src/windows/fs/rename_unchecked.rs
@@ -1,4 +1,4 @@
-use super::get_path::concatenate_or_return_absolute;
+use super::get_path::concatenate;
 use std::path::Path;
 use std::{fs, io};
 
@@ -10,7 +10,7 @@ pub(crate) fn rename_unchecked(
     new_start: &fs::File,
     new_path: &Path,
 ) -> io::Result<()> {
-    let old_full_path = concatenate_or_return_absolute(old_start, old_path)?;
-    let new_full_path = concatenate_or_return_absolute(new_start, new_path)?;
+    let old_full_path = concatenate(old_start, old_path)?;
+    let new_full_path = concatenate(new_start, new_path)?;
     fs::rename(old_full_path, new_full_path)
 }

--- a/cap-primitives/src/windows/fs/set_permissions_unchecked.rs
+++ b/cap-primitives/src/windows/fs/set_permissions_unchecked.rs
@@ -1,4 +1,4 @@
-use super::get_path::concatenate_or_return_absolute;
+use super::get_path::concatenate;
 use crate::fs::Permissions;
 use std::path::Path;
 use std::{fs, io};
@@ -16,6 +16,6 @@ pub(crate) fn set_permissions_unchecked(
     //
     // [Windows' documentation]: https://docs.microsoft.com/en-us/windows/win32/fileio/symbolic-link-effects-on-file-systems-functions#setfileattributes
     // [Rust's documentation]: https://doc.rust-lang.org/std/fs/fn.set_permissions.html#platform-specific-behavior
-    let out_path = concatenate_or_return_absolute(start, path)?;
+    let out_path = concatenate(start, path)?;
     fs::set_permissions(out_path, perm.into_std(start)?)
 }

--- a/cap-primitives/src/windows/fs/stat_unchecked.rs
+++ b/cap-primitives/src/windows/fs/stat_unchecked.rs
@@ -1,5 +1,5 @@
 #[cfg(windows_by_handle)]
-use super::get_path::concatenate_or_return_absolute;
+use super::get_path::concatenate;
 use crate::fs::{FollowSymlinks, Metadata};
 use std::path::Path;
 use std::{fs, io};
@@ -22,7 +22,7 @@ pub(crate) fn stat_unchecked(
     // has everything.
     #[cfg(windows_by_handle)]
     {
-        let full_path = concatenate_or_return_absolute(start, path)?;
+        let full_path = concatenate(start, path)?;
         match follow {
             FollowSymlinks::Yes => fs::metadata(full_path),
             FollowSymlinks::No => fs::symlink_metadata(full_path),

--- a/cap-primitives/src/windows/fs/symlink_unchecked.rs
+++ b/cap-primitives/src/windows/fs/symlink_unchecked.rs
@@ -1,4 +1,4 @@
-use super::get_path::concatenate_or_return_absolute;
+use super::get_path::concatenate;
 use std::path::Path;
 use std::{fs, io};
 
@@ -9,7 +9,7 @@ pub(crate) fn symlink_file_unchecked(
     new_start: &fs::File,
     new_path: &Path,
 ) -> io::Result<()> {
-    let new_full_path = concatenate_or_return_absolute(new_start, new_path)?;
+    let new_full_path = concatenate(new_start, new_path)?;
     std::os::windows::fs::symlink_file(old_path, new_full_path)
 }
 
@@ -20,6 +20,6 @@ pub(crate) fn symlink_dir_unchecked(
     new_start: &fs::File,
     new_path: &Path,
 ) -> io::Result<()> {
-    let new_full_path = concatenate_or_return_absolute(new_start, new_path)?;
+    let new_full_path = concatenate(new_start, new_path)?;
     std::os::windows::fs::symlink_dir(old_path, new_full_path)
 }


### PR DESCRIPTION
We never actually want this function passing absolute paths through, so
remove the logic to do so.