### PR TITLE
Implement `AsHandleOrSocket` and `From<OwnedHandleOrSocket>` for types.

### DIFF
--- a/cap-async-std/src/fs/dir.rs
+++ b/cap-async-std/src/fs/dir.rs
@@ -29,7 +29,10 @@ use {
 use {
     async_std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle},
     cap_primitives::fs::{symlink_dir, symlink_file},
-    io_extras::os::windows::{AsRawHandleOrSocket, IntoRawHandleOrSocket, RawHandleOrSocket},
+    io_extras::os::windows::{
+        AsHandleOrSocket, AsRawHandleOrSocket, BorrowedHandleOrSocket, IntoRawHandleOrSocket,
+        OwnedHandleOrSocket, RawHandleOrSocket,
+    },
 };
 
 /// A reference to an open directory on a filesystem.
@@ -937,6 +940,14 @@ impl AsRawHandleOrSocket for Dir {
     }
 }
 
+#[cfg(windows)]
+impl AsHandleOrSocket for Dir {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        self.std_file.as_handle_or_socket()
+    }
+}
+
 #[cfg(not(windows))]
 impl IntoRawFd for Dir {
     #[inline]
@@ -974,6 +985,14 @@ impl IntoRawHandleOrSocket for Dir {
     #[inline]
     fn into_raw_handle_or_socket(self) -> RawHandleOrSocket {
         self.std_file.into_raw_handle_or_socket()
+    }
+}
+
+#[cfg(windows)]
+impl From<Dir> for OwnedHandleOrSocket {
+    #[inline]
+    fn from(dir: Dir) -> Self {
+        dir.std_file.into()
     }
 }
 

--- a/cap-async-std/src/fs/file.rs
+++ b/cap-async-std/src/fs/file.rs
@@ -19,7 +19,10 @@ use std::pin::Pin;
 #[cfg(windows)]
 use {
     async_std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle},
-    io_extras::os::windows::{AsRawHandleOrSocket, IntoRawHandleOrSocket, RawHandleOrSocket},
+    io_extras::os::windows::{
+        AsHandleOrSocket, AsRawHandleOrSocket, BorrowedHandleOrSocket, IntoRawHandleOrSocket,
+        OwnedHandleOrSocket, RawHandleOrSocket,
+    },
 };
 
 /// A reference to an open file on a filesystem.
@@ -263,6 +266,14 @@ impl AsRawHandleOrSocket for File {
     }
 }
 
