### PR TITLE
Update to io-lifetimes 0.7.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rustix = { version = "0.35.6", features = ["fs"] }
 # nt_version uses internal Windows APIs, however we're only using it
 # for testing here.
 nt_version = "0.1.3"
-winapi = "0.3.9"
+winapi = { version = "0.3.9", features = ["winioctl"] }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ rand = "0.8.1"
 tempfile = "3.1.0"
 camino = "1.0.5"
 libc = "0.2.100"
-io-lifetimes = "0.5.1"
+io-lifetimes = "0.7.0"
 
 [target.'cfg(not(windows))'.dev-dependencies]
-rustix = "0.33.0"
+rustix = { version = "0.35.6", features = ["fs"] }
 
 [target.'cfg(windows)'.dev-dependencies]
 # nt_version uses internal Windows APIs, however we're only using it

--- a/cap-async-std/Cargo.toml
+++ b/cap-async-std/Cargo.toml
@@ -13,17 +13,17 @@ repository = "https://github.com/bytecodealliance/cap-std"
 edition = "2018"
 
 [dependencies]
-arf-strings = { version = "0.6.3", optional = true }
+arf-strings = { version = "0.6.7", optional = true }
 # Enable "unstable" for `spawn_blocking`.
 async-std = { version = "1.10.0", features = ["attributes", "unstable"] }
 cap-primitives = { path = "../cap-primitives", version = "^0.24.1-alpha.0"}
-io-lifetimes = { version = "0.5.1", default-features = false, features = ["async-std"] }
+io-lifetimes = { version = "0.7.0", default-features = false, features = ["async-std"] }
 ipnet = "2.3.0"
