### PR TITLE
Implement `FilelikeViewType` and `SocketlikeViewType` for cap-std's types.

### DIFF
--- a/cap-async-std/src/fs/dir.rs
+++ b/cap-async-std/src/fs/dir.rs
@@ -860,6 +860,9 @@ impl Dir {
     }
 }
 
+// Safety: `FilelikeViewType` is implemented for `std::fs::File`.
+unsafe impl io_lifetimes::views::FilelikeViewType for Dir {}
+
 #[cfg(not(windows))]
 impl FromRawFd for Dir {
     #[inline]

--- a/cap-async-std/src/fs/file.rs
+++ b/cap-async-std/src/fs/file.rs
@@ -188,6 +188,9 @@ fn permissions_into_std(
     permissions
 }
 
+// Safety: `FilelikeViewType` is implemented for `std::fs::File`.
+unsafe impl io_lifetimes::views::FilelikeViewType for File {}
+
 #[cfg(not(windows))]
 impl FromRawFd for File {
     #[inline]

--- a/cap-async-std/src/fs_utf8/dir.rs
+++ b/cap-async-std/src/fs_utf8/dir.rs
@@ -635,6 +635,9 @@ impl Dir {
     }
 }
 
+// Safety: `FilelikeViewType` is implemented for `std::fs::File`.
+unsafe impl io_lifetimes::views::FilelikeViewType for Dir {}
+
 #[cfg(not(windows))]
 impl FromRawFd for Dir {
     #[inline]

--- a/cap-async-std/src/fs_utf8/file.rs
+++ b/cap-async-std/src/fs_utf8/file.rs
@@ -151,6 +151,9 @@ impl File {
     }
 }
 
+// Safety: `FilelikeViewType` is implemented for `std::fs::File`.
+unsafe impl io_lifetimes::views::FilelikeViewType for File {}
+
 #[cfg(not(windows))]
 impl FromRawFd for File {
     #[inline]

--- a/cap-async-std/src/net/tcp_listener.rs
+++ b/cap-async-std/src/net/tcp_listener.rs
@@ -78,6 +78,9 @@ impl TcpListener {
     // async_std doesn't have `TcpListener::set_nonblocking`.
 }
 
+// Safety: `SocketlikeViewType` is implemented for `std`'s socket types.
+unsafe impl io_lifetimes::views::SocketlikeViewType for TcpListener {}
+
 #[cfg(not(windows))]
 impl FromRawFd for TcpListener {
     #[inline]

--- a/cap-async-std/src/net/tcp_stream.rs
+++ b/cap-async-std/src/net/tcp_stream.rs
@@ -122,6 +122,9 @@ impl TcpStream {
     // async_std doesn't have `set_nonblocking`.
 }
 
+// Safety: `SocketlikeViewType` is implemented for `std`'s socket types.
+unsafe impl io_lifetimes::views::SocketlikeViewType for TcpStream {}
+
 #[cfg(not(windows))]
 impl FromRawFd for TcpStream {
     #[inline]

--- a/cap-async-std/src/net/udp_socket.rs
+++ b/cap-async-std/src/net/udp_socket.rs
@@ -223,6 +223,9 @@ impl UdpSocket {
     // async_std doesn't have `set_nonblocking`.
 }
 
+// Safety: `SocketlikeViewType` is implemented for `std`'s socket types.
+unsafe impl io_lifetimes::views::SocketlikeViewType for UdpSocket {}
+
 #[cfg(not(windows))]
 impl FromRawFd for UdpSocket {
     #[inline]

--- a/cap-std/src/fs/dir.rs
+++ b/cap-std/src/fs/dir.rs
@@ -682,6 +682,9 @@ impl Dir {
     }
 }
 
+// Safety: `FilelikeViewType` is implemented for `std::fs::File`.
+unsafe impl io_lifetimes::views::FilelikeViewType for Dir {}
+
 #[cfg(not(windows))]
 impl FromRawFd for Dir {
     #[inline]

--- a/cap-std/src/fs/file.rs
+++ b/cap-std/src/fs/file.rs
@@ -158,6 +158,9 @@ fn permissions_into_std(file: &fs::File, permissions: Permissions) -> io::Result
     permissions.into_std(file)
 }
 
+// Safety: `FilelikeViewType` is implemented for `std::fs::File`.
+unsafe impl io_lifetimes::views::FilelikeViewType for File {}
+
 #[cfg(not(windows))]
 impl FromRawFd for File {
     #[inline]

--- a/cap-std/src/fs_utf8/dir.rs
+++ b/cap-std/src/fs_utf8/dir.rs
@@ -671,6 +671,9 @@ impl AsFd for Dir {
     }
 }
 
+// Safety: `FilelikeViewType` is implemented for `std::fs::File`.
+unsafe impl io_lifetimes::views::FilelikeViewType for Dir {}
+
 #[cfg(windows)]
 impl AsRawHandle for Dir {
     #[inline]

--- a/cap-std/src/fs_utf8/file.rs
+++ b/cap-std/src/fs_utf8/file.rs
@@ -157,6 +157,9 @@ impl File {
     }
 }
 
+// Safety: `FilelikeViewType` is implemented for `std::fs::File`.
+unsafe impl io_lifetimes::views::FilelikeViewType for File {}
+
 #[cfg(not(windows))]
 impl FromRawFd for File {
     #[inline]

--- a/cap-std/src/net/tcp_listener.rs
+++ b/cap-std/src/net/tcp_listener.rs
@@ -107,6 +107,9 @@ impl TcpListener {
     }
 }
 
+// Safety: `SocketlikeViewType` is implemented for `std`'s socket types.
+unsafe impl io_lifetimes::views::SocketlikeViewType for TcpListener {}
+
 #[cfg(not(windows))]
 impl FromRawFd for TcpListener {
     #[inline]

--- a/cap-std/src/net/tcp_stream.rs
+++ b/cap-std/src/net/tcp_stream.rs
@@ -162,6 +162,9 @@ impl TcpStream {
     }
 }
 
+// Safety: `SocketlikeViewType` is implemented for `std`'s socket types.
+unsafe impl io_lifetimes::views::SocketlikeViewType for TcpStream {}
+
 #[cfg(not(windows))]
 impl FromRawFd for TcpStream {
     #[inline]

--- a/cap-std/src/net/udp_socket.rs
+++ b/cap-std/src/net/udp_socket.rs
@@ -277,6 +277,9 @@ impl UdpSocket {
     }
 }
 
+// Safety: `SocketlikeViewType` is implemented for `std`'s socket types.
+unsafe impl io_lifetimes::views::SocketlikeViewType for UdpSocket {}
+
 #[cfg(not(windows))]
 impl FromRawFd for UdpSocket {
     #[inline]


### PR DESCRIPTION
This allow `io-lifetimes`' view types to be used with types such as `cap_std::fs::File`, which is consistent with how they're usable with types such as `std::fs::File`.