### PR TITLE
Update to io-extras 0.17.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -365,7 +365,7 @@ jobs:
             rust: 1.58
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - uses: ./.github/actions/install-rust

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -353,6 +353,30 @@ jobs:
         toolchain: ${{ matrix.rust }}
     - run: cargo test --all-features --workspace
 
+  test_msrv:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build: [msrv]
+        include:
+          - build: msrv
+            os: ubuntu-latest
+            rust: 1.58
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: ${{ matrix.rust }}
+    # Don't use --all-features because some of the features have dependencies
+    # that don't work on newer Rust versions.
+    - run: cargo test --workspace --features=fs_utf8,arf_strings
+      env:
+        RUST_BACKTRACE: 1
+
   fuzz_targets:
     name: Fuzz Targets
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ repository = "https://github.com/bytecodealliance/cap-std"
 edition = "2018"
 publish = false
 exclude = ["/.*"]
+# This is also checked in CI.
+rust-version = "1.56"
 
 [dev-dependencies]
 #async-std = { version = "1.10.0", features = ["attributes"] }

--- a/README.md
+++ b/README.md
@@ -238,6 +238,11 @@ a symlink to an absolute path within a `Dir` is always an error. With
 potentially resolve to something different than it would when resolved through
 the process filesystem namespace.
 
+## Minimum Supported Rust Version (MSRV)
+
+This crate currently works on Rust 1.58, when default features are enabled.
+Some of the optional features have stricter requirements.
+
 [`arf-strings`]: https://github.com/bytecodealliance/arf-strings/
 [`openat`]: https://crates.io/crates/openat
 [`pathrs`]: https://crates.io/crates/pathrs

--- a/cap-async-std/Cargo.toml
+++ b/cap-async-std/Cargo.toml
@@ -20,7 +20,7 @@ async-std = { version = "1.10.0", features = ["attributes", "unstable"] }
 cap-primitives = { path = "../cap-primitives", version = "^0.25.0" }
 io-lifetimes = { version = "1.0.0", default-features = false, features = ["async-std"] }
 ipnet = "2.3.0"
-io-extras = { version = "0.16.0", features = ["use_async_std"] }
+io-extras = { version = "0.17.0", features = ["use_async_std"] }
 camino = { version = "1.0.5", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -18,7 +18,7 @@ arbitrary = { version = "1.0.0", optional = true, features = ["derive"] }
 ipnet = "2.3.0"
 maybe-owned = "0.3.4"
 fs-set-times = "0.18.0"
-io-extras = "0.16.0"
+io-extras = "0.17.0"
 io-lifetimes = { version = "1.0.0", default-features = false }
 
 [dev-dependencies]

--- a/cap-std/Cargo.toml
+++ b/cap-std/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args = ["--cfg=doc_cfg"]
 arf-strings = { version = "0.7.0", optional = true }
 cap-primitives = { path = "../cap-primitives", version = "^1.0.0" }
 ipnet = "2.3.0"
-io-extras = "0.16.0"
+io-extras = "0.17.0"
 io-lifetimes = { version = "1.0.0", default-features = false }
 camino = { version = "1.0.5", optional = true }
 

--- a/cap-tempfile/src/tempfile.rs
+++ b/cap-tempfile/src/tempfile.rs
@@ -55,7 +55,7 @@ impl<'d> Debug for TempFile<'d> {
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn new_tempfile_linux(d: &Dir) -> io::Result<Option<File>> {
-    use cap_std::io_lifetimes::FromFd;
+    use cap_std::io_lifetimes::OwnedFd;
     use rustix::fs::{Mode, OFlags};
     // openat's API uses WRONLY.  There may be use cases for reading too, so let's support it.
     let oflags = OFlags::CLOEXEC | OFlags::TMPFILE | OFlags::RDWR;
@@ -64,7 +64,7 @@ fn new_tempfile_linux(d: &Dir) -> io::Result<Option<File>> {
     let mode = Mode::from_raw_mode(0o666);
     // Happy path - Linux with O_TMPFILE
     match rustix::fs::openat(d, ".", oflags, mode) {
-        Ok(r) => return Ok(Some(File::from_into_fd(r))),
+        Ok(r) => return Ok(Some(File::from(OwnedFd::from(r)))),
         // See https://github.com/Stebalien/tempfile/blob/1a40687e06eb656044e3d2dffa1379f04b3ef3fd/src/file/imp/unix.rs#L81
         // TODO: With newer Rust versions, this could be simplied to only write `Err` once.
         Err(rustix::io::Errno::OPNOTSUPP)


### PR DESCRIPTION
This fixes a compilation error on Rust 1.58. Also, add a basic test and README.md declaration for a Rust 1.58 MSRV.