### PR TITLE
Use `rustix::fs::statx` on Android.

### DIFF
--- a/cap-primitives/src/rustix/fs/metadata_ext.rs
+++ b/cap-primitives/src/rustix/fs/metadata_ext.rs
@@ -2,10 +2,7 @@
 
 use crate::fs::{FileTypeExt, Metadata, PermissionsExt};
 use crate::time::{Duration, SystemClock, SystemTime};
-// TODO: update all these to
-// #[cfg(any(target_os = "android", target_os = "linux"))]
-// once we're on restix >= v0.34.3.
-#[cfg(all(target_os = "linux", target_env = "gnu"))]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 use rustix::fs::{makedev, Statx};
 use rustix::fs::{RawMode, Stat};
 use std::convert::{TryFrom, TryInto};
@@ -222,7 +219,7 @@ impl MetadataExt {
     }
 
     /// Constructs a new instance of `Metadata` from the given `Statx`.
-    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    #[cfg(any(target_os = "android", target_os = "linux"))]
     #[inline]
     pub(crate) fn from_rustix_statx(statx: Statx) -> Metadata {
         Metadata {

--- a/cap-primitives/src/rustix/fs/stat_unchecked.rs
+++ b/cap-primitives/src/rustix/fs/stat_unchecked.rs
@@ -3,12 +3,9 @@ use rustix::fs::{statat, AtFlags};
 use std::path::Path;
 use std::{fs, io};
 
-// TODO: update all these to
-// #[cfg(any(target_os = "android", target_os = "linux"))]
-// once we're on restix >= v0.34.3.
-#[cfg(all(target_os = "linux", target_env = "gnu"))]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 use rustix::fs::{statx, StatxFlags};
-#[cfg(all(target_os = "linux", target_env = "gnu"))]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 use std::sync::atomic::{AtomicU8, Ordering};
 
 /// *Unsandboxed* function similar to `stat`, but which does not perform
@@ -28,7 +25,7 @@ pub(crate) fn stat_unchecked(
     // Older versions of Docker/seccomp would return `EPERM` for `statx`; see
     // <https://github.com/rust-lang/rust/pull/65685/>. We store the
     // availability in a global to avoid unnecessary syscalls.
-    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    #[cfg(any(target_os = "android", target_os = "linux"))]
     {
         // 0: Unknown
         // 1: Not available


### PR DESCRIPTION
Now that cap-std is using rustix 0.35.6, it can use `rustix::fs::statx`
on Android.