-io-extras = { version = "0.13.0", features = ["use_async_std"] }
+io-extras = { version = "0.15.0", features = ["use_async_std"] }
 camino = { version = "1.0.5", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = "0.33.0"
+rustix = { version = "0.35.6", features = ["fs"] }
 
 [features]
 default = []

--- a/cap-async-std/src/fs_utf8/mod.rs
+++ b/cap-async-std/src/fs_utf8/mod.rs
@@ -55,7 +55,7 @@ fn to_utf8<P: AsRef<async_std::path::Path>>(path: P) -> std::io::Result<Utf8Path
     #[cfg(not(windows))]
     {
         Ok(Utf8Path::from_path(path.as_ref().into())
-            .ok_or_else(|| ::rustix::io::Error::ILSEQ)?
+            .ok_or_else(|| ::rustix::io::Errno::ILSEQ)?
             .to_path_buf())
     }
 

--- a/cap-directories/Cargo.toml
+++ b/cap-directories/Cargo.toml
@@ -17,7 +17,7 @@ cap-std = { path = "../cap-std", version = "^0.24.1-alpha.0"}
 directories-next = "2.0.0"
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = "0.33.0"
+rustix = { version = "0.35.6" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"

--- a/cap-directories/src/lib.rs
+++ b/cap-directories/src/lib.rs
@@ -22,7 +22,7 @@ pub use user_dirs::UserDirs;
 
 #[cfg(not(windows))]
 pub(crate) fn not_found() -> io::Error {
-    rustix::io::Error::NOENT.into()
+    rustix::io::Errno::NOENT.into()
 }
 
 #[cfg(windows)]

--- a/cap-fs-ext/Cargo.toml
+++ b/cap-fs-ext/Cargo.toml
@@ -13,11 +13,11 @@ repository = "https://github.com/bytecodealliance/cap-std"
 edition = "2018"
 
 [dependencies]
-arf-strings = { version = "0.6.3", optional = true }
+arf-strings = { version = "0.6.7", optional = true }
 cap-async-std = { path = "../cap-async-std", optional = true, version = "^0.24.1-alpha.0"}
 cap-std = { path = "../cap-std", optional = true, version = "^0.24.1-alpha.0"}
 cap-primitives = { path = "../cap-primitives", version = "^0.24.1-alpha.0"}
-io-lifetimes = { version = "0.5.1", default-features = false }
+io-lifetimes = { version = "0.7.0", default-features = false }
 # Enable "unstable" for `spawn_blocking`.
 async-std = { version = "1.10.0", features = ["attributes", "unstable"], optional = true }
 async-trait = { version = "0.1.42", optional = true }

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -22,7 +22,7 @@ io-extras = "0.15.0"
 io-lifetimes = { version = "0.7.0", default-features = false }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.35.6", features = ["fs", "procfs", "termios", "time"] }
+rustix = { version = "0.35.6", features = ["fs", "process", "procfs", "termios", "time"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 errno = { version = "0.2.8", default-features = false }

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -17,12 +17,12 @@ ambient-authority = "0.0.1"
 arbitrary = { version = "1.0.0", optional = true, features = ["derive"] }
 ipnet = "2.3.0"
 maybe-owned = "0.3.4"
-fs-set-times = "0.15.0"
-io-extras = "0.13.0"
-io-lifetimes = { version = "0.5.1", default-features = false }
+fs-set-times = "0.17.0"
+io-extras = "0.15.0"
+io-lifetimes = { version = "0.7.0", default-features = false }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.33.0", features = ["procfs"] }
+rustix = { version = "0.35.6", features = ["fs", "procfs", "termios", "time"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 errno = { version = "0.2.8", default-features = false }
@@ -31,6 +31,6 @@ errno = { version = "0.2.8", default-features = false }
 errno = { version = "0.2.8", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
-winx = "0.31.0"
+winx = "0.33.0"
 winapi = "0.3.9"
 winapi-util = "0.1.5"

--- a/cap-primitives/src/rustix/fs/copy_impl.rs
+++ b/cap-primitives/src/rustix/fs/copy_impl.rs
@@ -120,7 +120,7 @@ pub(crate) fn copy_impl(
             let copy_result = copy_file_range(&reader, None, &writer, None, bytes_to_copy);
             if let Err(copy_err) = copy_result {
                 match copy_err {
-                    rustix::io::Error::NOSYS | rustix::io::Error::PERM => {
+                    rustix::io::Errno::NOSYS | rustix::io::Errno::PERM => {
                         HAS_COPY_FILE_RANGE.store(false, Ordering::Relaxed);
                     }
                     _ => {}
@@ -128,16 +128,16 @@ pub(crate) fn copy_impl(
             }
             copy_result
         } else {
-            Err(rustix::io::Error::NOSYS.into())
+            Err(rustix::io::Errno::NOSYS.into())
         };
         match copy_result {
             Ok(ret) => written += ret as u64,
             Err(err) => {
                 match err {
-                    rustix::io::Error::NOSYS
-                    | rustix::io::Error::XDEV
-                    | rustix::io::Error::INVAL
-                    | rustix::io::Error::PERM => {
+                    rustix::io::Errno::NOSYS
+                    | rustix::io::Errno::XDEV
+                    | rustix::io::Errno::INVAL
+                    | rustix::io::Errno::PERM => {
                         // Try fallback io::copy if either:
                         // - Kernel version is < 4.5 (ENOSYS)
                         // - Files are mounted on different fs (EXDEV)
@@ -193,10 +193,10 @@ pub(crate) fn copy_impl(
                 // destination already exists, or if the source and destination
                 // are on different devices. In all these cases `fcopyfile`
                 // should succeed.
-                rustix::io::Error::NOTSUP | rustix::io::Error::EXIST | rustix::io::Error::XDEV => {
+                rustix::io::Errno::NOTSUP | rustix::io::Errno::EXIST | rustix::io::Errno::XDEV => {
                     ()
                 }
-                rustix::io::Error::NOSYS => HAS_FCLONEFILEAT.store(false, Ordering::Relaxed),
+                rustix::io::Errno::NOSYS => HAS_FCLONEFILEAT.store(false, Ordering::Relaxed),
                 _ => return Err(err.into()),
             },
         }

--- a/cap-primitives/src/rustix/fs/errors.rs
+++ b/cap-primitives/src/rustix/fs/errors.rs
@@ -2,25 +2,25 @@ use std::io;
 
 #[cold]
 pub(crate) fn invalid_flags() -> io::Error {
-    rustix::io::Error::INVAL.into()
+    rustix::io::Errno::INVAL.into()
 }
 
 #[cold]
 pub(crate) fn no_such_file_or_directory() -> io::Error {
-    rustix::io::Error::NOENT.into()
+    rustix::io::Errno::NOENT.into()
 }
 
 #[cold]
 pub(crate) fn is_directory() -> io::Error {
-    rustix::io::Error::ISDIR.into()
+    rustix::io::Errno::ISDIR.into()
 }
 
 #[cold]
 pub(crate) fn is_not_directory() -> io::Error {
-    rustix::io::Error::NOTDIR.into()
+    rustix::io::Errno::NOTDIR.into()
 }
 
 #[cold]
 pub(crate) fn too_many_symlinks() -> io::Error {
-    rustix::io::Error::LOOP.into()
+    rustix::io::Errno::LOOP.into()
 }

--- a/cap-primitives/src/rustix/fs/file_path.rs
+++ b/cap-primitives/src/rustix/fs/file_path.rs
@@ -1,6 +1,6 @@
 use crate::fs::file_path_by_searching;
 #[cfg(not(any(target_os = "wasi", target_os = "fuchsia")))]
-use rustix::io::ttyname;
+use rustix::termios::ttyname;
 #[cfg(not(any(target_os = "wasi", target_os = "fuchsia")))]
 use std::ffi::OsString;
 use std::fs;

--- a/cap-primitives/src/rustix/fs/oflags.rs
+++ b/cap-primitives/src/rustix/fs/oflags.rs
@@ -40,7 +40,7 @@ pub(crate) fn get_access_mode(options: &OpenOptions) -> io::Result<OFlags> {
         (true, true, false) => Ok(OFlags::RDWR),
         (false, _, true) => Ok(OFlags::WRONLY | OFlags::APPEND),
         (true, _, true) => Ok(OFlags::RDWR | OFlags::APPEND),
-        (false, false, false) => Err(rustix::io::Error::INVAL.into()),
+        (false, false, false) => Err(rustix::io::Errno::INVAL.into()),
     }
 }
 
@@ -49,12 +49,12 @@ pub(crate) fn get_creation_mode(options: &OpenOptions) -> io::Result<OFlags> {
         (true, false) => {}
         (false, false) => {
             if options.truncate || options.create || options.create_new {
-                return Err(rustix::io::Error::INVAL.into());
+                return Err(rustix::io::Errno::INVAL.into());
             }
         }
         (_, true) => {
             if options.truncate && !options.create_new {
-                return Err(rustix::io::Error::INVAL.into());
+                return Err(rustix::io::Errno::INVAL.into());
             }
         }
     }

--- a/cap-primitives/src/rustix/fs/open_unchecked.rs
+++ b/cap-primitives/src/rustix/fs/open_unchecked.rs
@@ -32,18 +32,18 @@ pub(crate) fn open_unchecked(
         // `ELOOP` is the POSIX standard and most widely used error code to
         // indicate that a symlink was found when `O_NOFOLLOW` was set.
         #[cfg(not(any(target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd")))]
-        io::Error::LOOP => Err(OpenUncheckedError::Symlink(err.into(), ())),
+        io::Errno::LOOP => Err(OpenUncheckedError::Symlink(err.into(), ())),
 
         // FreeBSD and similar (but not Darwin) use `EMLINK`.
         #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-        io::Error::MLINK => Err(OpenUncheckedError::Symlink(err.into(), ())),
+        io::Errno::MLINK => Err(OpenUncheckedError::Symlink(err.into(), ())),
 
         // NetBSD uses `EFTYPE`.
         #[cfg(any(target_os = "netbsd"))]
-        io::Error::FTYPE => Err(OpenUncheckedError::Symlink(err.into(), ())),
+        io::Errno::FTYPE => Err(OpenUncheckedError::Symlink(err.into(), ())),
 
-        io::Error::NOENT => Err(OpenUncheckedError::NotFound(err.into())),
-        io::Error::NOTDIR => {
+        io::Errno::NOENT => Err(OpenUncheckedError::NotFound(err.into())),
+        io::Errno::NOTDIR => {
             if options.dir_required
                 && stat_unchecked(start, path, options.follow)
                     .map(|m| m.file_type().is_symlink())

--- a/cap-primitives/src/rustix/fs/set_times_impl.rs
+++ b/cap-primitives/src/rustix/fs/set_times_impl.rs
@@ -3,7 +3,7 @@
 
 use crate::fs::{open, OpenOptions, SystemTimeSpec};
 use fs_set_times::SetTimes;
-use rustix::io::Error;
+use rustix::io::Errno;
 use std::path::Path;
 use std::{fs, io};
 
@@ -22,8 +22,8 @@ pub(crate) fn set_times_impl(
                 mtime.map(SystemTimeSpec::into_std),
             )
         }
-        Err(err) => match Error::from_io_error(&err) {
-            Some(Error::ACCESS) | Some(Error::ISDIR) => (),
+        Err(err) => match Errno::from_io_error(&err) {
+            Some(Errno::ACCESS) | Some(Errno::ISDIR) => (),
             _ => return Err(err),
         },
     }
@@ -36,8 +36,8 @@ pub(crate) fn set_times_impl(
                 mtime.map(SystemTimeSpec::into_std),
             )
         }
-        Err(err) => match Error::from_io_error(&err) {
-            Some(Error::ACCESS) => (),
+        Err(err) => match Errno::from_io_error(&err) {
+            Some(Errno::ACCESS) => (),
             _ => return Err(err),
         },
     }
@@ -51,5 +51,5 @@ pub(crate) fn set_times_impl(
     //    instead of the file we're trying to get to.
     //
     // So neither does what we need.
-    Err(Error::NOTSUP.into())
+    Err(Errno::NOTSUP.into())
 }

--- a/cap-primitives/src/rustix/fs/stat_unchecked.rs
+++ b/cap-primitives/src/rustix/fs/stat_unchecked.rs
@@ -49,14 +49,14 @@ pub(crate) fn stat_unchecked(
                     }
                     return Ok(MetadataExt::from_rustix_statx(statx));
                 }
-                Err(rustix::io::Error::NOSYS) => STATX_STATE.store(1, Ordering::Relaxed),
-                Err(rustix::io::Error::PERM) if state == 0 => {
+                Err(rustix::io::Errno::NOSYS) => STATX_STATE.store(1, Ordering::Relaxed),
+                Err(rustix::io::Errno::PERM) if state == 0 => {
                     // This is an unlikely case, as `statx` doesn't normally
                     // return `PERM` errors. One way this can happen is when
                     // running on old versions of seccomp/Docker. If `statx` on
                     // the current working directory returns a similar error,
                     // then stop using `statx`.
-                    if let Err(rustix::io::Error::PERM) = statx(
+                    if let Err(rustix::io::Errno::PERM) = statx(
                         rustix::fs::cwd(),
                         "",
                         AtFlags::EMPTY_PATH,
@@ -64,7 +64,7 @@ pub(crate) fn stat_unchecked(
                     ) {
                         STATX_STATE.store(1, Ordering::Relaxed);
                     } else {
-                        return Err(rustix::io::Error::PERM.into());
+                        return Err(rustix::io::Errno::PERM.into());
                     }
                 }
                 Err(e) => return Err(e.into()),

--- a/cap-primitives/src/rustix/linux/fs/canonicalize_impl.rs
+++ b/cap-primitives/src/rustix/linux/fs/canonicalize_impl.rs
@@ -53,10 +53,10 @@ pub(crate) fn canonicalize_impl(start: &fs::File, path: &Path) -> io::Result<Pat
                 }
             }
         }
-        Err(err) => match rustix::io::Error::from_io_error(&err) {
+        Err(err) => match rustix::io::Errno::from_io_error(&err) {
             // `ENOSYS` from `open_beneath` means `openat2` is unavailable
             // and we should use a fallback.
-            Some(rustix::io::Error::NOSYS) => (),
+            Some(rustix::io::Errno::NOSYS) => (),
             _ => return Err(err),
         },
     }

--- a/cap-primitives/src/rustix/linux/fs/file_metadata.rs
+++ b/cap-primitives/src/rustix/linux/fs/file_metadata.rs
@@ -14,9 +14,9 @@ pub(super) fn file_metadata(file: &fs::File) -> io::Result<Metadata> {
     if !FSTAT_PATH_BADF.load(Relaxed) {
         match Metadata::from_file(file) {
             Ok(metadata) => return Ok(metadata),
-            Err(err) => match rustix::io::Error::from_io_error(&err) {
+            Err(err) => match rustix::io::Errno::from_io_error(&err) {
                 // Before Linux 3.6, `fstat` with `O_PATH` returned `EBADF`.
-                Some(rustix::io::Error::BADF) => FSTAT_PATH_BADF.store(true, Relaxed),
+                Some(rustix::io::Errno::BADF) => FSTAT_PATH_BADF.store(true, Relaxed),
                 _ => return Err(err),
             },
         }

--- a/cap-primitives/src/rustix/linux/fs/open_entry_impl.rs
+++ b/cap-primitives/src/rustix/linux/fs/open_entry_impl.rs
@@ -11,8 +11,8 @@ pub(crate) fn open_entry_impl(
 
     match result {
         Ok(file) => Ok(file),
-        Err(err) => match rustix::io::Error::from_io_error(&err) {
-            Some(rustix::io::Error::NOSYS) => manually::open_entry(start, path, options),
+        Err(err) => match rustix::io::Errno::from_io_error(&err) {
+            Some(rustix::io::Errno::NOSYS) => manually::open_entry(start, path, options),
             _ => Err(err),
         },
     }

--- a/cap-primitives/src/rustix/linux/fs/set_permissions_impl.rs
+++ b/cap-primitives/src/rustix/linux/fs/set_permissions_impl.rs
@@ -28,8 +28,8 @@ pub(crate) fn set_permissions_impl(
     // access, so first try read.
     match open(start, path, OpenOptions::new().read(true)) {
         Ok(file) => return set_file_permissions(&file, std_perm),
-        Err(err) => match rustix::io::Error::from_io_error(&err) {
-            Some(rustix::io::Error::ACCESS) => (),
+        Err(err) => match rustix::io::Errno::from_io_error(&err) {
+            Some(rustix::io::Errno::ACCESS) => (),
             _ => return Err(err),
         },
     }
@@ -37,8 +37,8 @@ pub(crate) fn set_permissions_impl(
     // Next try write.
     match open(start, path, OpenOptions::new().write(true)) {
         Ok(file) => return set_file_permissions(&file, std_perm),
-        Err(err) => match rustix::io::Error::from_io_error(&err) {
-            Some(rustix::io::Error::ACCESS) | Some(rustix::io::Error::ISDIR) => (),
+        Err(err) => match rustix::io::Errno::from_io_error(&err) {
+            Some(rustix::io::Errno::ACCESS) | Some(rustix::io::Errno::ISDIR) => (),
             _ => return Err(err),
         },
     }

--- a/cap-primitives/src/rustix/linux/fs/set_times_impl.rs
+++ b/cap-primitives/src/rustix/linux/fs/set_times_impl.rs
@@ -22,8 +22,8 @@ pub(crate) fn set_times_impl(
                 mtime.map(SystemTimeSpec::into_std),
             )
         }
-        Err(err) => match rustix::io::Error::from_io_error(&err) {
-            Some(rustix::io::Error::ACCESS) | Some(rustix::io::Error::ISDIR) => (),
+        Err(err) => match rustix::io::Errno::from_io_error(&err) {
+            Some(rustix::io::Errno::ACCESS) | Some(rustix::io::Errno::ISDIR) => (),
             _ => return Err(err),
         },
     }
@@ -36,8 +36,8 @@ pub(crate) fn set_times_impl(
                 mtime.map(SystemTimeSpec::into_std),
             )
         }
-        Err(err) => match rustix::io::Error::from_io_error(&err) {
-            Some(rustix::io::Error::ACCESS) => (),
+        Err(err) => match rustix::io::Errno::from_io_error(&err) {
+            Some(rustix::io::Errno::ACCESS) => (),
             _ => return Err(err),
         },
     }

--- a/cap-primitives/src/rustix/linux/fs/stat_impl.rs
+++ b/cap-primitives/src/rustix/linux/fs/stat_impl.rs
@@ -32,10 +32,10 @@ pub(crate) fn stat_impl(
     // If that worked, call `fstat`.
     match result {
         Ok(file) => file_metadata(&file),
-        Err(err) => match rustix::io::Error::from_io_error(&err) {
+        Err(err) => match rustix::io::Errno::from_io_error(&err) {
             // `ENOSYS` from `open_beneath` means `openat2` is unavailable
             // and we should use a fallback.
-            Some(rustix::io::Error::NOSYS) => manually::stat(start, path, follow),
+            Some(rustix::io::Errno::NOSYS) => manually::stat(start, path, follow),
             _ => Err(err),
         },
     }

--- a/cap-std/Cargo.toml
+++ b/cap-std/Cargo.toml
@@ -17,15 +17,15 @@ all-features = true
 rustdoc-args = ["--cfg=doc_cfg"]
 
 [dependencies]
-arf-strings = { version = "0.6.3", optional = true }
+arf-strings = { version = "0.6.7", optional = true }
 cap-primitives = { path = "../cap-primitives", version = "^0.24.1-alpha.0"}
 ipnet = "2.3.0"
-io-extras = "0.13.0"
-io-lifetimes = { version = "0.5.1", default-features = false }
+io-extras = "0.15.0"
+io-lifetimes = { version = "0.7.0", default-features = false }
 camino = { version = "1.0.5", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = "0.33.0"
+rustix = { version = "0.35.6", features = ["fs"] }
 
 [features]
 default = []

--- a/cap-std/src/fs_utf8/mod.rs
+++ b/cap-std/src/fs_utf8/mod.rs
@@ -57,7 +57,7 @@ fn to_utf8<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<Utf8PathBuf> {
     #[cfg(not(windows))]
     {
         Ok(Utf8Path::from_path(path.as_ref())
-            .ok_or_else(|| ::rustix::io::Error::ILSEQ)?
+            .ok_or_else(|| ::rustix::io::Errno::ILSEQ)?
             .to_path_buf())
     }
 

--- a/cap-tempfile/Cargo.toml
+++ b/cap-tempfile/Cargo.toml
@@ -24,7 +24,7 @@ rand = "0.8.1"
 winapi = "0.3.9"
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.33.0", features = ["procfs"] }
+rustix = { version = "0.35.6", features = ["procfs"] }
 
 [features]
 default = []

--- a/cap-tempfile/src/tempfile.rs
+++ b/cap-tempfile/src/tempfile.rs
@@ -68,9 +68,9 @@ fn new_tempfile_linux(d: &Dir) -> io::Result<Option<File>> {
         Ok(r) => return Ok(Some(File::from_fd(r.into()))),
         // See https://github.com/Stebalien/tempfile/blob/1a40687e06eb656044e3d2dffa1379f04b3ef3fd/src/file/imp/unix.rs#L81
         // TODO: With newer Rust versions, this could be simplied to only write `Err` once.
-        Err(rustix::io::Error::OPNOTSUPP)
-        | Err(rustix::io::Error::ISDIR)
-        | Err(rustix::io::Error::NOENT) => Ok(None),
+        Err(rustix::io::Errno::OPNOTSUPP)
+        | Err(rustix::io::Errno::ISDIR)
+        | Err(rustix::io::Errno::NOENT) => Ok(None),
         Err(e) => {
             return Err(e.into());
         }

--- a/cap-time-ext/Cargo.toml
+++ b/cap-time-ext/Cargo.toml
@@ -17,8 +17,8 @@ cap-primitives = { path = "../cap-primitives", version = "^0.24.1-alpha.0"}
 cap-std = { path = "../cap-std", optional = true, version = "^0.24.1-alpha.0"}
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = "0.33.0"
+rustix = { version = "0.35.6", features = ["time"] }
 
 [target.'cfg(windows)'.dependencies]
 once_cell = "1.5.2"
-winx = "0.31.0"
+winx = "0.33.0"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,7 +15,7 @@ cap-primitives = { path = "../cap-primitives", features = ["arbitrary"] }
 # Depend on io-lifetimes with default features, as the fuzzing framework
 # seems to add a dependency on `io_lifetimes::OwnedFd::drop` even when the
 # code itself doesn't have one.
-io-lifetimes = "0.5.1"
+io-lifetimes = "0.7.0"
 
 [[bin]]
 name = "cap-primitives"

--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -6,7 +6,7 @@ use sys_common::io::tmpdir;
 /*
 #[cfg(not(windows))]
 fn rename_path_in_use() -> String {
-    rustix::io::Error::BUSY.into().to_string()
+    rustix::io::Errno::BUSY.into().to_string()
 }
 #[cfg(windows)]
 fn rename_path_in_use() -> String {
@@ -16,7 +16,7 @@ fn rename_path_in_use() -> String {
 
 #[cfg(not(windows))]
 fn no_such_file_or_directory() -> String {
-    rustix::io::Error::NOENT.to_string()
+    rustix::io::Errno::NOENT.to_string()
 }
 #[cfg(windows)]
 fn no_such_file_or_directory() -> String {
@@ -28,7 +28,7 @@ fn no_such_file_or_directory() -> String {
 cfg_if::cfg_if! {
     if #[cfg(any(target_os = "macos", target_os = "netbsd", target_os = "freebsd", target_os = "openbsd", target_os = "ios", target_os = "dragonfly"))] {
         fn rename_file_over_dir() -> String {
-            rustix::io::Error::ISDIR.into().to_string()
+            rustix::io::Errno::ISDIR.into().to_string()
         }
 
         fn rename_file_over_dot() -> String {
@@ -36,11 +36,11 @@ cfg_if::cfg_if! {
         }
 
         fn rename_dot_over_file() -> String {
-            rustix::io::Error::INVAL.into().to_string()
+            rustix::io::Errno::INVAL.into().to_string()
         }
     } else {
         fn rename_file_over_dir() -> String {
-            rustix::io::Error::NOTEMPTY.into().to_string()
+            rustix::io::Errno::NOTEMPTY.into().to_string()
         }
 
         fn rename_file_over_dot() -> String {


### PR DESCRIPTION
io-lifetimes needed a semver bump due to `BorrowedFd::borrow_raw_fd`
being renamed to `BorrowedFd::borrow_raw`, to match the corresponding change
in std. cap-std doesn't use this function itself, but since it's a semver
bump, we need to bump it in cap-std so that it uses the new trait versions.