### PR TITLE
Remove the description of arf-strings from fs_utf8 module comments.

### DIFF
--- a/cap-async-std/src/fs_utf8/mod.rs
+++ b/cap-async-std/src/fs_utf8/mod.rs
@@ -4,22 +4,10 @@
 //! module uses [`Utf8Path`] and [`Utf8PathBuf`], meaning that all paths are
 //! valid UTF-8.
 //!
-//! But wait, POSIX doesn't require filenames to be UTF-8! What happens if
-//! there's a file with a non-UTF-8 name? To address this, this module uses
-//! [ARF strings] to encode non-UTF-8-encodable filenames as UTF-8. See the
-//! link for details, but the big picture is that all possible byte sequences
-//! are losslessly representable. The easy case of a file with a valid UTF-8
-//! name is easy, and the tricky case of a valid with an invalid UTF-8 name
-//! is possible -- it may take more work to handle properly, especially if
-//! you want to do interesting path manipulation, but it is possible.
-//!
-//! TODO: This whole scheme is still under development.
-//!
 //! If you don't want this, use the regular [`cap_async_std::fs`] module
 //! instead.
 //!
 //! [`cap_async_std::fs`]: ../fs/
-//! [ARF strings]: https://crates.io/crates/arf-strings
 
 mod dir;
 mod dir_entry;

--- a/cap-std/src/fs_utf8/mod.rs
+++ b/cap-std/src/fs_utf8/mod.rs
@@ -4,24 +4,12 @@
 //! uses [`Utf8Path`] and [`Utf8PathBuf`], meaning that all paths are valid
 //! UTF-8.
 //!
-//! But wait, POSIX doesn't require filenames to be UTF-8! What happens if
-//! there's a file with a non-UTF-8 name? To address this, this module uses
-//! [ARF strings] to encode non-UTF-8-encodable filenames as UTF-8. See the
-//! link for details, but the big picture is that all possible byte sequences
-//! are losslessly representable. The easy case of a file with a valid UTF-8
-//! name is easy, and the tricky case of a valid with an invalid UTF-8 name
-//! is possible -- it may take more work to handle properly, especially if
-//! you want to do interesting path manipulation, but it is possible.
-//!
-//! TODO: This whole scheme is still under development.
-//!
 //! To use this module, enable the `fs_utf8` cargo feature.
 //!
 //! If you don't want to restrict paths to UTF-8, use the regular
 //! [`cap_std::fs`] module instead.
 //!
 //! [`cap_std::fs`]: ../fs/
-//! [ARF strings]: https://crates.io/crates/arf-strings
 
 mod dir;
 mod dir_entry;


### PR DESCRIPTION
arf-strings are an experiment, and not necessarily something all users
need to know about just to use fs_utf8, especially now that we have
camino. So remove the top-level comments talking about arf strings
from the module documentation.

arf-strings are still mentioned in the top-level repository README.md,
which is sufficient visibility for them for now.