### PR TITLE
Exclude `.*` in the crates.io package.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["filesystem", "network-programming"]
 repository = "https://github.com/bytecodealliance/cap-std"
 edition = "2018"
 publish = false
+exclude = ["/.*"]
 
 [dev-dependencies]
 async-std = { version = "1.10.0", features = ["attributes"] }


### PR DESCRIPTION
Exclude the .github, .rustfmt.toml, .travis.yml, and other dotfiles from
the crates.io package.