+#[cfg(windows)]
+impl AsHandleOrSocket for File {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        self.std.as_handle_or_socket()
+    }
+}
+
 #[cfg(not(windows))]
 impl IntoRawFd for File {
     #[inline]
@@ -300,6 +311,14 @@ impl IntoRawHandleOrSocket for File {
     #[inline]
     fn into_raw_handle_or_socket(self) -> RawHandleOrSocket {
         self.std.into_raw_handle_or_socket()
+    }
+}
+
+#[cfg(windows)]
+impl From<File> for OwnedHandleOrSocket {
+    #[inline]
+    fn from(file: File) -> Self {
+        file.std.into()
     }
 }
 

--- a/cap-async-std/src/fs_utf8/dir.rs
+++ b/cap-async-std/src/fs_utf8/dir.rs
@@ -16,7 +16,10 @@ use {
 #[cfg(windows)]
 use {
     async_std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle},
-    io_extras::os::windows::{AsRawHandleOrSocket, IntoRawHandleOrSocket, RawHandleOrSocket},
+    io_extras::os::windows::{
+        AsHandleOrSocket, AsRawHandleOrSocket, BorrowedHandleOrSocket, IntoRawHandleOrSocket,
+        OwnedHandleOrSocket, RawHandleOrSocket,
+    },
 };
 
 /// A reference to an open directory on a filesystem.
@@ -705,6 +708,14 @@ impl AsHandle for Dir {
 }
 
 #[cfg(windows)]
+impl AsHandleOrSocket for Dir {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        self.cap_std.as_handle_or_socket()
+    }
+}
+
+#[cfg(windows)]
 impl AsRawHandleOrSocket for Dir {
     #[inline]
     fn as_raw_handle_or_socket(&self) -> RawHandleOrSocket {
@@ -749,6 +760,14 @@ impl IntoRawHandleOrSocket for Dir {
     #[inline]
     fn into_raw_handle_or_socket(self) -> RawHandleOrSocket {
         self.cap_std.into_raw_handle_or_socket()
+    }
+}
+
+#[cfg(windows)]
+impl From<Dir> for OwnedHandleOrSocket {
+    #[inline]
+    fn from(dir: Dir) -> Self {
+        dir.cap_std.into()
     }
 }
 

--- a/cap-async-std/src/fs_utf8/file.rs
+++ b/cap-async-std/src/fs_utf8/file.rs
@@ -18,7 +18,10 @@ use std::pin::Pin;
 #[cfg(windows)]
 use {
     async_std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle},
-    io_extras::os::windows::{AsRawHandleOrSocket, IntoRawHandleOrSocket, RawHandleOrSocket},
+    io_extras::os::windows::{
+        AsHandleOrSocket, AsRawHandleOrSocket, BorrowedHandleOrSocket, IntoRawHandleOrSocket,
+        OwnedHandleOrSocket, RawHandleOrSocket,
+    },
 };
 
 /// A reference to an open file on a filesystem.
@@ -226,6 +229,14 @@ impl AsRawHandleOrSocket for File {
     }
 }
 
+#[cfg(windows)]
+impl AsHandleOrSocket for File {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        self.cap_std.as_handle_or_socket()
+    }
+}
+
 #[cfg(not(windows))]
 impl IntoRawFd for File {
     #[inline]
@@ -263,6 +274,14 @@ impl IntoRawHandleOrSocket for File {
     #[inline]
     fn into_raw_handle_or_socket(self) -> RawHandleOrSocket {
         self.cap_std.into_raw_handle_or_socket()
+    }
+}
+
+#[cfg(windows)]
+impl From<File> for OwnedHandleOrSocket {
+    #[inline]
+    fn from(file: File) -> Self {
+        file.cap_std.into()
     }
 }
 

--- a/cap-async-std/src/fs_utf8/mod.rs
+++ b/cap-async-std/src/fs_utf8/mod.rs
@@ -56,7 +56,6 @@ fn from_utf8<'a>(path: &'a Utf8Path) -> std::io::Result<async_std::path::PathBuf
     Ok(path.into())
 }
 
-
 fn to_utf8<P: AsRef<async_std::path::Path>>(path: P) -> std::io::Result<Utf8PathBuf> {
     #[cfg(not(feature = "arf_strings"))]
     #[cfg(not(windows))]

--- a/cap-async-std/src/net/tcp_listener.rs
+++ b/cap-async-std/src/net/tcp_listener.rs
@@ -10,7 +10,10 @@ use std::fmt;
 #[cfg(windows)]
 use {
     async_std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket},
-    io_extras::os::windows::{AsRawHandleOrSocket, IntoRawHandleOrSocket, RawHandleOrSocket},
+    io_extras::os::windows::{
+        AsHandleOrSocket, AsRawHandleOrSocket, BorrowedHandleOrSocket, IntoRawHandleOrSocket,
+        OwnedHandleOrSocket, RawHandleOrSocket,
+    },
 };
 
 /// A TCP socket server, listening for connections.
@@ -153,6 +156,14 @@ impl AsRawHandleOrSocket for TcpListener {
     }
 }
 
