### PR TITLE
Remove `File::with_options`.

### DIFF
--- a/cap-async-std/src/fs/file.rs
+++ b/cap-async-std/src/fs/file.rs
@@ -55,8 +55,6 @@ impl File {
         self.std
     }
 
-    // async_std doesn't have `with_options`.
-
     /// Attempts to sync all OS-internal metadata to disk.
     ///
     /// This corresponds to [`async_std::fs::File::sync_all`].

--- a/cap-async-std/src/fs_utf8/file.rs
+++ b/cap-async-std/src/fs_utf8/file.rs
@@ -59,8 +59,6 @@ impl File {
         self.cap_std.into_std()
     }
 
-    // async_std doesn't have `with_options`.
-
     /// Attempts to sync all OS-internal metadata to disk.
     ///
     /// This corresponds to [`async_std::fs::File::sync_all`].

--- a/cap-std/src/fs/file.rs
+++ b/cap-std/src/fs/file.rs
@@ -47,15 +47,6 @@ impl File {
         self.std
     }
 
-    /// Returns a new [`OpenOptions`] object.
-    ///
-    /// This corresponds to [`std::fs::File::with_options`].
-    #[inline]
-    #[cfg(with_options)]
-    pub fn with_options() -> OpenOptions {
-        OpenOptions::new()
-    }
-
     /// Attempts to sync all OS-internal metadata to disk.
     ///
     /// This corresponds to [`std::fs::File::sync_all`].

--- a/cap-std/src/fs_utf8/file.rs
+++ b/cap-std/src/fs_utf8/file.rs
@@ -55,15 +55,6 @@ impl File {
         self.cap_std.into_std()
     }
 
-    /// Returns a new `OpenOptions` object.
-    ///
-    /// This corresponds to [`std::fs::File::with_options`].
-    #[inline]
-    #[cfg(with_options)]
-    pub fn with_options() -> OpenOptions {
-        crate::fs::File::with_options()
-    }
-
     /// Attempts to sync all OS-internal metadata to disk.
     ///
     /// This corresponds to [`std::fs::File::sync_all`].


### PR DESCRIPTION
`File::with_options` was renamed to `File::options`. cap-std already has
the new name, so this just removes the old name.