### PR TITLE
Re-export io_lifetimes in cap-async-std too.

### DIFF
--- a/cap-async-std/src/lib.rs
+++ b/cap-async-std/src/lib.rs
@@ -50,3 +50,5 @@ pub use cap_primitives::{ambient_authority, AmbientAuthority};
 // Re-export `async_std` to make it easy for users to depend on the same
 // version we do, because we use its types in our public API.
 pub use async_std;
+// And this is also part of our public API
+pub use io_lifetimes;


### PR DESCRIPTION
I just realized we should make the change from #266 in cap-async-std too,
for the same reason.