+#[cfg(windows)]
+impl AsHandleOrSocket for TcpListener {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        self.std.as_handle_or_socket()
+    }
+}
+
 #[cfg(not(windows))]
 impl IntoRawFd for TcpListener {
     #[inline]
@@ -190,6 +201,14 @@ impl IntoRawHandleOrSocket for TcpListener {
     #[inline]
     fn into_raw_handle_or_socket(self) -> RawHandleOrSocket {
         self.std.into_raw_handle_or_socket()
+    }
+}
+
+#[cfg(windows)]
+impl From<TcpListener> for OwnedHandleOrSocket {
+    #[inline]
+    fn from(listener: TcpListener) -> Self {
+        listener.std.into()
     }
 }
 

--- a/cap-async-std/src/net/tcp_stream.rs
+++ b/cap-async-std/src/net/tcp_stream.rs
@@ -13,7 +13,10 @@ use std::pin::Pin;
 #[cfg(windows)]
 use {
     async_std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket},
-    io_extras::os::windows::{AsRawHandleOrSocket, IntoRawHandleOrSocket, RawHandleOrSocket},
+    io_extras::os::windows::{
+        AsHandleOrSocket, AsRawHandleOrSocket, BorrowedHandleOrSocket, IntoRawHandleOrSocket,
+        OwnedHandleOrSocket, RawHandleOrSocket,
+    },
 };
 
 /// A TCP stream between a local and a remote socket.
@@ -197,6 +200,14 @@ impl AsRawHandleOrSocket for TcpStream {
     }
 }
 
+#[cfg(windows)]
+impl AsHandleOrSocket for TcpStream {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        self.std.as_handle_or_socket()
+    }
+}
+
 #[cfg(not(windows))]
 impl IntoRawFd for TcpStream {
     #[inline]
@@ -234,6 +245,14 @@ impl IntoRawHandleOrSocket for TcpStream {
     #[inline]
     fn into_raw_handle_or_socket(self) -> RawHandleOrSocket {
         self.std.into_raw_handle_or_socket()
+    }
+}
+
+#[cfg(windows)]
+impl From<TcpStream> for OwnedHandleOrSocket {
+    #[inline]
+    fn from(stream: TcpStream) -> Self {
+        stream.std.into()
     }
 }
 

--- a/cap-async-std/src/net/udp_socket.rs
+++ b/cap-async-std/src/net/udp_socket.rs
@@ -10,7 +10,10 @@ use std::fmt;
 #[cfg(windows)]
 use {
     async_std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket},
-    io_extras::os::windows::{AsRawHandleOrSocket, IntoRawHandleOrSocket, RawHandleOrSocket},
+    io_extras::os::windows::{
+        AsHandleOrSocket, AsRawHandleOrSocket, BorrowedHandleOrSocket, IntoRawHandleOrSocket,
+        OwnedHandleOrSocket, RawHandleOrSocket,
+    },
 };
 
 /// A UDP socket.
@@ -298,6 +301,14 @@ impl AsRawHandleOrSocket for UdpSocket {
     }
 }
 
