### PR TITLE
cap-primitives: Add `read_link_contents` and `symlink_contents`

### DIFF
--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -21,6 +21,9 @@ fs-set-times = "0.17.0"
 io-extras = "0.15.0"
 io-lifetimes = { version = "0.7.0", default-features = false }
 
+[dev-dependencies]
+cap-tempfile = { path = "../cap-tempfile" }
+
 [target.'cfg(not(windows))'.dependencies]
 rustix = { version = "0.35.6", features = ["fs", "process", "procfs", "termios", "time"] }
 

--- a/cap-primitives/src/fs/mod.rs
+++ b/cap-primitives/src/fs/mod.rs
@@ -80,7 +80,7 @@ pub use open_dir::*;
 pub use open_options::OpenOptions;
 pub use permissions::Permissions;
 pub use read_dir::{read_base_dir, read_dir, ReadDir};
-pub use read_link::read_link;
+pub use read_link::{read_link, read_link_contents};
 pub use remove_dir::remove_dir;
 pub use remove_dir_all::remove_dir_all;
 pub use remove_file::remove_file;
@@ -92,7 +92,7 @@ pub use set_permissions::set_permissions;
 pub use set_times::{set_times, set_times_nofollow};
 pub use stat::stat;
 #[cfg(not(windows))]
-pub use symlink::symlink;
+pub use symlink::{symlink, symlink_contents};
 #[cfg(windows)]
 pub use symlink::{symlink_dir, symlink_file};
 pub use system_time_spec::SystemTimeSpec;

--- a/cap-primitives/src/fs/symlink.rs
+++ b/cap-primitives/src/fs/symlink.rs
@@ -12,13 +12,12 @@ use std::path::Path;
 use std::{fs, io};
 
 /// Perform a `symlinkat`-like operation, ensuring that the resolution of the
-/// path never escapes the directory tree rooted at `start`.
+/// path never escapes the directory tree rooted at `start`.  An error
+/// is returned if the target path is absolute.
 #[cfg_attr(not(racy_asserts), allow(clippy::let_and_return))]
 #[cfg(not(windows))]
 #[inline]
 pub fn symlink(old_path: &Path, new_start: &fs::File, new_path: &Path) -> io::Result<()> {
-    use crate::fs::symlink_impl;
-
     // Don't allow creating symlinks to absolute paths. This isn't strictly
     // necessary to preserve the sandbox, since `open` will refuse to follow
     // absolute symlinks in any case. However, it is useful to enforce this
@@ -27,6 +26,12 @@ pub fn symlink(old_path: &Path, new_start: &fs::File, new_path: &Path) -> io::Re
     if old_path.has_root() {
         return Err(errors::escape_attempt());
     }
+
+    write_symlink_impl(old_path, new_start, new_path)
+}
+
+fn write_symlink_impl(old_path: &Path, new_start: &fs::File, new_path: &Path) -> io::Result<()> {
+    use crate::fs::symlink_impl;
 
     #[cfg(racy_asserts)]
     let stat_before = stat_unchecked(new_start, new_path, FollowSymlinks::No);
@@ -48,6 +53,17 @@ pub fn symlink(old_path: &Path, new_start: &fs::File, new_path: &Path) -> io::Re
     );
 
     result
+}
+
+/// Perform a `symlinkat`-like operation, ensuring that the resolution of the
+/// link path never escapes the directory tree rooted at `start`.
+#[cfg(not(windows))]
+pub fn symlink_contents<P: AsRef<Path>, Q: AsRef<Path>>(
+    old_path: P,
+    new_start: &fs::File,
+    new_path: Q,
+) -> io::Result<()> {
+    write_symlink_impl(old_path.as_ref(), new_start, new_path.as_ref())
 }
 
 /// Perform a `symlink_file`-like operation, ensuring that the resolution of

--- a/cap-primitives/src/fs/symlink.rs
+++ b/cap-primitives/src/fs/symlink.rs
@@ -30,6 +30,7 @@ pub fn symlink(old_path: &Path, new_start: &fs::File, new_path: &Path) -> io::Re
     write_symlink_impl(old_path, new_start, new_path)
 }
 
+#[cfg(not(windows))]
 fn write_symlink_impl(old_path: &Path, new_start: &fs::File, new_path: &Path) -> io::Result<()> {
     use crate::fs::symlink_impl;
 


### PR DESCRIPTION


There are use cases for reading and writing the contents of
symbolic links without the check that errors out on absolute paths.
It's safe when the calling process is not going to interpret it.

For example in rpm-ostree, we construct a new root filesystem which
in some cases may have absolute links, but the calling process doesn't
read those links back.  Instead we spawn containers into the target
root to run code there.

---

