### PR TITLE
cap-std: Re-export io-lifetimes

### DIFF
--- a/cap-std/src/lib.rs
+++ b/cap-std/src/lib.rs
@@ -48,3 +48,5 @@ pub mod time;
 #[doc(hidden)]
 pub use cap_primitives::ambient_authority_known_at_compile_time;
 pub use cap_primitives::{ambient_authority, AmbientAuthority};
+// And this is also part of our public API
+pub use io_lifetimes;


### PR DESCRIPTION
For similar reasons as we re-export cap-primitives bits.

(Also, the fact that the io-lifetimes semver is different from
 cap-std makes having this even more convenient for users instead
 of juggling two separate dependencies in `Cargo.toml`)