+#[cfg(windows)]
+impl AsHandleOrSocket for UdpSocket {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        self.std.as_handle_or_socket()
+    }
+}
+
 #[cfg(not(windows))]
 impl IntoRawFd for UdpSocket {
     #[inline]
@@ -335,6 +346,14 @@ impl IntoRawHandleOrSocket for UdpSocket {
     #[inline]
     fn into_raw_handle_or_socket(self) -> RawHandleOrSocket {
         self.std.into_raw_handle_or_socket()
+    }
+}
+
+#[cfg(windows)]
+impl From<UdpSocket> for OwnedHandleOrSocket {
+    #[inline]
+    fn from(socket: UdpSocket) -> Self {
+        socket.std.into()
     }
 }
 

--- a/cap-primitives/src/time/system_clock.rs
+++ b/cap-primitives/src/time/system_clock.rs
@@ -17,7 +17,7 @@ impl SystemClock {
     ///
     /// This corresponds to [`std::time::SystemTime::UNIX_EPOCH`].
     pub const UNIX_EPOCH: SystemTime = SystemTime {
-        std: time::SystemTime::UNIX_EPOCH
+        std: time::SystemTime::UNIX_EPOCH,
     };
 
     /// Constructs a new instance of `Self`.

--- a/cap-primitives/src/time/system_clock.rs
+++ b/cap-primitives/src/time/system_clock.rs
@@ -17,7 +17,7 @@ impl SystemClock {
     ///
     /// This corresponds to [`std::time::SystemTime::UNIX_EPOCH`].
     pub const UNIX_EPOCH: SystemTime = SystemTime {
-        std: time::SystemTime::UNIX_EPOCH,
+        std: time::SystemTime::UNIX_EPOCH
     };
 
     /// Constructs a new instance of `Self`.

--- a/cap-std/src/fs/dir.rs
+++ b/cap-std/src/fs/dir.rs
@@ -27,7 +27,10 @@ use {
 #[cfg(windows)]
 use {
     cap_primitives::fs::{symlink_dir, symlink_file},
-    io_extras::os::windows::{AsRawHandleOrSocket, IntoRawHandleOrSocket, RawHandleOrSocket},
+    io_extras::os::windows::{
+        AsHandleOrSocket, AsRawHandleOrSocket, BorrowedHandleOrSocket, IntoRawHandleOrSocket,
+        OwnedHandleOrSocket, RawHandleOrSocket,
+    },
     std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle},
 };
 
@@ -759,6 +762,14 @@ impl AsRawHandleOrSocket for Dir {
     }
 }
 
+#[cfg(windows)]
+impl AsHandleOrSocket for Dir {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        self.std_file.as_handle_or_socket()
+    }
+}
+
 #[cfg(not(windows))]
 impl IntoRawFd for Dir {
     #[inline]
@@ -796,6 +807,14 @@ impl IntoRawHandleOrSocket for Dir {
     #[inline]
     fn into_raw_handle_or_socket(self) -> RawHandleOrSocket {
         self.std_file.into_raw_handle_or_socket()
+    }
+}
+
+#[cfg(windows)]
+impl From<Dir> for OwnedHandleOrSocket {
+    #[inline]
+    fn from(dir: Dir) -> Self {
+        dir.std_file.into()
     }
 }
 

--- a/cap-std/src/fs/file.rs
+++ b/cap-std/src/fs/file.rs
@@ -12,7 +12,10 @@ use std::path::Path;
 use std::{fmt, fs, process};
 #[cfg(windows)]
 use {
-    io_extras::os::windows::{AsRawHandleOrSocket, IntoRawHandleOrSocket, RawHandleOrSocket},
+    io_extras::os::windows::{
+        AsHandleOrSocket, AsRawHandleOrSocket, BorrowedHandleOrSocket, IntoRawHandleOrSocket,
+        OwnedHandleOrSocket, RawHandleOrSocket,
+    },
     std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle},
 };
 
@@ -233,6 +236,14 @@ impl AsRawHandleOrSocket for File {
     }
 }
 
+#[cfg(windows)]
+impl AsHandleOrSocket for File {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        self.std.as_handle_or_socket()
+    }
+}
+
 #[cfg(not(windows))]
 impl IntoRawFd for File {
     #[inline]
@@ -270,6 +281,14 @@ impl IntoRawHandleOrSocket for File {
     #[inline]
     fn into_raw_handle_or_socket(self) -> RawHandleOrSocket {
         self.std.into_raw_handle_or_socket()
+    }
+}
+
+#[cfg(windows)]
+impl From<File> for OwnedHandleOrSocket {
+    #[inline]
+    fn from(file: File) -> Self {
+        file.std.into()
     }
 }
 

--- a/cap-std/src/fs_utf8/dir.rs
+++ b/cap-std/src/fs_utf8/dir.rs
@@ -13,7 +13,10 @@ use io_lifetimes::{AsHandle, BorrowedHandle, OwnedHandle};
 use std::{fmt, fs, io};
 #[cfg(windows)]
 use {
-    io_extras::os::windows::{AsRawHandleOrSocket, IntoRawHandleOrSocket, RawHandleOrSocket},
+    io_extras::os::windows::{
+        AsHandleOrSocket, AsRawHandleOrSocket, BorrowedHandleOrSocket, IntoRawHandleOrSocket,
+        OwnedHandleOrSocket, RawHandleOrSocket,
+    },
     std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle},
 };
 
