### PR TITLE
tempfile: Re-export `cap-std`

### DIFF
--- a/cap-tempfile/src/lib.rs
+++ b/cap-tempfile/src/lib.rs
@@ -21,6 +21,9 @@ pub mod utf8;
 mod tempfile;
 pub use tempfile::*;
 
+/// Re-export because we use this in our public API.
+pub use cap_std;
+
 #[doc(hidden)]
 pub use cap_std::ambient_authority_known_at_compile_time;
 pub use cap_std::{ambient_authority, AmbientAuthority};


### PR DESCRIPTION
In many of the projects I work on we use Github dependabot, configured
to open a separate PR for each bump.  But right now dependabot
does not understand the cargo/rust level dependencies involved in e.g.
https://github.com/coreos/cap-std-ext/blob/main/Cargo.toml#L12-L14

I think it's general best practice to re-export dependencies used
in public API, so that consumers can keep their direct set
smaller, and this way dependabot updates in this form will just work
because we can just depend on `cap-tempfile`.