### PR TITLE
Fix statx created times when unavailable

### DIFF
--- a/cap-primitives/src/rustix/fs/metadata_ext.rs
+++ b/cap-primitives/src/rustix/fs/metadata_ext.rs
@@ -226,8 +226,16 @@ impl MetadataExt {
             file_type: FileTypeExt::from_raw_mode(RawMode::from(statx.stx_mode)),
             len: u64::try_from(statx.stx_size).unwrap(),
             permissions: PermissionsExt::from_raw_mode(RawMode::from(statx.stx_mode)),
-            modified: system_time_from_rustix(statx.stx_mtime.tv_sec, statx.stx_mtime.tv_nsec as _),
-            accessed: system_time_from_rustix(statx.stx_atime.tv_sec, statx.stx_atime.tv_nsec as _),
+            modified: if statx.stx_mask & StatxFlags::MTIME.bits() != 0 {
+                system_time_from_rustix(statx.stx_mtime.tv_sec, statx.stx_mtime.tv_nsec as _)
+            } else {
+                None
+            },
+            accessed: if statx.stx_mask & StatxFlags::ATIME.bits() != 0 {
+                system_time_from_rustix(statx.stx_atime.tv_sec, statx.stx_atime.tv_nsec as _)
+            } else {
+                None
+            },
             created: if statx.stx_mask & StatxFlags::BTIME.bits() != 0 {
                 system_time_from_rustix(statx.stx_btime.tv_sec, statx.stx_btime.tv_nsec as _)
             } else {

--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -936,24 +936,44 @@ fn check_metadata(std: &std::fs::Metadata, cap: &cap_std::fs::Metadata) {
 
     // If the standard library supports file modified/accessed/created times,
     // then cap-std should too.
-    if let Ok(expected) = std.modified() {
-        assert_eq!(expected, check!(cap.modified()).into_std());
+    match std.modified() {
+        Ok(expected) => assert_eq!(expected, check!(cap.modified()).into_std()),
+        Err(e) => assert!(
+            cap.modified().is_err(),
+            "modified time should be error ({}), got {:#?}",
+            e,
+            cap.modified()
+        ),
     }
     // The access times might be a little different due to either our own
     // or concurrent accesses.
     const ACCESS_TOLERANCE_SEC: u32 = 60;
-    if let Ok(expected) = std.accessed() {
-        let access_tolerance = std::time::Duration::from_secs(ACCESS_TOLERANCE_SEC.into());
-        assert!(
-            ((expected - access_tolerance)..(expected + access_tolerance))
-                .contains(&check!(cap.accessed()).into_std()),
-            "std accessed {:#?}, cap accessed {:#?}",
-            expected,
+    match std.accessed() {
+        Ok(expected) => {
+            let access_tolerance = std::time::Duration::from_secs(ACCESS_TOLERANCE_SEC.into());
+            assert!(
+                ((expected - access_tolerance)..(expected + access_tolerance))
+                    .contains(&check!(cap.accessed()).into_std()),
+                "std accessed {:#?}, cap accessed {:#?}",
+                expected,
+                cap.accessed()
+            );
+        }
+        Err(e) => assert!(
+            cap.accessed().is_err(),
+            "accessed time should be error ({}), got {:#?}",
+            e,
             cap.accessed()
-        );
+        ),
     }
-    if let Ok(expected) = std.created() {
-        assert_eq!(expected, check!(cap.created()).into_std());
+    match std.created() {
+        Ok(expected) => assert_eq!(expected, check!(cap.created()).into_std()),
+        Err(e) => assert!(
+            cap.created().is_err(),
+            "created time should be error ({}), got {:#?}",
+            e,
+            cap.created()
+        ),
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
This previously returned `Some(UNIX_EPOCH)` instead of `None` when `statx` did not return a created time.


This is easily tested on Linux against a `tmpfs`. For example, if `/dev/shm` is a `tmpfs`, then `stat /dev/shm` will show "Birth time" as "-" and `TMPDIR=/dev/shm cargo test` will fail the unit tests (without the corresponding fix).