@@ -698,6 +701,14 @@ impl AsRawHandleOrSocket for Dir {
     }
 }
 
+#[cfg(windows)]
+impl AsHandleOrSocket for Dir {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        self.cap_std.as_handle_or_socket()
+    }
+}
+
 #[cfg(not(windows))]
 impl IntoRawFd for Dir {
     #[inline]
@@ -735,6 +746,14 @@ impl IntoRawHandleOrSocket for Dir {
     #[inline]
     fn into_raw_handle_or_socket(self) -> RawHandleOrSocket {
         self.cap_std.into_raw_handle_or_socket()
+    }
+}
+
+#[cfg(windows)]
+impl From<Dir> for OwnedHandleOrSocket {
+    #[inline]
+    fn from(dir: Dir) -> Self {
+        dir.cap_std.into()
     }
 }
 

--- a/cap-std/src/fs_utf8/file.rs
+++ b/cap-std/src/fs_utf8/file.rs
@@ -14,7 +14,10 @@ use std::path::Path;
 use std::{fmt, fs, process};
 #[cfg(windows)]
 use {
-    io_extras::os::windows::{AsRawHandleOrSocket, IntoRawHandleOrSocket, RawHandleOrSocket},
+    io_extras::os::windows::{
+        AsHandleOrSocket, AsRawHandleOrSocket, BorrowedHandleOrSocket, IntoRawHandleOrSocket,
+        OwnedHandleOrSocket, RawHandleOrSocket,
+    },
     std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle},
 };
 
@@ -232,6 +235,14 @@ impl AsRawHandleOrSocket for File {
     }
 }
 
+#[cfg(windows)]
+impl AsHandleOrSocket for File {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        self.cap_std.as_handle_or_socket()
+    }
+}
+
 #[cfg(not(windows))]
 impl IntoRawFd for File {
     #[inline]
@@ -269,6 +280,14 @@ impl IntoRawHandleOrSocket for File {
     #[inline]
     fn into_raw_handle_or_socket(self) -> RawHandleOrSocket {
         self.cap_std.into_raw_handle_or_socket()
+    }
+}
+
+#[cfg(windows)]
+impl From<File> for OwnedHandleOrSocket {
+    #[inline]
+    fn from(file: File) -> Self {
+        file.cap_std.into()
     }
 }
 

--- a/cap-std/src/net/tcp_listener.rs
+++ b/cap-std/src/net/tcp_listener.rs
@@ -8,7 +8,10 @@ use io_lifetimes::{AsSocket, BorrowedSocket, OwnedSocket};
 use std::{fmt, io, net};
 #[cfg(windows)]
 use {
-    io_extras::os::windows::{AsRawHandleOrSocket, IntoRawHandleOrSocket, RawHandleOrSocket},
+    io_extras::os::windows::{
+        AsHandleOrSocket, AsRawHandleOrSocket, BorrowedHandleOrSocket, IntoRawHandleOrSocket,
+        OwnedHandleOrSocket, RawHandleOrSocket,
+    },
     std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket},
 };
 
@@ -182,6 +185,14 @@ impl AsRawHandleOrSocket for TcpListener {
     }
 }
 
