### PR TITLE
cap-std: Fix the build on docs.rs

### DIFF
--- a/cap-std/Cargo.toml
+++ b/cap-std/Cargo.toml
@@ -13,7 +13,8 @@ repository = "https://github.com/bytecodealliance/cap-std"
 edition = "2018"
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--all-features", "--cfg=doc_cfg"]
+all-features = true
+rustdoc-args = ["--cfg=doc_cfg"]
 
 [dependencies]
 arf-strings = { version = "0.6.3", optional = true }


### PR DESCRIPTION
Followup to https://github.com/bytecodealliance/cap-std/pull/221