### PR TITLE
Update to io-lifetimes 1.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ rand = "0.8.1"
 tempfile = "3.1.0"
 camino = "1.0.5"
 libc = "0.2.100"
-io-lifetimes = "0.7.0"
+io-lifetimes = "1.0.0-rc1"
 
 [target.'cfg(not(windows))'.dev-dependencies]
-rustix = { version = "0.35.6", features = ["fs"] }
+rustix = { version = "0.36.0-rc1", features = ["fs"] }
 
 [target.'cfg(windows)'.dev-dependencies]
 # nt_version uses internal Windows APIs, however we're only using it

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ publish = false
 exclude = ["/.*"]
 
 [dev-dependencies]
-async-std = { version = "1.10.0", features = ["attributes"] }
+#async-std = { version = "1.10.0", features = ["attributes"] }
 anyhow = "1.0.37"
-cap-async-std = { path = "cap-async-std", version = "^0.25.0" }
+#cap-async-std = { path = "cap-async-std", version = "^0.25.0" }
 cap-fs-ext = { path = "cap-fs-ext", version = "^0.25.0" }
 cap-directories = { path = "cap-directories", version = "^0.25.0" }
 cap-std = { path = "cap-std", version = "^0.25.0" }
@@ -51,23 +51,23 @@ fs_utf8 = [
     "cap-fs-ext/fs_utf8",
     "cap-tempfile/fs_utf8",
 ]
-async_std_fs_utf8 = [
-    "cap-async-std/fs_utf8",
-    "cap-fs-ext/async_std_fs_utf8"
-]
+#async_std_fs_utf8 = [
+#    "cap-async-std/fs_utf8",
+#    "cap-fs-ext/async_std_fs_utf8"
+#]
 arf_strings = [
     "cap-std/arf_strings",
     "cap-fs-ext/arf_strings",
     "cap-tempfile/arf_strings",
 ]
