### PR TITLE
Update to io-lifetimes 0.5.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ rand = "0.8.1"
 tempfile = "3.1.0"
 camino = "1.0.5"
 libc = "0.2.100"
-io-lifetimes = "0.4.4"
+io-lifetimes = "0.5.1"
 
 [target.'cfg(not(windows))'.dev-dependencies]
-rustix = "0.32.0"
+rustix = "0.33.0"
 
 [target.'cfg(windows)'.dev-dependencies]
 # nt_version uses internal Windows APIs, however we're only using it

--- a/cap-async-std/Cargo.toml
+++ b/cap-async-std/Cargo.toml
@@ -17,13 +17,13 @@ arf-strings = { version = "0.6.3", optional = true }
 # Enable "unstable" for `spawn_blocking`.
 async-std = { version = "1.10.0", features = ["attributes", "unstable"] }
 cap-primitives = { path = "../cap-primitives", version = "^0.23.2-alpha.0"}
-io-lifetimes = { version = "0.4.0", default-features = false, features = ["async-std"] }
+io-lifetimes = { version = "0.5.1", default-features = false, features = ["async-std"] }
 ipnet = "2.3.0"
-io-extras = { version = "0.12.0", features = ["use_async_std"] }
+io-extras = { version = "0.13.0", features = ["use_async_std"] }
 camino = { version = "1.0.5", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = "0.32.0"
+rustix = "0.33.0"
 
 [features]
 default = []

--- a/cap-directories/Cargo.toml
+++ b/cap-directories/Cargo.toml
@@ -17,7 +17,7 @@ cap-std = { path = "../cap-std", version = "^0.23.2-alpha.0"}
 directories-next = "2.0.0"
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = "0.32.0"
+rustix = "0.33.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"

--- a/cap-fs-ext/Cargo.toml
+++ b/cap-fs-ext/Cargo.toml
@@ -17,7 +17,7 @@ arf-strings = { version = "0.6.3", optional = true }
 cap-async-std = { path = "../cap-async-std", optional = true, version = "^0.23.2-alpha.0"}
 cap-std = { path = "../cap-std", optional = true, version = "^0.23.2-alpha.0"}
 cap-primitives = { path = "../cap-primitives", version = "^0.23.2-alpha.0"}
-io-lifetimes = { version = "0.4.0", default-features = false }
+io-lifetimes = { version = "0.5.1", default-features = false }
 # Enable "unstable" for `spawn_blocking`.
 async-std = { version = "1.10.0", features = ["attributes", "unstable"], optional = true }
 async-trait = { version = "0.1.42", optional = true }

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -17,12 +17,12 @@ ambient-authority = "0.0.1"
 arbitrary = { version = "1.0.0", optional = true, features = ["derive"] }
 ipnet = "2.3.0"
 maybe-owned = "0.3.4"
-fs-set-times = "0.14.2"
-io-extras = "0.12.0"
-io-lifetimes = { version = "0.4.0", default-features = false }
+fs-set-times = "0.15.0"
+io-extras = "0.13.0"
+io-lifetimes = { version = "0.5.1", default-features = false }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.32.0", features = ["procfs"] }
+rustix = { version = "0.33.0", features = ["procfs"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 errno = { version = "0.2.8", default-features = false }

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -31,6 +31,6 @@ errno = { version = "0.2.8", default-features = false }
 errno = { version = "0.2.8", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
-winx = "0.30.0"
+winx = "0.31.0"
 winapi = "0.3.9"
 winapi-util = "0.1.5"

--- a/cap-std/Cargo.toml
+++ b/cap-std/Cargo.toml
@@ -20,12 +20,12 @@ rustdoc-args = ["--cfg=doc_cfg"]
 arf-strings = { version = "0.6.3", optional = true }
 cap-primitives = { path = "../cap-primitives", version = "^0.23.2-alpha.0"}
 ipnet = "2.3.0"
-io-extras = "0.12.0"
-io-lifetimes = { version = "0.4.0", default-features = false }
+io-extras = "0.13.0"
+io-lifetimes = { version = "0.5.1", default-features = false }
 camino = { version = "1.0.5", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = "0.32.0"
+rustix = "0.33.0"
 
 [features]
 default = []

--- a/cap-time-ext/Cargo.toml
+++ b/cap-time-ext/Cargo.toml
@@ -21,4 +21,4 @@ rustix = "0.33.0"
 
 [target.'cfg(windows)'.dependencies]
 once_cell = "1.5.2"
-winx = "0.30.0"
+winx = "0.31.0"

--- a/cap-time-ext/Cargo.toml
+++ b/cap-time-ext/Cargo.toml
@@ -17,7 +17,7 @@ cap-primitives = { path = "../cap-primitives", version = "^0.23.2-alpha.0"}
 cap-std = { path = "../cap-std", optional = true, version = "^0.23.2-alpha.0"}
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = "0.32.0"
+rustix = "0.33.0"
 
 [target.'cfg(windows)'.dependencies]
 once_cell = "1.5.2"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,7 +15,7 @@ cap-primitives = { path = "../cap-primitives", features = ["arbitrary"] }
 # Depend on io-lifetimes with default features, as the fuzzing framework
 # seems to add a dependency on `io_lifetimes::OwnedFd::drop` even when the
 # code itself doesn't have one.
-io-lifetimes = "0.4.0"
+io-lifetimes = "0.5.1"
 
 [[bin]]
 name = "cap-primitives"


### PR DESCRIPTION
This updates to io-lifetimes 0.5.1, in cap-std itself and in its
dependencies.

io-lifetimes is pretty stable at this point so hopefully these
kinds of semver-breaking releases won't happen frequently. In this
case, io-lifetimes needed a version bump due to the `HandleOrNull`
change, which only affects Windows, and only affects low-level ffi
users of io-lifetimes.