+#[cfg(windows)]
+impl AsHandleOrSocket for TcpListener {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        self.std.as_handle_or_socket()
+    }
+}
+
 #[cfg(not(windows))]
 impl IntoRawFd for TcpListener {
     #[inline]
@@ -219,6 +230,14 @@ impl IntoRawHandleOrSocket for TcpListener {
     #[inline]
     fn into_raw_handle_or_socket(self) -> RawHandleOrSocket {
         self.std.into_raw_handle_or_socket()
+    }
+}
+
+#[cfg(windows)]
+impl From<TcpListener> for OwnedHandleOrSocket {
+    #[inline]
+    fn from(listener: TcpListener) -> Self {
+        listener.std.into()
     }
 }
 

--- a/cap-std/src/net/tcp_stream.rs
+++ b/cap-std/src/net/tcp_stream.rs
@@ -10,7 +10,10 @@ use std::time::Duration;
 use std::{fmt, net};
 #[cfg(windows)]
 use {
-    io_extras::os::windows::{AsRawHandleOrSocket, IntoRawHandleOrSocket, RawHandleOrSocket},
+    io_extras::os::windows::{
+        AsHandleOrSocket, AsRawHandleOrSocket, BorrowedHandleOrSocket, IntoRawHandleOrSocket,
+        OwnedHandleOrSocket, RawHandleOrSocket,
+    },
     std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket},
 };
 
@@ -237,6 +240,14 @@ impl AsRawHandleOrSocket for TcpStream {
     }
 }
 
+#[cfg(windows)]
+impl AsHandleOrSocket for TcpStream {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        self.std.as_handle_or_socket()
+    }
+}
+
 #[cfg(not(windows))]
 impl IntoRawFd for TcpStream {
     #[inline]
@@ -274,6 +285,14 @@ impl IntoRawHandleOrSocket for TcpStream {
     #[inline]
     fn into_raw_handle_or_socket(self) -> RawHandleOrSocket {
         self.std.into_raw_handle_or_socket()
+    }
+}
+
+#[cfg(windows)]
+impl From<TcpStream> for OwnedHandleOrSocket {
+    #[inline]
+    fn from(stream: TcpStream) -> Self {
+        stream.std.into()
     }
 }
 

--- a/cap-std/src/net/udp_socket.rs
+++ b/cap-std/src/net/udp_socket.rs
@@ -9,7 +9,10 @@ use std::time::Duration;
 use std::{fmt, io, net};
 #[cfg(windows)]
 use {
-    io_extras::os::windows::{AsRawHandleOrSocket, IntoRawHandleOrSocket, RawHandleOrSocket},
+    io_extras::os::windows::{
+        AsHandleOrSocket, AsRawHandleOrSocket, BorrowedHandleOrSocket, IntoRawHandleOrSocket,
+        OwnedHandleOrSocket, RawHandleOrSocket,
+    },
     std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket},
 };
 
@@ -352,6 +355,14 @@ impl AsRawHandleOrSocket for UdpSocket {
     }
 }
 
+#[cfg(windows)]
+impl AsHandleOrSocket for UdpSocket {
+    #[inline]
+    fn as_handle_or_socket(&self) -> BorrowedHandleOrSocket<'_> {
+        self.std.as_handle_or_socket()
+    }
+}
+
 #[cfg(not(windows))]
 impl IntoRawFd for UdpSocket {
     #[inline]
@@ -389,6 +400,14 @@ impl IntoRawHandleOrSocket for UdpSocket {
     #[inline]
     fn into_raw_handle_or_socket(self) -> RawHandleOrSocket {
         self.std.into_raw_handle_or_socket()
+    }
+}
+
+#[cfg(windows)]
+impl From<UdpSocket> for OwnedHandleOrSocket {
+    #[inline]
+    fn from(socket: UdpSocket) -> Self {
+        socket.std.into()
     }
 }
 


### PR DESCRIPTION
Implement `AsHandleOrSocket` and `From<OwnedHandleOrSocket>` for types that implement `AsRawHandleOrSocket` and `IntoRawHandleOrSocket`.
