### PR TITLE
Remove the dependency on `errno` from cap-primitives.

### DIFF
--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -27,12 +27,6 @@ cap-tempfile = { path = "../cap-tempfile" }
 [target.'cfg(not(windows))'.dependencies]
 rustix = { version = "0.35.6", features = ["fs", "process", "procfs", "termios", "time"] }
 
-[target.'cfg(target_os = "macos")'.dependencies]
-errno = { version = "0.2.8", default-features = false }
-
-[target.'cfg(target_os = "ios")'.dependencies]
-errno = { version = "0.2.8", default-features = false }
-
 [target.'cfg(windows)'.dependencies]
 winx = "0.33.0"
 winapi-util = "0.1.5"


### PR DESCRIPTION
cap-primitives no longer calls `set_errno`, so it no longer needs its
`errno` dependency in Cargo.toml.