### PR TITLE
Move the `is_file_read_write` implementation out of rustix.

### DIFF
--- a/cap-primitives/src/rustix/fs/is_file_read_write_impl.rs
+++ b/cap-primitives/src/rustix/fs/is_file_read_write_impl.rs
@@ -1,7 +1,27 @@
-use rustix::fs::is_file_read_write;
+use rustix::fs::OFlags;
 use std::{fs, io};
 
 #[inline]
 pub(crate) fn is_file_read_write_impl(file: &fs::File) -> io::Result<(bool, bool)> {
-    Ok(is_file_read_write(file)?)
+    let mode = rustix::fs::fcntl_getfl(file)?;
+
+    // Check for `O_PATH`.
+    #[cfg(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "emscripten"
+    ))]
+    if mode.contains(OFlags::PATH) {
+        return Ok((false, false));
+    }
+
+    // Use `RWMODE` rather than `ACCMODE` as `ACCMODE` may include `O_PATH`.
+    // We handled `O_PATH` above.
+    match mode & OFlags::RWMODE {
+        OFlags::RDONLY => Ok((true, false)),
+        OFlags::RDWR => Ok((true, true)),
+        OFlags::WRONLY => Ok((false, true)),
+        _ => unreachable!(),
+    }
 }


### PR DESCRIPTION
This function is a higher-level abstraction that doesn't really fit in
rustix, and complicates an upcoming rustix refactoring, so move it out
to cap-std.