### PR TITLE
Port from winapi to windows-sys.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,14 @@ rustix = { version = "0.35.6", features = ["fs"] }
 # nt_version uses internal Windows APIs, however we're only using it
 # for testing here.
 nt_version = "0.1.3"
-winapi = { version = "0.3.9", features = ["winioctl"] }
+
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.36.0"
+features = [
+    "Win32_Storage_FileSystem",
+    "Win32_Foundation",
+    "Win32_System_SystemServices",
+]
 
 [features]
 default = []

--- a/cap-directories/Cargo.toml
+++ b/cap-directories/Cargo.toml
@@ -19,5 +19,8 @@ directories-next = "2.0.0"
 [target.'cfg(not(windows))'.dependencies]
 rustix = { version = "0.35.6" }
 
-[target.'cfg(windows)'.dependencies]
-winapi = "0.3.9"
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.36.0"
+features = [
+    "Win32_Foundation",
+]

--- a/cap-directories/src/lib.rs
+++ b/cap-directories/src/lib.rs
@@ -27,5 +27,5 @@ pub(crate) fn not_found() -> io::Error {
 
 #[cfg(windows)]
 pub(crate) fn not_found() -> io::Error {
-    io::Error::from_raw_os_error(winapi::shared::winerror::ERROR_PATH_NOT_FOUND as i32)
+    io::Error::from_raw_os_error(windows_sys::Win32::Foundation::ERROR_PATH_NOT_FOUND as i32)
 }

--- a/cap-fs-ext/Cargo.toml
+++ b/cap-fs-ext/Cargo.toml
@@ -32,8 +32,12 @@ async_std = ["cap-async-std", "async-std", "io-lifetimes/async-std", "async-trai
 async_std_fs_utf8 = ["cap-async-std/fs_utf8", "camino"]
 async_std_arf_strings = ["cap-async-std/arf_strings", "async_std_fs_utf8", "arf-strings"]
 
-[target.'cfg(windows)'.dependencies]
-winapi = "0.3.9"
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.36.0"
+features = [
+    "Win32_Storage_FileSystem",
+    "Win32_System_SystemServices",
+]
 
 [dev-dependencies]
 cap-tempfile = { path = "../cap-tempfile" }

--- a/cap-fs-ext/src/dir_ext.rs
+++ b/cap-fs-ext/src/dir_ext.rs
@@ -537,8 +537,10 @@ impl DirExt for cap_std::fs::Dir {
         use cap_primitives::fs::_WindowsByHandle;
         use cap_std::fs::OpenOptions;
         use std::os::windows::fs::OpenOptionsExt;
-        use winapi::um::winbase::{FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT};
-        use winapi::um::winnt::{DELETE, FILE_ATTRIBUTE_DIRECTORY};
+        use windows_sys::Win32::Storage::FileSystem::{
+            FILE_ATTRIBUTE_DIRECTORY, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+        };
+        use windows_sys::Win32::System::SystemServices::DELETE;
         let path = path.as_ref();
 
         let mut opts = OpenOptions::new();
@@ -831,8 +833,10 @@ impl AsyncDirExt for cap_async_std::fs::Dir {
         use cap_primitives::fs::_WindowsByHandle;
         use cap_std::fs::OpenOptions;
         use std::os::windows::fs::OpenOptionsExt;
-        use winapi::um::winbase::{FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT};
-        use winapi::um::winnt::{DELETE, FILE_ATTRIBUTE_DIRECTORY};
+        use windows_sys::Win32::Storage::FileSystem::{
+            FILE_ATTRIBUTE_DIRECTORY, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+        };
+        use windows_sys::Win32::System::SystemServices::DELETE;
         let path = path.as_ref();
 
         let mut opts = OpenOptions::new();
@@ -996,8 +1000,10 @@ impl DirExtUtf8 for cap_std::fs_utf8::Dir {
         use cap_primitives::fs::_WindowsByHandle;
         use cap_std::fs::OpenOptions;
         use std::os::windows::fs::OpenOptionsExt;
-        use winapi::um::winbase::{FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT};
-        use winapi::um::winnt::{DELETE, FILE_ATTRIBUTE_DIRECTORY};
+        use windows_sys::Win32::Storage::FileSystem::{
+            FILE_ATTRIBUTE_DIRECTORY, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+        };
+        use windows_sys::Win32::System::SystemServices::DELETE;
         let path = path.as_ref();
 
         let mut opts = OpenOptions::new();
@@ -1228,8 +1234,10 @@ impl AsyncDirExtUtf8 for cap_async_std::fs_utf8::Dir {
         use cap_primitives::fs::_WindowsByHandle;
         use cap_std::fs::OpenOptions;
         use std::os::windows::fs::OpenOptionsExt;
-        use winapi::um::winbase::{FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT};
-        use winapi::um::winnt::{DELETE, FILE_ATTRIBUTE_DIRECTORY};
+        use windows_sys::Win32::Storage::FileSystem::{
+            FILE_ATTRIBUTE_DIRECTORY, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+        };
+        use windows_sys::Win32::System::SystemServices::DELETE;
         let path = path.as_ref();
 
         let mut opts = OpenOptions::new();

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -32,5 +32,12 @@ errno = { version = "0.2.8", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 winx = "0.33.0"
-winapi = "0.3.9"
 winapi-util = "0.1.5"
+
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.36.0"
+features = [
+    "Win32_Storage_FileSystem",
+    "Win32_Foundation",
+    "Win32_System_SystemServices",
+]

--- a/cap-primitives/src/fs/manually/open.rs
+++ b/cap-primitives/src/fs/manually/open.rs
@@ -15,7 +15,7 @@ use std::{fs, io, mem};
 #[cfg(windows)]
 use {
     crate::fs::{open_dir_unchecked, path_really_has_trailing_dot, SymlinkKind},
-    winapi::um::winnt::FILE_ATTRIBUTE_DIRECTORY,
+    windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_DIRECTORY,
 };
 
 /// Implement `open` by breaking up the path into components, resolving each

--- a/cap-primitives/src/windows/fs/dir_entry_inner.rs
+++ b/cap-primitives/src/windows/fs/dir_entry_inner.rs
@@ -7,7 +7,9 @@ use crate::fs::{
 use std::ffi::OsString;
 use std::os::windows::fs::OpenOptionsExt;
 use std::{fmt, fs, io};
-use winapi::um::winbase::{FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT};
+use windows_sys::Win32::Storage::FileSystem::{
+    FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+};
 
 pub(crate) struct DirEntryInner {
     std: fs::DirEntry,

--- a/cap-primitives/src/windows/fs/dir_utils.rs
+++ b/cap-primitives/src/windows/fs/dir_utils.rs
@@ -6,8 +6,9 @@ use std::os::windows::ffi::{OsStrExt, OsStringExt};
 use std::os::windows::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
-use winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS;
-use winapi::um::winnt;
+use windows_sys::Win32::Storage::FileSystem::{
+    FILE_FLAG_BACKUP_SEMANTICS, FILE_SHARE_READ, FILE_SHARE_WRITE,
+};
 
 /// Rust's `Path` implicitly strips redundant slashes, however they aren't
 /// redundant in one case: at the end of a path they indicate that a path is
@@ -66,7 +67,7 @@ pub(crate) fn dir_options() -> OpenOptions {
         .read(true)
         .dir_required(true)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
-        .share_mode(winnt::FILE_SHARE_READ | winnt::FILE_SHARE_WRITE)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
         .clone()
 }
 
@@ -98,7 +99,7 @@ pub(crate) fn open_ambient_dir_impl(path: &Path, _: AmbientAuthority) -> io::Res
     let dir = fs::OpenOptions::new()
         .read(true)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
-        .share_mode(winnt::FILE_SHARE_READ | winnt::FILE_SHARE_WRITE)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
         .open(&path)?;
 
     // Require a directory. It may seem possible to eliminate this `metadata()`

--- a/cap-primitives/src/windows/fs/errors.rs
+++ b/cap-primitives/src/windows/fs/errors.rs
@@ -1,22 +1,22 @@
 use std::io;
-use winapi::shared::winerror;
+use windows_sys::Win32::Foundation;
 
 #[cold]
 pub(crate) fn no_such_file_or_directory() -> io::Error {
-    io::Error::from_raw_os_error(winerror::ERROR_FILE_NOT_FOUND as i32)
+    io::Error::from_raw_os_error(Foundation::ERROR_FILE_NOT_FOUND as i32)
 }
 
 #[cold]
 pub(crate) fn is_directory() -> io::Error {
-    io::Error::from_raw_os_error(winerror::ERROR_DIRECTORY_NOT_SUPPORTED as i32)
+    io::Error::from_raw_os_error(Foundation::ERROR_DIRECTORY_NOT_SUPPORTED as i32)
 }
 
 #[cold]
 pub(crate) fn is_not_directory() -> io::Error {
-    io::Error::from_raw_os_error(winerror::ERROR_DIRECTORY as i32)
+    io::Error::from_raw_os_error(Foundation::ERROR_DIRECTORY as i32)
 }
 
 #[cold]
 pub(crate) fn too_many_symlinks() -> io::Error {
-    io::Error::from_raw_os_error(winerror::ERROR_TOO_MANY_LINKS as i32)
+    io::Error::from_raw_os_error(Foundation::ERROR_TOO_MANY_LINKS as i32)
 }

--- a/cap-primitives/src/windows/fs/oflags.rs
+++ b/cap-primitives/src/windows/fs/oflags.rs
@@ -1,7 +1,9 @@
 use crate::fs::{FollowSymlinks, OpenOptions};
 use std::fs;
 use std::os::windows::fs::OpenOptionsExt;
-use winapi::um::winbase::{FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT};
+use windows_sys::Win32::Storage::FileSystem::{
+    FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+};
 
 /// Translate the given `cap_std` into `std` options. Also return a bool
 /// indicating that the `trunc` flag was requested but could not be set,

--- a/cap-primitives/src/windows/fs/open_impl.rs
+++ b/cap-primitives/src/windows/fs/open_impl.rs
@@ -1,7 +1,7 @@
 use crate::fs::{manually, OpenOptions};
 use std::path::Path;
 use std::{fs, io};
-use winapi::shared::winerror::ERROR_FILE_NOT_FOUND;
+use windows_sys::Win32::Foundation::ERROR_FILE_NOT_FOUND;
 
 pub(crate) fn open_impl(
     start: &fs::File,

--- a/cap-primitives/src/windows/fs/open_options_ext.rs
+++ b/cap-primitives/src/windows/fs/open_options_ext.rs
@@ -1,4 +1,6 @@
-use winapi::um::{winbase, winnt};
+use windows_sys::Win32::Storage::FileSystem::{
+    FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, SECURITY_SQOS_PRESENT,
+};
 
 #[derive(Debug, Clone)]
 pub(crate) struct OpenOptionsExt {
@@ -13,7 +15,7 @@ impl OpenOptionsExt {
     pub(crate) const fn new() -> Self {
         Self {
             access_mode: None,
-            share_mode: winnt::FILE_SHARE_READ | winnt::FILE_SHARE_WRITE | winnt::FILE_SHARE_DELETE,
+            share_mode: FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
             custom_flags: 0,
             attributes: 0,
             security_qos_flags: 0,
@@ -41,7 +43,7 @@ impl OpenOptionsExt {
     }
 
     pub(crate) fn security_qos_flags(&mut self, flags: u32) -> &mut Self {
-        self.security_qos_flags = flags | winbase::SECURITY_SQOS_PRESENT;
+        self.security_qos_flags = flags | SECURITY_SQOS_PRESENT;
         self
     }
 }

--- a/cap-primitives/src/windows/fs/read_link_impl.rs
+++ b/cap-primitives/src/windows/fs/read_link_impl.rs
@@ -2,7 +2,9 @@ use crate::fs::{open, FollowSymlinks, OpenOptions};
 use std::os::windows::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
-use winapi::um::winbase::{FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT};
+use windows_sys::Win32::Storage::FileSystem::{
+    FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+};
 
 /// *Unsandboxed* function similar to `read_link`, but which does not perform
 /// sandboxing.

--- a/cap-primitives/src/windows/fs/reopen_impl.rs
+++ b/cap-primitives/src/windows/fs/reopen_impl.rs
@@ -1,16 +1,13 @@
 use crate::fs::OpenOptions;
 use io_lifetimes::AsHandle;
 use std::{fs, io};
-use winapi::shared::minwindef::DWORD;
-use winapi::shared::winerror::ERROR_INVALID_PARAMETER;
-use winapi::um::winbase::{
+use windows_sys::Win32::Foundation::ERROR_INVALID_PARAMETER;
+use windows_sys::Win32::Storage::FileSystem::{
     FILE_FLAG_DELETE_ON_CLOSE, FILE_FLAG_OPEN_REPARSE_POINT, FILE_FLAG_WRITE_THROUGH,
-    SECURITY_CONTEXT_TRACKING, SECURITY_DELEGATION, SECURITY_EFFECTIVE_ONLY,
-    SECURITY_IDENTIFICATION, SECURITY_IMPERSONATION,
+    FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_WRITE_DATA, SECURITY_CONTEXT_TRACKING,
+    SECURITY_DELEGATION, SECURITY_EFFECTIVE_ONLY, SECURITY_IDENTIFICATION, SECURITY_IMPERSONATION,
 };
-use winapi::um::winnt::{
-    FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_WRITE_DATA, GENERIC_READ, GENERIC_WRITE,
-};
+use windows_sys::Win32::System::SystemServices::{GENERIC_READ, GENERIC_WRITE};
 use winx::file::{AccessMode, Flags};
 
 /// Implementation of `reopen`.
@@ -86,7 +83,7 @@ pub(crate) fn reopen_impl(file: &fs::File, options: &OpenOptions) -> io::Result<
     winx::file::reopen_file(file.as_handle(), new_access_mode, flags)
 }
 
-fn get_access_mode(options: &OpenOptions) -> io::Result<DWORD> {
+fn get_access_mode(options: &OpenOptions) -> io::Result<u32> {
     match (
         options.read,
         options.write,
@@ -105,7 +102,7 @@ fn get_access_mode(options: &OpenOptions) -> io::Result<DWORD> {
     }
 }
 
-fn get_flags_and_attributes(options: &OpenOptions) -> DWORD {
+fn get_flags_and_attributes(options: &OpenOptions) -> u32 {
     options.ext.custom_flags
         | options.ext.attributes
         | options.ext.security_qos_flags

--- a/cap-primitives/src/windows/fs/set_times_impl.rs
+++ b/cap-primitives/src/windows/fs/set_times_impl.rs
@@ -3,7 +3,9 @@ use fs_set_times::SetTimes;
 use std::os::windows::fs::OpenOptionsExt;
 use std::path::Path;
 use std::{fs, io};
-use winapi::um::winbase::{FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT};
+use windows_sys::Win32::Storage::FileSystem::{
+    FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+};
 
 #[inline]
 pub(crate) fn set_times_impl(

--- a/cap-primitives/src/windows/fs/stat_unchecked.rs
+++ b/cap-primitives/src/windows/fs/stat_unchecked.rs
@@ -4,7 +4,9 @@ use crate::fs::{FollowSymlinks, Metadata};
 use std::path::Path;
 use std::{fs, io};
 #[cfg(not(windows_by_handle))]
-use winapi::um::winbase::{FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT};
+use windows_sys::Win32::Storage::FileSystem::{
+    FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+};
 #[cfg(not(windows_by_handle))]
 use {
     crate::fs::{open_unchecked, OpenOptions},

--- a/cap-tempfile/Cargo.toml
+++ b/cap-tempfile/Cargo.toml
@@ -20,11 +20,14 @@ camino = { version = "1.0.5", optional = true }
 [target.'cfg(target_os = "emscripten")'.dependencies]
 rand = "0.8.1"
 
-[target.'cfg(windows)'.dev-dependencies]
-winapi = "0.3.9"
-
 [target.'cfg(not(windows))'.dependencies]
 rustix = { version = "0.35.6", features = ["procfs"] }
+
+[target.'cfg(windows)'.dev-dependencies.windows-sys]
+version = "0.36.0"
+features = [
+    "Win32_Foundation",
+]
 
 [features]
 default = []

--- a/cap-tempfile/src/lib.rs
+++ b/cap-tempfile/src/lib.rs
@@ -245,8 +245,8 @@ fn close_outer() {
     #[cfg(windows)]
     assert!(matches!(
         t.close().unwrap_err().raw_os_error().map(|err| err as _),
-        Some(winapi::shared::winerror::ERROR_SHARING_VIOLATION)
-            | Some(winapi::shared::winerror::ERROR_DIR_NOT_EMPTY)
+        Some(windows_sys::Win32::Foundation::ERROR_SHARING_VIOLATION)
+            | Some(windows_sys::Win32::Foundation::ERROR_DIR_NOT_EMPTY)
     ));
     #[cfg(not(windows))]
     t.close().unwrap();

--- a/cap-tempfile/src/utf8.rs
+++ b/cap-tempfile/src/utf8.rs
@@ -216,8 +216,8 @@ fn close_outer() {
     #[cfg(windows)]
     assert!(matches!(
         t.close().unwrap_err().raw_os_error().map(|err| err as _),
-        Some(winapi::shared::winerror::ERROR_SHARING_VIOLATION)
-            | Some(winapi::shared::winerror::ERROR_DIR_NOT_EMPTY)
+        Some(windows_sys::Win32::Foundation::ERROR_SHARING_VIOLATION)
+            | Some(windows_sys::Win32::Foundation::ERROR_DIR_NOT_EMPTY)
     ));
     #[cfg(not(windows))]
     t.close().unwrap();

--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -20,7 +20,7 @@ fn no_such_file_or_directory() -> String {
 }
 #[cfg(windows)]
 fn no_such_file_or_directory() -> String {
-    std::io::Error::from_raw_os_error(winapi::shared::winerror::ERROR_FILE_NOT_FOUND as i32)
+    std::io::Error::from_raw_os_error(windows_sys::Win32::Foundation::ERROR_FILE_NOT_FOUND as i32)
         .to_string()
 }
 

--- a/tests/reopen.rs
+++ b/tests/reopen.rs
@@ -7,7 +7,7 @@ use cap_fs_ext::{OpenOptions, Reopen};
 use std::io::{Read, Write};
 use sys_common::io::tmpdir;
 #[cfg(windows)]
-use winapi::um::winnt::FILE_GENERIC_READ;
+use windows_sys::Win32::Storage::FileSystem::FILE_GENERIC_READ;
 
 #[test]
 fn basic_reopen() {

--- a/tests/sys_common/symlink_junction.rs
+++ b/tests/sys_common/symlink_junction.rs
@@ -9,6 +9,8 @@
 //
 // [windows-sys bug filed]: https://github.com/microsoft/windows-rs/issues/1823>
 // [winapi doc]: https://docs.rs/winapi/latest/winapi/um/winnt/constant.MAXIMUM_REPARSE_DATA_BUFFER_SIZE.html
+#[cfg(windows)]
+#[allow(dead_code)]
 pub const MAXIMUM_REPARSE_DATA_BUFFER_SIZE: u32 = 16 * 1024; // 16_384u32
 
 #[cfg(feature = "fs_utf8")]

--- a/tests/sys_common/symlink_junction.rs
+++ b/tests/sys_common/symlink_junction.rs
@@ -2,6 +2,15 @@
 // library/std/src/sys/windows/fs.rs at revision
 // 108e90ca78f052c0c1c49c42a22c85620be19712.
 
+// TODO: Replace this definition of `MAXIMUM_REPARSE_DATA_BUFFER_SIZE`
+// once windows-sys has it.
+//  - [windows-sys bug filed]
+//  - [winapi doc]
+//
+// [windows-sys bug filed]: https://github.com/microsoft/windows-rs/issues/1823>
+// [winapi doc]: https://docs.rs/winapi/latest/winapi/um/winnt/constant.MAXIMUM_REPARSE_DATA_BUFFER_SIZE.html
+pub const MAXIMUM_REPARSE_DATA_BUFFER_SIZE: u32 = 16 * 1024; // 16_384u32
+
 #[cfg(feature = "fs_utf8")]
 use camino::Utf8Path;
 use cap_std::fs::Dir;
@@ -55,18 +64,20 @@ pub fn symlink_junction_utf8<P: AsRef<Utf8Path>, Q: AsRef<Utf8Path>>(
 #[allow(non_snake_case)]
 #[repr(C)]
 pub struct REPARSE_MOUNTPOINT_DATA_BUFFER {
-    pub ReparseTag: winapi::shared::minwindef::DWORD,
-    pub ReparseDataLength: winapi::shared::minwindef::DWORD,
-    pub Reserved: winapi::shared::minwindef::WORD,
-    pub ReparseTargetLength: winapi::shared::minwindef::WORD,
-    pub ReparseTargetMaximumLength: winapi::shared::minwindef::WORD,
-    pub Reserved1: winapi::shared::minwindef::WORD,
-    pub ReparseTarget: winapi::um::winnt::WCHAR,
+    pub ReparseTag: u32,
+    pub ReparseDataLength: u32,
+    pub Reserved: u16,
+    pub ReparseTargetLength: u16,
+    pub ReparseTargetMaximumLength: u16,
+    pub Reserved1: u16,
+    pub ReparseTarget: libc::wchar_t,
 }
 
 #[cfg(windows)]
 #[allow(dead_code)]
-pub fn cvt(i: winapi::shared::minwindef::BOOL) -> io::Result<winapi::shared::minwindef::BOOL> {
+pub fn cvt(
+    i: windows_sys::Win32::Foundation::BOOL,
+) -> io::Result<windows_sys::Win32::Foundation::BOOL> {
     if i == 0 {
         Err(io::Error::last_os_error())
     } else {
@@ -93,16 +104,16 @@ fn symlink_junction_inner(target: &Path, dir: &Dir, junction: &Path) -> io::Resu
     let mut opts = OpenOptions::new();
     opts.write(true);
     opts.custom_flags(
-        winapi::um::winbase::FILE_FLAG_OPEN_REPARSE_POINT
-            | winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS,
+        windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT
+            | windows_sys::Win32::Storage::FileSystem::FILE_FLAG_BACKUP_SEMANTICS,
     );
     let f = dir.open_with(junction, &opts)?;
     let h = f.as_raw_handle();
 
     unsafe {
-        let mut data = [0_u8; winapi::um::winnt::MAXIMUM_REPARSE_DATA_BUFFER_SIZE as usize];
+        let mut data = [0_u8; MAXIMUM_REPARSE_DATA_BUFFER_SIZE as usize];
         let db = data.as_mut_ptr() as *mut REPARSE_MOUNTPOINT_DATA_BUFFER;
-        let buf = &mut (*db).ReparseTarget as *mut winapi::um::winnt::WCHAR;
+        let buf = &mut (*db).ReparseTarget as *mut libc::wchar_t;
         let mut i = 0;
         // FIXME: this conversion is very hacky
         let v = br"\??\";
@@ -113,16 +124,15 @@ fn symlink_junction_inner(target: &Path, dir: &Dir, junction: &Path) -> io::Resu
         }
         *buf.offset(i) = 0;
         i += 1;
-        (*db).ReparseTag = winapi::um::winnt::IO_REPARSE_TAG_MOUNT_POINT;
-        (*db).ReparseTargetMaximumLength = (i * 2) as winapi::shared::minwindef::WORD;
-        (*db).ReparseTargetLength = ((i - 1) * 2) as winapi::shared::minwindef::WORD;
-        (*db).ReparseDataLength =
-            (*db).ReparseTargetLength as winapi::shared::minwindef::DWORD + 12;
+        (*db).ReparseTag = windows_sys::Win32::System::SystemServices::IO_REPARSE_TAG_MOUNT_POINT;
+        (*db).ReparseTargetMaximumLength = (i * 2) as u16;
+        (*db).ReparseTargetLength = ((i - 1) * 2) as u16;
+        (*db).ReparseDataLength = (*db).ReparseTargetLength as u32 + 12;
 
         let mut ret = 0;
-        cvt(winapi::um::ioapiset::DeviceIoControl(
-            h as *mut _,
-            winapi::um::winioctl::FSCTL_SET_REPARSE_POINT,
+        cvt(windows_sys::Win32::System::IO::DeviceIoControl(
+            h as _,
+            windows_sys::Win32::System::Ioctl::FSCTL_SET_REPARSE_POINT,
             data.as_ptr() as *mut _,
             (*db).ReparseDataLength + 8,
             ptr::null_mut(),
@@ -154,16 +164,16 @@ fn symlink_junction_inner_utf8(
     let mut opts = OpenOptions::new();
     opts.write(true);
     opts.custom_flags(
-        winapi::um::winbase::FILE_FLAG_OPEN_REPARSE_POINT
-            | winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS,
+        windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT
+            | windows_sys::Win32::Storage::FileSystem::FILE_FLAG_BACKUP_SEMANTICS,
     );
     let f = dir.open_with(junction, &opts)?;
     let h = f.as_raw_handle();
 
     unsafe {
-        let mut data = [0_u8; winapi::um::winnt::MAXIMUM_REPARSE_DATA_BUFFER_SIZE as usize];
+        let mut data = [0_u8; MAXIMUM_REPARSE_DATA_BUFFER_SIZE as usize];
         let db = data.as_mut_ptr() as *mut REPARSE_MOUNTPOINT_DATA_BUFFER;
-        let buf = &mut (*db).ReparseTarget as *mut winapi::um::winnt::WCHAR;
+        let buf = &mut (*db).ReparseTarget as *mut libc::wchar_t;
         let mut i = 0;
         // FIXME: this conversion is very hacky
         let v = br"\??\";
@@ -174,16 +184,15 @@ fn symlink_junction_inner_utf8(
         }
         *buf.offset(i) = 0;
         i += 1;
-        (*db).ReparseTag = winapi::um::winnt::IO_REPARSE_TAG_MOUNT_POINT;
-        (*db).ReparseTargetMaximumLength = (i * 2) as winapi::shared::minwindef::WORD;
-        (*db).ReparseTargetLength = ((i - 1) * 2) as winapi::shared::minwindef::WORD;
-        (*db).ReparseDataLength =
-            (*db).ReparseTargetLength as winapi::shared::minwindef::DWORD + 12;
+        (*db).ReparseTag = windows_sys::Win32::System::SystemServices::IO_REPARSE_TAG_MOUNT_POINT;
+        (*db).ReparseTargetMaximumLength = (i * 2) as u16;
+        (*db).ReparseTargetLength = ((i - 1) * 2) as u16;
+        (*db).ReparseDataLength = (*db).ReparseTargetLength as u32 + 12;
 
         let mut ret = 0;
-        cvt(winapi::um::ioapiset::DeviceIoControl(
-            h as *mut _,
-            winapi::um::winioctl::FSCTL_SET_REPARSE_POINT,
+        cvt(windows_sys::Win32::System::IO::DeviceIoControl(
+            h as _,
+            windows_sys::Win32::System::Ioctl::FSCTL_SET_REPARSE_POINT,
             data.as_ptr() as *mut _,
             (*db).ReparseDataLength + 8,
             ptr::null_mut(),


### PR DESCRIPTION
windows-sys has bindings for `PathCchCanonicalizeEx`, `PathCchCombineEx`,
and `PathCchAppendEx`, which we may be able to use in #156.