### PR TITLE
README.md: Link to cap-std-ext

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ develops libraries to make it easy to write capability-based code, including:
  - [`cap-rand`], which provides capability-based access to
    [random number generators]
 
+There is also a [`cap-std-ext`](https://crates.io/crates/cap-std-ext) crate available
+which is maintained independently, and includes further extension APIs for
+both filesystem APIs (including atomic create/replace on Linux specifically)
+and passing file descriptors to child processes.
+
 Cap-std features protection against [CWE-22], "Improper Limitation of a
 Pathname to a Restricted Directory ('Path Traversal')", which is #8 in the
 [2021 CWE Top 25 Most Dangerous Software Weaknesses]. It can also be used to


### PR DESCRIPTION
I am hopeful we can drain most of the functionality here into
cap-std itself or cap-fs-ext, but for now let's link to it so others
can find it more easily.

Most of this would be nice to have in Rust `std` too; that's a whole
other TODO item.  Perhaps best tackled once `std` itself depends on
rustix.