### PR TITLE
dir: Add `try_exists()`

### DIFF
--- a/cap-async-std/src/fs/dir.rs
+++ b/cap-async-std/src/fs/dir.rs
@@ -754,6 +754,21 @@ impl Dir {
         self.metadata(path).await.is_ok()
     }
 
+    /// Returns `true` if the path points at an existing entity.
+    ///
+    /// This is an asynchronous version of [`std::fs::try_exists`], and also only
+    /// accesses paths relative to `self`.
+    ///
+    /// NOTE: This API is not yet part of `async_std`.
+    #[inline]
+    pub async fn try_exists<P: AsRef<Path>>(&self, path: P) -> io::Result<bool> {
+        match self.metadata(path.as_ref()).await {
+            Ok(_) => Ok(true),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+
     /// Returns `true` if the path exists on disk and is pointing at a regular
     /// file.
     ///

--- a/cap-async-std/src/fs_utf8/dir.rs
+++ b/cap-async-std/src/fs_utf8/dir.rs
@@ -546,6 +546,15 @@ impl Dir {
         }
     }
 
+    /// Returns `true` if the path points at an existing entity.
+    ///
+    /// This corresponds to [`async_std::path::Path::exists`], but only
+    /// accesses paths relative to `self`.
+    #[inline]
+    pub async fn try_exists<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<bool> {
+        self.cap_std.try_exists(from_utf8(path)?).await
+    }
+
     /// Returns `true` if the path exists on disk and is pointing at a regular
     /// file.
     ///

--- a/cap-std/src/fs/dir.rs
+++ b/cap-std/src/fs/dir.rs
@@ -584,6 +584,24 @@ impl Dir {
         self.metadata(path).is_ok()
     }
 
+    /// Returns `true` if the path points at an existing entity.
+    ///
+    /// This corresponds to [`std::fs::try_exists`], but only
+    /// accesses paths relative to `self`.
+    ///
+    /// # API correspondence with `std`
+    ///
+    /// This API is not yet stable in `std`, but is likely to be.  For more
+    /// information, see the [tracker issue](https://github.com/rust-lang/rust/issues/83186).
+    #[inline]
+    pub fn try_exists<P: AsRef<Path>>(&self, path: P) -> io::Result<bool> {
+        match self.metadata(path) {
+            Ok(_) => Ok(true),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(error),
+        }
+    }
+
     /// Returns `true` if the path exists on disk and is pointing at a regular
     /// file.
     ///

--- a/cap-std/src/fs_utf8/dir.rs
+++ b/cap-std/src/fs_utf8/dir.rs
@@ -533,6 +533,15 @@ impl Dir {
         }
     }
 
+    /// Returns `true` if the path points at an existing entity.
+    ///
+    /// This corresponds to [`std::path::Path::exists`], but only
+    /// accesses paths relative to `self`.
+    #[inline]
+    pub fn try_exists<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<bool> {
+        self.cap_std.try_exists(from_utf8(path)?)
+    }
+
     /// Returns `true` if the path exists on disk and is pointing at a regular
     /// file.
     ///

--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -192,6 +192,21 @@ fn optionally_recursive_mkdir() {
 }
 
 #[test]
+fn try_exists() {
+    let tmpdir = tmpdir();
+    assert_eq!(tmpdir.try_exists("somefile").unwrap(), false);
+    let dir = Path::new("d1/d2");
+    let parent = dir.parent().unwrap();
+    assert_eq!(tmpdir.try_exists(parent).unwrap(), false);
+    assert_eq!(tmpdir.try_exists(dir).unwrap(), false);
+    check!(tmpdir.create_dir(parent));
+    assert_eq!(tmpdir.try_exists(parent).unwrap(), true);
+    assert_eq!(tmpdir.try_exists(dir).unwrap(), false);
+    check!(tmpdir.create_dir(dir));
+    assert_eq!(tmpdir.try_exists(dir).unwrap(), true);
+}
+
+#[test]
 fn optionally_nonrecursive_mkdir() {
     let tmpdir = tmpdir();
     let dir = "d1/d2";

--- a/tests/fs_utf8.rs
+++ b/tests/fs_utf8.rs
@@ -458,8 +458,10 @@ fn file_test_fileinfo_check_exists_before_and_after_file_creation() {
     let file = "fileinfo_check_exists_b_and_a.txt";
     check!(check!(tmpdir.create(file)).write(b"foo"));
     assert!(tmpdir.exists(file));
+    assert!(tmpdir.try_exists(file).unwrap());
     check!(tmpdir.remove_file(file));
     assert!(!tmpdir.exists(file));
+    assert!(!tmpdir.try_exists(file).unwrap());
 }
 
 #[test]


### PR DESCRIPTION
I want to use this for the same reason as
https://github.com/rust-lang/rust/pull/81822
was added to std.  While it's currently unstable, I can't imagine
it would change.