### PR TITLE
Add a function to expose `StdRng::from_entropy` in a capability-safe way.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ cap-fs-ext = { path = "cap-fs-ext", version = "^1.0.0-rc1" }
 cap-directories = { path = "cap-directories", version = "^1.0.0-rc1" }
 cap-std = { path = "cap-std", version = "^1.0.0-rc1" }
 cap-tempfile = { path = "cap-tempfile", version = "^1.0.0-rc1" }
+cap-rand = { path = "cap-rand", version = "^1.0.0-rc1" }
 rand = "0.8.1"
 tempfile = "3.1.0"
 camino = "1.0.5"

--- a/cap-rand/src/lib.rs
+++ b/cap-rand/src/lib.rs
@@ -14,7 +14,8 @@
 //! interface, it provides a `from_entropy` function which directly reads
 //! from the operating system entropy source. To preserve the
 //! capability-based interface, avoid using `rand::SeedableRng`'s
-//! `from_entropy` function on any of the types that implement that trait.
+//! `from_entropy` function on any of the types that implement that trait; use
+//! [`std_rng_from_entropy`] instead.
 //!
 //! [`OsRng`]: crate::rngs::OsRng
 //! [`CapRng`]: crate::rngs::CapRng
@@ -164,6 +165,19 @@ pub fn thread_rng(_: AmbientAuthority) -> rngs::CapRng {
     rngs::CapRng {
         inner: rand::thread_rng(),
     }
+}
+
+/// Retrieve the standard random number generator, seeded by the system.
+///
+/// This corresponds to [`rand::rngs::StdRng::from_entropy`].
+///
+/// # Ambient Authority
+///
+/// This function makes use of ambient authority to access the platform entropy
+/// source.
+#[inline]
+pub fn std_rng_from_entropy(_: AmbientAuthority) -> rngs::StdRng {
+    rand::rngs::StdRng::from_entropy()
 }
 
 /// Generates a random value using the thread-local random number generator.

--- a/tests/rand.rs
+++ b/tests/rand.rs
@@ -1,0 +1,5 @@
+#[test]
+fn test_std_rng_from_entropy() {
+    let rng = cap_rand::std_rng_from_entropy(cap_rand::ambient_authority());
+    assert_eq!(rng.clone(), rng);
+}


### PR DESCRIPTION
`StdRng` has a `from_entropy` function which instantiates a `StdRng` from ambient authority. It's part of the `SeedableRng` trait, so we can't easily avoid it, but we can provide a wrapper that does make the ambient authority explicit.