### PR TITLE
Prefer to use `O_PATH` in `set_permissions` on Linux.

### DIFF
--- a/cap-primitives/src/rustix/linux/fs/procfs.rs
+++ b/cap-primitives/src/rustix/linux/fs/procfs.rs
@@ -25,6 +25,12 @@ pub(crate) fn get_path_from_proc_self_fd(file: &fs::File) -> io::Result<PathBuf>
     )
 }
 
+/// Linux's `fchmodat` doesn't support `AT_NOFOLLOW_SYMLINK`, so we can't trust
+/// that it won't follow a symlink outside the sandbox. As an alternative, the
+/// symlinks in Linux's /proc/self/fd/* aren't ordinary symlinks, they're
+/// "magic links", which are more transparent, to the point of allowing chmod
+/// to work. So we open the file with `O_PATH` and then do `fchmodat` on the
+/// corresponding /proc/self/fd/* link.
 pub(crate) fn set_permissions_through_proc_self_fd(
     start: &fs::File,
     path: &Path,

--- a/cap-primitives/src/rustix/linux/fs/set_permissions_impl.rs
+++ b/cap-primitives/src/rustix/linux/fs/set_permissions_impl.rs
@@ -1,10 +1,8 @@
 use super::procfs::set_permissions_through_proc_self_fd;
 use crate::fs::{errors, open, OpenOptions, Permissions};
-use rustix::fs::{fchmod, Mode, OFlags, RawMode};
-use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use rustix::fs::{fchmod, Mode, RawMode};
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering::Relaxed;
 use std::{fs, io};
 
 pub(crate) fn set_permissions_impl(
@@ -12,38 +10,18 @@ pub(crate) fn set_permissions_impl(
     path: &Path,
     perm: Permissions,
 ) -> io::Result<()> {
-    // Record whether we've seen an `EBADF` from an `fchmod` on an `O_PATH`
-    // file descriptor, meaning we're on a Linux that doesn't support it.
-    static FCHMOD_PATH_BADF: AtomicBool = AtomicBool::new(false);
-
     let std_perm = perm.into_std(start)?;
 
-    if !FCHMOD_PATH_BADF.load(Relaxed) {
-        // First try to open the path with `O_PATH`; if that succeeds, it'll give
-        // us a few options. Use `read(true)` even though we don't need `read`
-        // permissions, because Rust's libstd requires an access mode, and Linux
-        // ignores `O_RDONLY` with `O_PATH`.
-        // TODO: Add tests with no-read no-permissions.
-        let opath_result = open(
-            start,
-            path,
-            OpenOptions::new()
-                .read(true)
-                .custom_flags(OFlags::PATH.bits() as i32),
-        );
-
-        // If `O_PATH` worked, try to use `fchmod` on it.
-        if let Ok(file) = opath_result {
-            match set_file_permissions(&file, std_perm.clone()) {
-                Ok(()) => return Ok(()),
-                Err(err) => match rustix::io::Error::from_io_error(&err) {
-                    // If it fails with `EBADF`, `fchmod` didn't like `O_PATH`,
-                    // so proceed to the fallback strategies below.
-                    Some(rustix::io::Error::BADF) => FCHMOD_PATH_BADF.store(true, Relaxed),
-                    _ => return Err(err),
-                },
-            }
-        }
+    // First try using `O_PATH` and doing a chmod on `/proc/self/fd/{}`
+    // (`fchmod` doesn't work on `O_PATH` file descriptors).
+    //
+    // This may fail, due to older Linux versions not supporting `O_PATH`, or
+    // due to procfs being unavailable, but if it does work, go with it, as
+    // `O_PATH` tells Linux that we don't actually need to read or write the
+    // file, which may avoid side effects associated with opening device files.
+    let result = set_permissions_through_proc_self_fd(start, path, std_perm.clone());
+    if let Ok(()) = result {
+        return Ok(());
     }
 
     // Then try `fchmod` with a normal handle. Normal handles need some kind of
@@ -65,8 +43,8 @@ pub(crate) fn set_permissions_impl(
         },
     }
 
-    // If neither of those worked, turn to `/proc`.
-    set_permissions_through_proc_self_fd(start, path, std_perm)
+    // Nothing worked, so just return the original error.
+    result
 }
 
 fn set_file_permissions(file: &fs::File, perm: fs::Permissions) -> io::Result<()> {


### PR DESCRIPTION
This patch makes two changes:

 - It removes the code that tries `O_PATH` + `fchmod`, as `fchmod` is
   [documented] to fail on `O_PATH` file descriptors, which now seems
   unlikely to ever change.

 - It moves the call to `set_permissions_through_proc_self_fd` to the
   top so that it's the first strategy tried. This function uses
   `O_PATH` + `fchmodat` on /proc/self/fd/{}, which may fail due to
   missing support for `O_PATH` or procfs not being mounted, but if it
   does succeed, it's the best option because opening files with
   `O_PATH` tells Linux we don't need `read`/`write`/etc. access, which
   may allow it to succeed in more cases, and may have fewer side
   effects when opening device files.

[documented]: https://man7.org/linux/man-pages/man2/open.2.html#DESCRIPTION