-async_std_arf_strings = [
-    "cap-async-std/arf_strings",
-    "cap-fs-ext/async_std_arf_strings"
-]
+#async_std_arf_strings = [
+#    "cap-async-std/arf_strings",
+#    "cap-fs-ext/async_std_arf_strings"
+#]
 
 [workspace]
 members = [
-  "cap-async-std",
+  #"cap-async-std",
   "cap-fs-ext",
   "cap-directories",
   "cap-primitives",

--- a/cap-async-std/Cargo.toml
+++ b/cap-async-std/Cargo.toml
@@ -18,13 +18,13 @@ arf-strings = { version = "0.6.7", optional = true }
 # Enable "unstable" for `spawn_blocking`.
 async-std = { version = "1.10.0", features = ["attributes", "unstable"] }
 cap-primitives = { path = "../cap-primitives", version = "^0.25.0" }
-io-lifetimes = { version = "0.7.0", default-features = false, features = ["async-std"] }
+io-lifetimes = { version = "1.0.0-rc1", default-features = false, features = ["async-std"] }
 ipnet = "2.3.0"
-io-extras = { version = "0.15.0", features = ["use_async_std"] }
+io-extras = { version = "0.16.0-rc1", features = ["use_async_std"] }
 camino = { version = "1.0.5", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.35.6", features = ["fs"] }
+rustix = { version = "0.36.0-rc1", features = ["fs"] }
 
 [features]
 default = []

--- a/cap-async-std/Cargo.toml
+++ b/cap-async-std/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["network", "file", "async", "future", "await"]
 categories = ["filesystem", "network-programming", "asynchronous", "concurrency"]
 repository = "https://github.com/bytecodealliance/cap-std"
 edition = "2018"
+publish = false # temporary, until async-rs/async-std#1036 is available
 
 [dependencies]
 arf-strings = { version = "0.6.7", optional = true }

--- a/cap-async-std/src/fs/dir.rs
+++ b/cap-async-std/src/fs/dir.rs
@@ -14,10 +14,10 @@ use cap_primitives::fs::{
 };
 use cap_primitives::AmbientAuthority;
 #[cfg(not(windows))]
-use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 use io_lifetimes::{AsFilelike, FromFilelike};
 #[cfg(windows)]
-use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
+use io_lifetimes::{AsHandle, BorrowedHandle, OwnedHandle};
 use std::fmt;
 #[cfg(unix)]
 use {
@@ -869,10 +869,10 @@ impl FromRawFd for Dir {
 }
 
 #[cfg(not(windows))]
-impl FromFd for Dir {
+impl From<OwnedFd> for Dir {
     #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std_file(fs::File::from_fd(fd))
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_std_file(fs::File::from(fd))
     }
 }
 
@@ -887,10 +887,10 @@ impl FromRawHandle for Dir {
 }
 
 #[cfg(windows)]
-impl FromHandle for Dir {
+impl From<OwnedHandle> for Dir {
     #[inline]
-    fn from_handle(handle: OwnedHandle) -> Self {
-        Self::from_std_file(fs::File::from_handle(handle))
+    fn from(handle: OwnedHandle) -> Self {
+        Self::from_std_file(fs::File::from(handle))
     }
 }
 
@@ -943,10 +943,10 @@ impl IntoRawFd for Dir {
 }
 
 #[cfg(not(windows))]
-impl IntoFd for Dir {
+impl From<Dir> for OwnedFd {
     #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.std_file.into_fd()
+    fn from(dir: Dir) -> OwnedFd {
+        dir.std_file.into()
     }
 }
 
@@ -959,10 +959,10 @@ impl IntoRawHandle for Dir {
 }
 
 #[cfg(windows)]
-impl IntoHandle for Dir {
+impl From<Dir> for OwnedHandle {
     #[inline]
-    fn into_handle(self) -> OwnedHandle {
-        self.std_file.into_handle()
+    fn from(dir: Dir) -> OwnedHandle {
+        dir.std_file.into()
     }
 }
 

--- a/cap-async-std/src/fs/file.rs
+++ b/cap-async-std/src/fs/file.rs
@@ -10,9 +10,9 @@ use cap_primitives::fs::{is_file_read_write, open_ambient};
 use cap_primitives::AmbientAuthority;
 use io_lifetimes::AsFilelike;
 #[cfg(not(windows))]
-use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(windows)]
-use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
+use io_lifetimes::{AsHandle, BorrowedHandle, OwnedHandle};
 use std::fmt;
 use std::path::Path;
 use std::pin::Pin;
@@ -197,10 +197,10 @@ impl FromRawFd for File {
 }
 
 #[cfg(not(windows))]
-impl FromFd for File {
+impl From<OwnedFd> for File {
     #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(fs::File::from_fd(fd))
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_std(fs::File::from(fd))
     }
 }
 
@@ -213,10 +213,10 @@ impl FromRawHandle for File {
 }
 
 #[cfg(windows)]
-impl FromHandle for File {
+impl From<OwnedHandle> for File {
     #[inline]
-    fn from_handle(handle: OwnedHandle) -> Self {
-        Self::from_std(fs::File::from_handle(handle))
+    fn from(handle: OwnedHandle) -> Self {
+        Self::from_std(fs::File::from(handle))
     }
 }
 
@@ -269,10 +269,10 @@ impl IntoRawFd for File {
 }
 
 #[cfg(not(windows))]
-impl IntoFd for File {
+impl From<File> for OwnedFd {
     #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.std.into_fd()
+    fn from(file: File) -> OwnedFd {
+        file.std.into()
     }
 }
 
@@ -285,10 +285,10 @@ impl IntoRawHandle for File {
 }
 
 #[cfg(windows)]
-impl IntoHandle for File {
+impl From<File> for OwnedHandle {
     #[inline]
-    fn into_handle(self) -> OwnedHandle {
-        self.std.into_handle()
+    fn from(file: File) -> OwnedHandle {
+        file.std.into()
     }
 }
 

--- a/cap-async-std/src/fs_utf8/dir.rs
+++ b/cap-async-std/src/fs_utf8/dir.rs
@@ -6,7 +6,7 @@ use cap_primitives::AmbientAuthority;
 #[cfg(not(windows))]
 use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 #[cfg(windows)]
-use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
+use io_lifetimes::{AsHandle, BorrowedHandle, OwnedHandle};
 use std::fmt;
 #[cfg(unix)]
 use {
@@ -644,10 +644,10 @@ impl FromRawFd for Dir {
 }
 
 #[cfg(not(windows))]
-impl FromFd for Dir {
+impl From<OwnedFd> for Dir {
     #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std_file(fs::File::from_fd(fd))
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_std_file(fs::File::from(fd))
     }
 }
 
@@ -662,10 +662,10 @@ impl FromRawHandle for Dir {
 }
 
 #[cfg(windows)]
-impl FromHandle for Dir {
+impl From<OwnedHandle> for Dir {
     #[inline]
-    fn from_handle(handle: OwnedHandle) -> Self {
-        Self::from_std_file(fs::File::from_handle(handle))
+    fn from(handle: OwnedHandle) -> Self {
+        Self::from_std_file(fs::File::from(handle))
     }
 }
 
@@ -718,10 +718,10 @@ impl IntoRawFd for Dir {
 }
 
 #[cfg(not(windows))]
-impl IntoFd for Dir {
+impl From<Dir> for OwnedFd {
     #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.cap_std.into_fd()
+    fn from(dir: Dir) -> OwnedFd {
+        dir.cap_std.into()
     }
 }
 
@@ -734,10 +734,10 @@ impl IntoRawHandle for Dir {
 }
 
 #[cfg(windows)]
-impl IntoHandle for Dir {
+impl From<Dir> for OwnedHandle {
     #[inline]
-    fn into_handle(self) -> OwnedHandle {
-        self.cap_std.into_handle()
+    fn from(dir: Dir) -> OwnedHandle {
+        dir.cap_std.into()
     }
 }
 

--- a/cap-async-std/src/fs_utf8/file.rs
+++ b/cap-async-std/src/fs_utf8/file.rs
@@ -12,7 +12,7 @@ use cap_primitives::AmbientAuthority;
 #[cfg(not(windows))]
 use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 #[cfg(windows)]
-use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
+use io_lifetimes::{AsHandle, BorrowedHandle, OwnedHandle};
 use std::fmt;
 use std::pin::Pin;
 #[cfg(windows)]
@@ -160,10 +160,10 @@ impl FromRawFd for File {
 }
 
 #[cfg(not(windows))]
-impl FromFd for File {
+impl From<OwnedFd> for File {
     #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(fs::File::from_fd(fd))
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_std(fs::File::from(fd))
     }
 }
 
@@ -176,10 +176,10 @@ impl FromRawHandle for File {
 }
 
 #[cfg(windows)]
-impl FromHandle for File {
+impl From<OwnedHandle> for File {
     #[inline]
-    fn from_handle(handle: OwnedHandle) -> Self {
-        Self::from_std(fs::File::from_handle(handle))
+    fn from(handle: OwnedHandle) -> Self {
+        Self::from_std(fs::File::from(handle))
     }
 }
 
@@ -232,10 +232,10 @@ impl IntoRawFd for File {
 }
 
 #[cfg(not(windows))]
-impl IntoFd for File {
+impl From<File> for OwnedFd {
     #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.cap_std.into_fd()
+    fn from(file: File) -> OwnedFd {
+        file.cap_std.into()
     }
 }
 
@@ -248,10 +248,10 @@ impl IntoRawHandle for File {
 }
 
 #[cfg(windows)]
-impl IntoHandle for File {
+impl From<File> for OwnedHandle {
     #[inline]
-    fn into_handle(self) -> OwnedHandle {
-        self.cap_std.into_handle()
+    fn from(file: File) -> OwnedHandle {
+        file.cap_std.into()
     }
 }
 

--- a/cap-async-std/src/net/tcp_listener.rs
+++ b/cap-async-std/src/net/tcp_listener.rs
@@ -3,9 +3,9 @@ use crate::net::{Incoming, SocketAddr, TcpStream};
 use async_std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use async_std::{io, net};
 #[cfg(not(windows))]
-use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(windows)]
-use io_lifetimes::{AsSocket, BorrowedSocket, FromSocket, IntoSocket, OwnedSocket};
+use io_lifetimes::{AsSocket, BorrowedSocket, OwnedSocket};
 use std::fmt;
 #[cfg(windows)]
 use {
@@ -87,10 +87,10 @@ impl FromRawFd for TcpListener {
 }
 
 #[cfg(not(windows))]
-impl FromFd for TcpListener {
+impl From<OwnedFd> for TcpListener {
     #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(net::TcpListener::from_fd(fd))
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_std(net::TcpListener::from(fd))
     }
 }
 
@@ -103,10 +103,10 @@ impl FromRawSocket for TcpListener {
 }
 
 #[cfg(windows)]
-impl FromSocket for TcpListener {
+impl From<OwnedSocket> for TcpListener {
     #[inline]
-    fn from_socket(socket: OwnedSocket) -> Self {
-        Self::from_std(net::TcpListener::from_socket(socket))
+    fn from(socket: OwnedSocket) -> Self {
+        Self::from_std(net::TcpListener::from(socket))
     }
 }
 
@@ -159,10 +159,10 @@ impl IntoRawFd for TcpListener {
 }
 
 #[cfg(not(windows))]
-impl IntoFd for TcpListener {
+impl From<TcpListener> for OwnedFd {
     #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.std.into_fd()
+    fn from(listener: TcpListener) -> OwnedFd {
+        listener.std.into()
     }
 }
 
@@ -175,10 +175,10 @@ impl IntoRawSocket for TcpListener {
 }
 
 #[cfg(windows)]
-impl IntoSocket for TcpListener {
+impl From<TcpListener> for OwnedSocket {
     #[inline]
-    fn into_socket(self) -> OwnedSocket {
-        self.std.into_socket()
+    fn from(listener: TcpListener) -> OwnedSocket {
+        listener.std.into()
     }
 }
 

--- a/cap-async-std/src/net/tcp_stream.rs
+++ b/cap-async-std/src/net/tcp_stream.rs
@@ -5,9 +5,9 @@ use async_std::net;
 use async_std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use async_std::task::{Context, Poll};
 #[cfg(not(windows))]
-use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(windows)]
-use io_lifetimes::{AsSocket, BorrowedSocket, FromSocket, IntoSocket, OwnedSocket};
+use io_lifetimes::{AsSocket, BorrowedSocket, OwnedSocket};
 use std::fmt;
 use std::pin::Pin;
 #[cfg(windows)]
@@ -131,10 +131,10 @@ impl FromRawFd for TcpStream {
 }
 
 #[cfg(not(windows))]
-impl FromFd for TcpStream {
+impl From<OwnedFd> for TcpStream {
     #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(net::TcpStream::from_fd(fd))
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_std(net::TcpStream::from(fd))
     }
 }
 
@@ -147,10 +147,10 @@ impl FromRawSocket for TcpStream {
 }
 
 #[cfg(windows)]
-impl FromSocket for TcpStream {
+impl From<OwnedSocket> for TcpStream {
     #[inline]
-    fn from_socket(socket: OwnedSocket) -> Self {
-        Self::from_std(net::TcpStream::from_socket(socket))
+    fn from(socket: OwnedSocket) -> Self {
+        Self::from_std(net::TcpStream::from(socket))
     }
 }
 
@@ -203,10 +203,10 @@ impl IntoRawFd for TcpStream {
 }
 
 #[cfg(not(windows))]
-impl IntoFd for TcpStream {
+impl From<TcpStream> for OwnedFd {
     #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.std.into_fd()
+    fn from(stream: TcpStream) -> OwnedFd {
+        stream.std.into()
     }
 }
 
@@ -219,10 +219,10 @@ impl IntoRawSocket for TcpStream {
 }
 
 #[cfg(windows)]
-impl IntoSocket for TcpStream {
+impl From<TcpStream> for OwnedSocket {
     #[inline]
-    fn into_socket(self) -> OwnedSocket {
-        self.std.into_socket()
+    fn from(stream: TcpStream) -> OwnedSocket {
+        stream.std.into()
     }
 }
 

--- a/cap-async-std/src/net/udp_socket.rs
+++ b/cap-async-std/src/net/udp_socket.rs
@@ -3,9 +3,9 @@ use crate::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use async_std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use async_std::{io, net};
 #[cfg(not(windows))]
-use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(windows)]
-use io_lifetimes::{AsSocket, BorrowedSocket, FromSocket, IntoSocket, OwnedSocket};
+use io_lifetimes::{AsSocket, BorrowedSocket, OwnedSocket};
 use std::fmt;
 #[cfg(windows)]
 use {
@@ -232,10 +232,10 @@ impl FromRawFd for UdpSocket {
 }
 
 #[cfg(not(windows))]
-impl FromFd for UdpSocket {
+impl From<OwnedFd> for UdpSocket {
     #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(net::UdpSocket::from_fd(fd))
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_std(net::UdpSocket::from(fd))
     }
 }
 
@@ -248,10 +248,10 @@ impl FromRawSocket for UdpSocket {
 }
 
 #[cfg(windows)]
-impl FromSocket for UdpSocket {
+impl From<OwnedSocket> for UdpSocket {
     #[inline]
-    fn from_socket(socket: OwnedSocket) -> Self {
-        Self::from_std(net::UdpSocket::from_socket(socket))
+    fn from(socket: OwnedSocket) -> Self {
+        Self::from_std(net::UdpSocket::from(socket))
     }
 }
 
@@ -304,10 +304,10 @@ impl IntoRawFd for UdpSocket {
 }
 
 #[cfg(not(windows))]
-impl IntoFd for UdpSocket {
+impl From<UdpSocket> for OwnedFd {
     #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.std.into_fd()
+    fn from(socket: UdpSocket) -> OwnedFd {
+        socket.std.into()
     }
 }
 
@@ -320,10 +320,10 @@ impl IntoRawSocket for UdpSocket {
 }
 
 #[cfg(windows)]
-impl IntoSocket for UdpSocket {
+impl From<UdpSocket> for OwnedSocket {
     #[inline]
-    fn into_socket(self) -> OwnedSocket {
-        self.std.into_socket()
+    fn from(socket: UdpSocket) -> OwnedSocket {
+        self.std.into()
     }
 }
 

--- a/cap-async-std/src/os/unix/net/unix_datagram.rs
+++ b/cap-async-std/src/os/unix/net/unix_datagram.rs
@@ -3,7 +3,7 @@ use crate::os::unix::net::SocketAddr;
 use async_std::io;
 use async_std::os::unix;
 use async_std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
-use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 use std::fmt;
 
 /// A Unix datagram socket.
@@ -148,10 +148,10 @@ impl FromRawFd for UnixDatagram {
     }
 }
 
-impl FromFd for UnixDatagram {
+impl From<OwnedFd> for UnixDatagram {
     #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(unix::net::UnixDatagram::from_fd(fd))
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_std(unix::net::UnixDatagram::from(fd))
     }
 }
 
@@ -176,10 +176,10 @@ impl IntoRawFd for UnixDatagram {
     }
 }
 
-impl IntoFd for UnixDatagram {
+impl From<UnixDatagram> for OwnedFd {
     #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.std.into_fd()
+    fn from(datagram: UnixDatagram) -> OwnedFd {
+        datagram.std.into()
     }
 }
 

--- a/cap-async-std/src/os/unix/net/unix_listener.rs
+++ b/cap-async-std/src/os/unix/net/unix_listener.rs
@@ -2,7 +2,7 @@ use crate::os::unix::net::{Incoming, SocketAddr, UnixStream};
 use async_std::io;
 use async_std::os::unix;
 use async_std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
-use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 use std::fmt;
 
 /// A structure representing a Unix domain socket server.
@@ -82,10 +82,10 @@ impl FromRawFd for UnixListener {
     }
 }
 
-impl FromFd for UnixListener {
+impl From<OwnedFd> for UnixListener {
     #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(unix::net::UnixListener::from_fd(fd))
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_std(unix::net::UnixListener::from(fd))
     }
 }
 
@@ -110,10 +110,10 @@ impl IntoRawFd for UnixListener {
     }
 }
 
-impl IntoFd for UnixListener {
+impl From<UnixListener> for OwnedFd {
     #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.std.into_fd()
+    fn from(listener: UnixListener) -> OwnedFd {
+        listener.std.into()
     }
 }
 

--- a/cap-async-std/src/os/unix/net/unix_stream.rs
+++ b/cap-async-std/src/os/unix/net/unix_stream.rs
@@ -4,7 +4,7 @@ use async_std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use async_std::os::unix;
 use async_std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use async_std::task::{Context, Poll};
-use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 use std::fmt;
 use std::pin::Pin;
 
@@ -102,10 +102,10 @@ impl FromRawFd for UnixStream {
     }
 }
 
-impl FromFd for UnixStream {
+impl From<OwnedFd> for UnixStream {
     #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(unix::net::UnixStream::from_fd(fd))
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_std(unix::net::UnixStream::from(fd))
     }
 }
 
@@ -130,10 +130,10 @@ impl IntoRawFd for UnixStream {
     }
 }
 
-impl IntoFd for UnixStream {
+impl From<UnixStream> for OwnedFd {
     #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.std.into_fd()
+    fn from(stream: UnixStream) -> OwnedFd {
+        stream.std.into()
     }
 }
 

--- a/cap-directories/Cargo.toml
+++ b/cap-directories/Cargo.toml
@@ -17,7 +17,7 @@ cap-std = { path = "../cap-std", version = "^0.25.0" }
 directories-next = "2.0.0"
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.35.6" }
+rustix = { version = "0.36.0-rc1" }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.36.0"

--- a/cap-fs-ext/Cargo.toml
+++ b/cap-fs-ext/Cargo.toml
@@ -17,7 +17,7 @@ arf-strings = { version = "0.6.7", optional = true }
 #cap-async-std = { path = "../cap-async-std", optional = true, version = "^0.25.0" }
 cap-std = { path = "../cap-std", optional = true, version = "^0.25.0" }
 cap-primitives = { path = "../cap-primitives", version = "^0.25.0" }
-io-lifetimes = { version = "0.7.0", default-features = false }
+io-lifetimes = { version = "1.0.0-rc1", default-features = false }
 # Enable "unstable" for `spawn_blocking`.
 #async-std = { version = "1.10.0", features = ["attributes", "unstable"], optional = true }
 #async-trait = { version = "0.1.42", optional = true }

--- a/cap-fs-ext/Cargo.toml
+++ b/cap-fs-ext/Cargo.toml
@@ -14,13 +14,13 @@ edition = "2018"
 
 [dependencies]
 arf-strings = { version = "0.6.7", optional = true }
-cap-async-std = { path = "../cap-async-std", optional = true, version = "^0.25.0" }
+#cap-async-std = { path = "../cap-async-std", optional = true, version = "^0.25.0" }
 cap-std = { path = "../cap-std", optional = true, version = "^0.25.0" }
 cap-primitives = { path = "../cap-primitives", version = "^0.25.0" }
 io-lifetimes = { version = "0.7.0", default-features = false }
 # Enable "unstable" for `spawn_blocking`.
-async-std = { version = "1.10.0", features = ["attributes", "unstable"], optional = true }
-async-trait = { version = "0.1.42", optional = true }
+#async-std = { version = "1.10.0", features = ["attributes", "unstable"], optional = true }
+#async-trait = { version = "0.1.42", optional = true }
 camino = { version = "1.0.5", optional = true }
 
 [features]
@@ -28,9 +28,9 @@ default = ["std"]
 fs_utf8 = ["cap-std/fs_utf8", "camino"]
 arf_strings = ["cap-std/arf_strings", "fs_utf8", "arf-strings"]
 std = ["cap-std"]
-async_std = ["cap-async-std", "async-std", "io-lifetimes/async-std", "async-trait"]
-async_std_fs_utf8 = ["cap-async-std/fs_utf8", "camino"]
-async_std_arf_strings = ["cap-async-std/arf_strings", "async_std_fs_utf8", "arf-strings"]
+#async_std = ["cap-async-std", "async-std", "io-lifetimes/async-std", "async-trait"]
+#async_std_fs_utf8 = ["cap-async-std/fs_utf8", "camino"]
+#async_std_arf_strings = ["cap-async-std/arf_strings", "async_std_fs_utf8", "arf-strings"]
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.36.0"

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -28,8 +28,7 @@ cap-tempfile = { path = "../cap-tempfile" }
 rustix = { version = "0.36.0-rc1", features = ["fs", "process", "procfs", "termios", "time"] }
 
 [target.'cfg(windows)'.dependencies]
-winx = "0.33.0"
-winapi-util = "0.1.5"
+winx = "0.34.0-rc1"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.36.0"

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -17,15 +17,15 @@ ambient-authority = "0.0.1"
 arbitrary = { version = "1.0.0", optional = true, features = ["derive"] }
 ipnet = "2.3.0"
 maybe-owned = "0.3.4"
-fs-set-times = "0.17.0"
-io-extras = "0.15.0"
-io-lifetimes = { version = "0.7.0", default-features = false }
+fs-set-times = "0.18.0-rc1"
+io-extras = "0.16.0-rc1"
+io-lifetimes = { version = "1.0.0-rc1", default-features = false }
 
 [dev-dependencies]
 cap-tempfile = { path = "../cap-tempfile" }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.35.6", features = ["fs", "process", "procfs", "termios", "time"] }
+rustix = { version = "0.36.0-rc1", features = ["fs", "process", "procfs", "termios", "time"] }
 
 [target.'cfg(windows)'.dependencies]
 winx = "0.33.0"

--- a/cap-primitives/src/rustix/fs/open_unchecked.rs
+++ b/cap-primitives/src/rustix/fs/open_unchecked.rs
@@ -1,7 +1,7 @@
 use super::compute_oflags;
 use crate::fs::{stat_unchecked, OpenOptions, OpenUncheckedError};
 use crate::AmbientAuthority;
-use io_lifetimes::{AsFilelike, FromFd};
+use io_lifetimes::AsFilelike;
 use rustix::fs::{cwd, openat, Mode};
 use rustix::io;
 use std::fs;
@@ -24,7 +24,7 @@ pub(crate) fn open_unchecked(
 
     let err = match openat(start, path, oflags, mode) {
         Ok(file) => {
-            return Ok(fs::File::from_fd(file.into()));
+            return Ok(fs::File::from(file));
         }
         Err(err) => err,
     };

--- a/cap-primitives/src/rustix/fs/read_dir_inner.rs
+++ b/cap-primitives/src/rustix/fs/read_dir_inner.rs
@@ -4,9 +4,9 @@ use crate::fs::{
     Metadata, OpenOptions, ReadDir,
 };
 use io_extras::os::rustix::{AsRawFd, FromRawFd, RawFd};
-use io_lifetimes::{AsFd, IntoFd};
+use io_lifetimes::AsFd;
+use rustix::fd::OwnedFd;
 use rustix::fs::Dir;
-use rustix::io::OwnedFd;
 use std::ffi::OsStr;
 use std::mem::ManuallyDrop;
 #[cfg(unix)]
@@ -32,7 +32,7 @@ impl ReadDirInner {
         let dir = Dir::read_from(fd.as_fd())?;
         Ok(Self {
             raw_fd: fd.as_fd().as_raw_fd(),
-            rustix: Arc::new(Mutex::new((dir, fd.into_fd().into()))),
+            rustix: Arc::new(Mutex::new((dir, OwnedFd::from(fd)))),
         })
     }
 
@@ -46,7 +46,7 @@ impl ReadDirInner {
         let dir = Dir::read_from(fd.as_fd())?;
         Ok(Self {
             raw_fd: fd.as_fd().as_raw_fd(),
-            rustix: Arc::new(Mutex::new((dir, fd.into_fd().into()))),
+            rustix: Arc::new(Mutex::new((dir, fd.into()))),
         })
     }
 
@@ -59,7 +59,7 @@ impl ReadDirInner {
         let dir = Dir::read_from(fd.as_fd())?;
         Ok(Self {
             raw_fd: fd.as_fd().as_raw_fd(),
-            rustix: Arc::new(Mutex::new((dir, fd.into_fd().into()))),
+            rustix: Arc::new(Mutex::new((dir, fd.into()))),
         })
     }
 

--- a/cap-primitives/src/windows/fs/file_type_ext.rs
+++ b/cap-primitives/src/windows/fs/file_type_ext.rs
@@ -24,7 +24,7 @@ impl ImplFileTypeExt {
         }
 
         // Use the open file to check for one of the exotic file types.
-        let file_type = winapi_util::file::typ(file)?;
+        let file_type = winx::winapi_util::file::typ(file)?;
         if file_type.is_char() {
             return Ok(FileType::ext(ImplFileTypeExt::CharacterDevice));
         }

--- a/cap-primitives/src/windows/fs/metadata_ext.rs
+++ b/cap-primitives/src/windows/fs/metadata_ext.rs
@@ -44,7 +44,7 @@ impl MetadataExt {
 
         #[cfg(not(windows_by_handle))]
         if volume_serial_number.is_none() || number_of_links.is_none() || file_index.is_none() {
-            let fileinfo = winapi_util::file::information(file)?;
+            let fileinfo = winx::winapi_util::file::information(file)?;
             if volume_serial_number.is_none() {
                 let t64: u64 = fileinfo.volume_serial_number();
                 let t32: u32 = t64.try_into().unwrap();

--- a/cap-std/Cargo.toml
+++ b/cap-std/Cargo.toml
@@ -20,12 +20,12 @@ rustdoc-args = ["--cfg=doc_cfg"]
 arf-strings = { version = "0.6.7", optional = true }
 cap-primitives = { path = "../cap-primitives", version = "^0.25.0" }
 ipnet = "2.3.0"
-io-extras = "0.15.0"
-io-lifetimes = { version = "0.7.0", default-features = false }
+io-extras = "0.16.0-rc1"
+io-lifetimes = { version = "1.0.0-rc1", default-features = false }
 camino = { version = "1.0.5", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.35.6", features = ["fs"] }
+rustix = { version = "0.36.0-rc1", features = ["fs"] }
 
 [features]
 default = []

--- a/cap-std/src/fs/dir.rs
+++ b/cap-std/src/fs/dir.rs
@@ -11,9 +11,9 @@ use cap_primitives::fs::{
 use cap_primitives::AmbientAuthority;
 use io_lifetimes::AsFilelike;
 #[cfg(not(windows))]
-use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(windows)]
-use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
+use io_lifetimes::{AsHandle, BorrowedHandle, OwnedHandle};
 #[cfg(target_os = "wasi")]
 use rustix::fs::OpenOptionsExt;
 use std::io::{self, Read, Write};
@@ -691,10 +691,10 @@ impl FromRawFd for Dir {
 }
 
 #[cfg(not(windows))]
-impl FromFd for Dir {
+impl From<OwnedFd> for Dir {
     #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std_file(fs::File::from_fd(fd))
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_std_file(fs::File::from(fd))
     }
 }
 
@@ -709,10 +709,10 @@ impl FromRawHandle for Dir {
 }
 
 #[cfg(windows)]
-impl FromHandle for Dir {
+impl From<OwnedHandle> for Dir {
     #[inline]
-    fn from_handle(handle: OwnedHandle) -> Self {
-        Self::from_std_file(fs::File::from_handle(handle))
+    fn from(handle: OwnedHandle) -> Self {
+        Self::from_std_file(fs::File::from(handle))
     }
 }
 
@@ -765,10 +765,10 @@ impl IntoRawFd for Dir {
 }
 
 #[cfg(not(windows))]
-impl IntoFd for Dir {
+impl From<Dir> for OwnedFd {
     #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.std_file.into_fd()
+    fn from(dir: Dir) -> OwnedFd {
+        dir.std_file.into()
     }
 }
 
@@ -781,10 +781,10 @@ impl IntoRawHandle for Dir {
 }
 
 #[cfg(windows)]
-impl IntoHandle for Dir {
+impl From<Dir> for OwnedHandle {
     #[inline]
-    fn into_handle(self) -> OwnedHandle {
-        self.std_file.into_handle()
+    fn from(dir: Dir) -> OwnedHandle {
+        dir.std_file.into()
     }
 }
 

--- a/cap-std/src/fs/file.rs
+++ b/cap-std/src/fs/file.rs
@@ -4,9 +4,9 @@ use cap_primitives::AmbientAuthority;
 #[cfg(not(windows))]
 use io_extras::os::rustix::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(not(windows))]
-use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(windows)]
-use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
+use io_lifetimes::{AsHandle, BorrowedHandle, OwnedHandle};
 use std::io::{self, IoSlice, IoSliceMut, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 use std::{fmt, fs, process};
@@ -167,10 +167,10 @@ impl FromRawFd for File {
 }
 
 #[cfg(not(windows))]
-impl FromFd for File {
+impl From<OwnedFd> for File {
     #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(fs::File::from_fd(fd))
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_std(fs::File::from(fd))
     }
 }
 
@@ -183,10 +183,10 @@ impl FromRawHandle for File {
 }
 
 #[cfg(windows)]
-impl FromHandle for File {
+impl From<OwnedHandle> for File {
     #[inline]
-    fn from_handle(handle: OwnedHandle) -> Self {
-        Self::from_std(fs::File::from_handle(handle))
+    fn from(handle: OwnedHandle) -> Self {
+        Self::from_std(fs::File::from(handle))
     }
 }
 
@@ -239,10 +239,10 @@ impl IntoRawFd for File {
 }
 
 #[cfg(not(windows))]
-impl IntoFd for File {
+impl From<File> for OwnedFd {
     #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.std.into_fd()
+    fn from(file: File) -> OwnedFd {
+        file.std.into()
     }
 }
 
@@ -255,10 +255,10 @@ impl IntoRawHandle for File {
 }
 
 #[cfg(windows)]
-impl IntoHandle for File {
+impl From<File> for OwnedHandle {
     #[inline]
-    fn into_handle(self) -> OwnedHandle {
-        self.std.into_handle()
+    fn from(file: File) -> OwnedHandle {
+        file.std.into()
     }
 }
 

--- a/cap-std/src/fs_utf8/dir.rs
+++ b/cap-std/src/fs_utf8/dir.rs
@@ -7,9 +7,9 @@ use cap_primitives::AmbientAuthority;
 #[cfg(not(windows))]
 use io_extras::os::rustix::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(not(windows))]
-use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(windows)]
-use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
+use io_lifetimes::{AsHandle, BorrowedHandle, OwnedHandle};
 use std::{fmt, fs, io};
 #[cfg(windows)]
 use {
@@ -628,10 +628,10 @@ impl FromRawFd for Dir {
 }
 
 #[cfg(not(windows))]
-impl FromFd for Dir {
+impl From<OwnedFd> for Dir {
     #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std_file(fs::File::from_fd(fd))
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_std_file(fs::File::from(fd))
     }
 }
 
@@ -646,12 +646,12 @@ impl FromRawHandle for Dir {
 }
 
 #[cfg(windows)]
-impl FromHandle for Dir {
+impl From<OwnedHandle> for Dir {
     /// To prevent race conditions on Windows, the handle must be opened
     /// without `FILE_SHARE_DELETE`.
     #[inline]
-    fn from_handle(handle: OwnedHandle) -> Self {
-        Self::from_std_file(fs::File::from_handle(handle))
+    fn from(handle: OwnedHandle) -> Self {
+        Self::from_std_file(fs::File::from(handle))
     }
 }
 
@@ -704,10 +704,10 @@ impl IntoRawFd for Dir {
 }
 
 #[cfg(not(windows))]
-impl IntoFd for Dir {
+impl From<Dir> for OwnedFd {
     #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.cap_std.into_fd()
+    fn from(dir: Dir) -> OwnedFd {
+        dir.cap_std.into()
     }
 }
 
@@ -720,10 +720,10 @@ impl IntoRawHandle for Dir {
 }
 
 #[cfg(windows)]
-impl IntoHandle for Dir {
+impl From<Dir> for OwnedHandle {
     #[inline]
-    fn into_handle(self) -> OwnedHandle {
-        self.cap_std.into_handle()
+    fn from(dir: Dir) -> OwnedHandle {
+        dir.cap_std.into()
     }
 }
 

--- a/cap-std/src/fs_utf8/file.rs
+++ b/cap-std/src/fs_utf8/file.rs
@@ -5,9 +5,9 @@ use cap_primitives::AmbientAuthority;
 #[cfg(not(windows))]
 use io_extras::os::rustix::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(not(windows))]
-use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(windows)]
-use io_lifetimes::{AsHandle, BorrowedHandle, FromHandle, IntoHandle, OwnedHandle};
+use io_lifetimes::{AsHandle, BorrowedHandle, OwnedHandle};
 use std::io::{self, IoSlice, IoSliceMut, Read, Seek, SeekFrom, Write};
 #[cfg(target_os = "wasi")]
 use std::path::Path;
@@ -166,10 +166,10 @@ impl FromRawFd for File {
 }
 
 #[cfg(not(windows))]
-impl FromFd for File {
+impl From<OwnedFd> for File {
     #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(fs::File::from_fd(fd))
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_std(fs::File::from(fd))
     }
 }
 
@@ -182,10 +182,10 @@ impl FromRawHandle for File {
 }
 
 #[cfg(windows)]
-impl FromHandle for File {
+impl From<OwnedHandle> for File {
     #[inline]
-    fn from_handle(handle: OwnedHandle) -> Self {
-        Self::from_std(fs::File::from_handle(handle))
+    fn from(handle: OwnedHandle) -> Self {
+        Self::from_std(fs::File::from(handle))
     }
 }
 
@@ -238,10 +238,10 @@ impl IntoRawFd for File {
 }
 
 #[cfg(not(windows))]
-impl IntoFd for File {
+impl From<File> for OwnedFd {
     #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.cap_std.into_fd()
+    fn from(file: File) -> OwnedFd {
+        file.cap_std.into()
     }
 }
 
@@ -254,10 +254,10 @@ impl IntoRawHandle for File {
 }
 
 #[cfg(windows)]
-impl IntoHandle for File {
+impl From<File> for OwnedHandle {
     #[inline]
-    fn into_handle(self) -> OwnedHandle {
-        self.cap_std.into_handle()
+    fn from(file: File) -> OwnedHandle {
+        file.cap_std.into()
     }
 }
 

--- a/cap-std/src/net/tcp_listener.rs
+++ b/cap-std/src/net/tcp_listener.rs
@@ -2,9 +2,9 @@ use crate::net::{Incoming, SocketAddr, TcpStream};
 #[cfg(not(windows))]
 use io_extras::os::rustix::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(not(windows))]
-use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(windows)]
-use io_lifetimes::{AsSocket, BorrowedSocket, FromSocket, IntoSocket, OwnedSocket};
+use io_lifetimes::{AsSocket, BorrowedSocket, OwnedSocket};
 use std::{fmt, io, net};
 #[cfg(windows)]
 use {
@@ -116,10 +116,10 @@ impl FromRawFd for TcpListener {
 }
 
 #[cfg(not(windows))]
-impl FromFd for TcpListener {
+impl From<OwnedFd> for TcpListener {
     #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(net::TcpListener::from_fd(fd))
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_std(net::TcpListener::from(fd))
     }
 }
 
@@ -132,10 +132,10 @@ impl FromRawSocket for TcpListener {
 }
 
 #[cfg(windows)]
-impl FromSocket for TcpListener {
+impl From<OwnedSocket> for TcpListener {
     #[inline]
-    fn from_socket(socket: OwnedSocket) -> Self {
-        Self::from_std(net::TcpListener::from_socket(socket))
+    fn from(socket: OwnedSocket) -> Self {
+        Self::from_std(net::TcpListener::from(socket))
     }
 }
 
@@ -188,10 +188,10 @@ impl IntoRawFd for TcpListener {
 }
 
 #[cfg(not(windows))]
-impl IntoFd for TcpListener {
+impl From<TcpListener> for OwnedFd {
     #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.std.into_fd()
+    fn from(listener: TcpListener) -> OwnedFd {
+        listener.std.into()
     }
 }
 
@@ -204,10 +204,10 @@ impl IntoRawSocket for TcpListener {
 }
 
 #[cfg(windows)]
-impl IntoSocket for TcpListener {
+impl From<TcpListener> for OwnedSocket {
     #[inline]
-    fn into_socket(self) -> OwnedSocket {
-        self.std.into_socket()
+    fn from(listener: TcpListener) -> OwnedSocket {
+        listener.std.into()
     }
 }
 

--- a/cap-std/src/net/tcp_stream.rs
+++ b/cap-std/src/net/tcp_stream.rs
@@ -2,9 +2,9 @@ use crate::net::{Shutdown, SocketAddr};
 #[cfg(not(windows))]
 use io_extras::os::rustix::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(not(windows))]
-use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(windows)]
-use io_lifetimes::{AsSocket, BorrowedSocket, FromSocket, IntoSocket, OwnedSocket};
+use io_lifetimes::{AsSocket, BorrowedSocket, OwnedSocket};
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::time::Duration;
 use std::{fmt, net};
@@ -171,10 +171,10 @@ impl FromRawFd for TcpStream {
 }
 
 #[cfg(not(windows))]
-impl FromFd for TcpStream {
+impl From<OwnedFd> for TcpStream {
     #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(net::TcpStream::from_fd(fd))
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_std(net::TcpStream::from(fd))
     }
 }
 
@@ -187,10 +187,10 @@ impl FromRawSocket for TcpStream {
 }
 
 #[cfg(windows)]
-impl FromSocket for TcpStream {
+impl From<OwnedSocket> for TcpStream {
     #[inline]
-    fn from_socket(socket: OwnedSocket) -> Self {
-        Self::from_std(net::TcpStream::from_socket(socket))
+    fn from(socket: OwnedSocket) -> Self {
+        Self::from_std(net::TcpStream::from(socket))
     }
 }
 
@@ -243,10 +243,10 @@ impl IntoRawFd for TcpStream {
 }
 
 #[cfg(not(windows))]
-impl IntoFd for TcpStream {
+impl From<TcpStream> for OwnedFd {
     #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.std.into_fd()
+    fn from(stream: TcpStream) -> OwnedFd {
+        stream.std.into()
     }
 }
 
@@ -259,10 +259,10 @@ impl IntoRawSocket for TcpStream {
 }
 
 #[cfg(windows)]
-impl IntoSocket for TcpStream {
+impl From<TcpStream> for OwnedSocket {
     #[inline]
-    fn into_socket(self) -> OwnedSocket {
-        self.std.into_socket()
+    fn from(socket: TcpStream) -> OwnedSocket {
+        socket.std.into()
     }
 }
 

--- a/cap-std/src/net/udp_socket.rs
+++ b/cap-std/src/net/udp_socket.rs
@@ -2,9 +2,9 @@ use crate::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 #[cfg(not(windows))]
 use io_extras::os::rustix::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(not(windows))]
-use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(windows)]
-use io_lifetimes::{AsSocket, BorrowedSocket, FromSocket, IntoSocket, OwnedSocket};
+use io_lifetimes::{AsSocket, BorrowedSocket, OwnedSocket};
 use std::time::Duration;
 use std::{fmt, io, net};
 #[cfg(windows)]
@@ -286,10 +286,10 @@ impl FromRawFd for UdpSocket {
 }
 
 #[cfg(not(windows))]
-impl FromFd for UdpSocket {
+impl From<OwnedFd> for UdpSocket {
     #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(net::UdpSocket::from_fd(fd))
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_std(net::UdpSocket::from(fd))
     }
 }
 
@@ -302,10 +302,10 @@ impl FromRawSocket for UdpSocket {
 }
 
 #[cfg(windows)]
-impl FromSocket for UdpSocket {
+impl From<OwnedSocket> for UdpSocket {
     #[inline]
-    fn from_socket(socket: OwnedSocket) -> Self {
-        Self::from_std(net::UdpSocket::from_socket(socket))
+    fn from(socket: OwnedSocket) -> Self {
+        Self::from_std(net::UdpSocket::from(socket))
     }
 }
 
@@ -358,10 +358,10 @@ impl IntoRawFd for UdpSocket {
 }
 
 #[cfg(not(windows))]
-impl IntoFd for UdpSocket {
+impl From<UdpSocket> for OwnedFd {
     #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.std.into_fd()
+    fn from(socket: UdpSocket) -> OwnedFd {
+        socket.std.into()
     }
 }
 
@@ -374,10 +374,10 @@ impl IntoRawSocket for UdpSocket {
 }
 
 #[cfg(windows)]
-impl IntoSocket for UdpSocket {
+impl From<UdpSocket> for OwnedSocket {
     #[inline]
-    fn into_socket(self) -> OwnedSocket {
-        self.std.into_socket()
+    fn from(socket: UdpSocket) -> OwnedSocket {
+        socket.std.into()
     }
 }
 

--- a/cap-std/src/os/unix/net/unix_datagram.rs
+++ b/cap-std/src/os/unix/net/unix_datagram.rs
@@ -1,6 +1,6 @@
 use crate::net::Shutdown;
 use crate::os::unix::net::SocketAddr;
-use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 use std::os::unix;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::time::Duration;
@@ -203,10 +203,10 @@ impl FromRawFd for UnixDatagram {
     }
 }
 
-impl FromFd for UnixDatagram {
+impl From<OwnedFd> for UnixDatagram {
     #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(unix::net::UnixDatagram::from_fd(fd))
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_std(unix::net::UnixDatagram::from(fd))
     }
 }
 
@@ -231,10 +231,10 @@ impl IntoRawFd for UnixDatagram {
     }
 }
 
-impl IntoFd for UnixDatagram {
+impl From<UnixDatagram> for OwnedFd {
     #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.std.into_fd()
+    fn from(datagram: UnixDatagram) -> OwnedFd {
+        datagram.std.into()
     }
 }
 

--- a/cap-std/src/os/unix/net/unix_listener.rs
+++ b/cap-std/src/os/unix/net/unix_listener.rs
@@ -1,5 +1,5 @@
 use crate::os::unix::net::{Incoming, SocketAddr, UnixStream};
-use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 use std::os::unix;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::{fmt, io};
@@ -103,10 +103,10 @@ impl FromRawFd for UnixListener {
     }
 }
 
-impl FromFd for UnixListener {
+impl From<OwnedFd> for UnixListener {
     #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(unix::net::UnixListener::from_fd(fd))
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_std(unix::net::UnixListener::from(fd))
     }
 }
 
@@ -131,10 +131,10 @@ impl IntoRawFd for UnixListener {
     }
 }
 
-impl IntoFd for UnixListener {
+impl From<UnixListener> for OwnedFd {
     #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.std.into_fd()
+    fn from(listener: UnixListener) -> OwnedFd {
+        listener.std.into()
     }
 }
 

--- a/cap-std/src/os/unix/net/unix_stream.rs
+++ b/cap-std/src/os/unix/net/unix_stream.rs
@@ -1,6 +1,6 @@
 use crate::net::Shutdown;
 use crate::os::unix::net::SocketAddr;
-use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 use std::fmt;
 use std::io::{self, IoSlice, IoSliceMut, Read, Write};
 use std::os::unix;
@@ -157,10 +157,10 @@ impl FromRawFd for UnixStream {
     }
 }
 
-impl FromFd for UnixStream {
+impl From<OwnedFd> for UnixStream {
     #[inline]
-    fn from_fd(fd: OwnedFd) -> Self {
-        Self::from_std(unix::net::UnixStream::from_fd(fd))
+    fn from(fd: OwnedFd) -> Self {
+        Self::from_std(unix::net::UnixStream::from(fd))
     }
 }
 
@@ -185,10 +185,10 @@ impl IntoRawFd for UnixStream {
     }
 }
 
-impl IntoFd for UnixStream {
+impl From<UnixStream> for OwnedFd {
     #[inline]
-    fn into_fd(self) -> OwnedFd {
-        self.std.into_fd()
+    fn from(stream: UnixStream) -> OwnedFd {
+        stream.std.into()
     }
 }
 

--- a/cap-tempfile/Cargo.toml
+++ b/cap-tempfile/Cargo.toml
@@ -21,7 +21,7 @@ camino = { version = "1.0.5", optional = true }
 rand = "0.8.1"
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.35.6", features = ["procfs"] }
+rustix = { version = "0.36.0-rc1", features = ["procfs"] }
 
 [target.'cfg(windows)'.dev-dependencies.windows-sys]
 version = "0.36.0"

--- a/cap-tempfile/src/tempfile.rs
+++ b/cap-tempfile/src/tempfile.rs
@@ -55,7 +55,7 @@ impl<'d> Debug for TempFile<'d> {
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn new_tempfile_linux(d: &Dir) -> io::Result<Option<File>> {
-    use rustix::fd::FromFd;
+    use cap_std::io_lifetimes::FromFd;
     use rustix::fs::{Mode, OFlags};
     // openat's API uses WRONLY.  There may be use cases for reading too, so let's support it.
     let oflags = OFlags::CLOEXEC | OFlags::TMPFILE | OFlags::RDWR;
@@ -64,7 +64,7 @@ fn new_tempfile_linux(d: &Dir) -> io::Result<Option<File>> {
     let mode = Mode::from_raw_mode(0o666);
     // Happy path - Linux with O_TMPFILE
     match rustix::fs::openat(d, ".", oflags, mode) {
-        Ok(r) => return Ok(Some(File::from_fd(r.into()))),
+        Ok(r) => return Ok(Some(File::from_into_fd(r))),
         // See https://github.com/Stebalien/tempfile/blob/1a40687e06eb656044e3d2dffa1379f04b3ef3fd/src/file/imp/unix.rs#L81
         // TODO: With newer Rust versions, this could be simplied to only write `Err` once.
         Err(rustix::io::Errno::OPNOTSUPP)

--- a/cap-time-ext/Cargo.toml
+++ b/cap-time-ext/Cargo.toml
@@ -17,7 +17,7 @@ cap-primitives = { path = "../cap-primitives", version = "^0.25.0" }
 cap-std = { path = "../cap-std", optional = true, version = "^0.25.0" }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.35.6", features = ["time"] }
+rustix = { version = "0.36.0-rc1", features = ["time"] }
 
 [target.'cfg(windows)'.dependencies]
 once_cell = "1.5.2"

--- a/cap-time-ext/Cargo.toml
+++ b/cap-time-ext/Cargo.toml
@@ -21,4 +21,4 @@ rustix = { version = "0.36.0-rc1", features = ["time"] }
 
 [target.'cfg(windows)'.dependencies]
 once_cell = "1.5.2"
-winx = "0.33.0"
+winx = "0.34.0-rc1"

--- a/examples/async_std_fs_misc.rs
+++ b/examples/async_std_fs_misc.rs
@@ -1,6 +1,7 @@
 // Copied from https://doc.rust-lang.org/rust-by-example/std_misc/fs.html and
 // adapted to use this crate instead.
 
+/*
 use async_std::io;
 use async_std::io::prelude::*;
 use cap_async_std::ambient_authority;
@@ -110,4 +111,8 @@ async fn main() {
     cwd.remove_dir("a/c/d").await.unwrap_or_else(|why| {
         println!("! {:?}", why.kind());
     });
+}
+*/
+fn main() {
+    eprintln!("async-std doesn't have io_safety traits implemented yet");
 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,7 +15,7 @@ cap-primitives = { path = "../cap-primitives", features = ["arbitrary"] }
 # Depend on io-lifetimes with default features, as the fuzzing framework
 # seems to add a dependency on `io_lifetimes::OwnedFd::drop` even when the
 # code itself doesn't have one.
-io-lifetimes = "0.7.0"
+io-lifetimes = "1.0.0-rc1"
 
 [[bin]]
 name = "cap-primitives"


### PR DESCRIPTION
This converts to the new traits, with `From` instead of `IntoFd` and `FromFd`.
    
This currently depends on cap-async-std being disabled, since async-std
doesn't yet have the io-safety trait impls yet.
