### PR TITLE
Generalize `Dir::reopen_dir` to support Windows.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ rand = "0.8.1"
 tempfile = "3.1.0"
 camino = "1.0.5"
 libc = "0.2.100"
+io-lifetimes = "0.4.4"
 
 [target.'cfg(not(windows))'.dev-dependencies]
 rustix = "0.31.0"

--- a/cap-std/src/fs/dir.rs
+++ b/cap-std/src/fs/dir.rs
@@ -29,6 +29,7 @@ use {
     io_extras::os::windows::{AsRawHandleOrSocket, IntoRawHandleOrSocket, RawHandleOrSocket},
     std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle},
 };
+use io_lifetimes::AsFilelike;
 
 /// A reference to an open directory on a filesystem.
 ///
@@ -614,11 +615,9 @@ impl Dir {
     ///
     /// This can be useful when interacting with other libraries and or C/C++ code
     /// which has invoked `openat(..., O_DIRECTORY)` external to this crate.
-    #[cfg(not(windows))]
-    pub fn reopen_dir(fd: BorrowedFd) -> io::Result<Self> {
-        use io_lifetimes::AsFilelike;
+    pub fn reopen_dir<Filelike: AsFilelike>(dir: &Filelike) -> io::Result<Self> {
         cap_primitives::fs::open_dir(
-            &fd.as_filelike_view::<std::fs::File>(),
+            &dir.as_filelike_view::<std::fs::File>(),
             std::path::Component::CurDir.as_ref(),
         )
         .map(Self::from_std_file)

--- a/cap-std/src/fs/dir.rs
+++ b/cap-std/src/fs/dir.rs
@@ -9,6 +9,7 @@ use cap_primitives::fs::{
     remove_open_dir_all, rename, stat, DirOptions, FollowSymlinks, Permissions,
 };
 use cap_primitives::AmbientAuthority;
+use io_lifetimes::AsFilelike;
 #[cfg(not(windows))]
 use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 #[cfg(windows)]
@@ -29,7 +30,6 @@ use {
     io_extras::os::windows::{AsRawHandleOrSocket, IntoRawHandleOrSocket, RawHandleOrSocket},
     std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle},
 };
-use io_lifetimes::AsFilelike;
 
 /// A reference to an open directory on a filesystem.
 ///

--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -851,9 +851,9 @@ fn maybe_dir() {
 #[test]
 #[cfg(not(windows))]
 fn reopen_fd() {
-    use rustix::fd::AsFd;
+    use io_lifetimes::AsFilelike;
     let tmpdir = tmpdir();
     check!(tmpdir.create_dir("subdir"));
-    let tmpdir2 = check!(cap_std::fs::Dir::reopen_dir(tmpdir.as_fd()));
+    let tmpdir2 = check!(cap_std::fs::Dir::reopen_dir(&tmpdir.as_filelike()));
     assert!(tmpdir2.exists("subdir"));
 }


### PR DESCRIPTION
Generalize from `AsFd to `AsFilelike` in `reopen_dir` so that Windows is
supported in addition to Unix.