### PR TITLE
Fix compilation errors on Rust nightly.

### DIFF
--- a/cap-primitives/src/fs/via_parent/create_dir.rs
+++ b/cap-primitives/src/fs/via_parent/create_dir.rs
@@ -13,7 +13,7 @@ pub(crate) fn create_dir(start: &fs::File, path: &Path, options: &DirOptions) ->
     // slashes.
     let path = strip_dir_suffix(path);
 
-    let (dir, basename) = open_parent(start, &path)?;
+    let (dir, basename) = open_parent(start, &*path)?;
 
     create_dir_unchecked(&dir, basename.as_ref(), options)
 }

--- a/cap-primitives/src/fs/via_parent/rename.rs
+++ b/cap-primitives/src/fs/via_parent/rename.rs
@@ -19,8 +19,8 @@ pub(crate) fn rename(
     let old_path = strip_dir_suffix(old_path);
     let new_path = strip_dir_suffix(new_path);
 
-    let (old_dir, old_basename) = open_parent(old_start, &old_path)?;
-    let (new_dir, new_basename) = open_parent(new_start, &new_path)?;
+    let (old_dir, old_basename) = open_parent(old_start, &*old_path)?;
+    let (new_dir, new_basename) = open_parent(new_start, &*new_path)?;
 
     rename_unchecked(
         &old_dir,


### PR DESCRIPTION
Fix compilation errors that started appering on Rust nightly. This
appears to just need an explicit dereference where one was not
previously needed.

An example of the error message is:

```
error[E0308]: mismatched types
  --> cap-primitives/src/fs/via_parent/rename.rs:22:58
   |
22 |     let (old_dir, old_basename) = open_parent(old_start, &old_path)?;
   |                                                          ^^^^^^^^^ expected struct `Path`, found opaque type
   |
  ::: cap-primitives/src/rustix/fs/dir_utils.rs:67:48
   |
67 | pub(crate) fn strip_dir_suffix(path: &Path) -> impl Deref<Target = Path> + '_ {
   |                                                ------------------------------ the found opaque type
   |
   = note:   expected struct `Path`
           found opaque type `impl Deref<Target = Path>`
```