### PR TITLE
Port `dir_metadata` to `fs_utf8` and `cap-async-std`.

### DIFF
--- a/cap-async-std/src/fs/file.rs
+++ b/cap-async-std/src/fs/file.rs
@@ -88,9 +88,10 @@ impl File {
     ///
     /// This corresponds to [`async_std::fs::File::metadata`].
     #[inline]
-    pub fn metadata(&self) -> io::Result<Metadata> {
-        let sync = self.std.as_filelike_view::<std::fs::File>();
-        metadata_from(&*sync)
+    pub async fn metadata(&self) -> io::Result<Metadata> {
+        let clone = self.clone();
+        let sync = clone.std.as_filelike_view::<std::fs::File>();
+        spawn_blocking(move || metadata_from(&*sync)).await
     }
 
     // async_std doesn't have `try_clone`.

--- a/cap-async-std/src/fs_utf8/dir.rs
+++ b/cap-async-std/src/fs_utf8/dir.rs
@@ -619,10 +619,7 @@ impl Dir {
     ///
     /// This function accesses a directory outside of the `self` subtree.
     #[inline]
-    pub async fn open_parent_dir<P: AsRef<Utf8Path>>(
-        &self,
-        ambient_authority: AmbientAuthority,
-    ) -> io::Result<Self> {
+    pub async fn open_parent_dir(&self, ambient_authority: AmbientAuthority) -> io::Result<Self> {
         self.cap_std
             .open_parent_dir(ambient_authority)
             .await

--- a/cap-async-std/src/fs_utf8/dir.rs
+++ b/cap-async-std/src/fs_utf8/dir.rs
@@ -201,6 +201,15 @@ impl Dir {
         self.cap_std.metadata(path).await
     }
 
+    /// Queries metadata about the underlying directory.
+    ///
+    /// This is similar to [`std::fs::File::metadata`], but for `Dir` rather
+    /// than for `File`.
+    #[inline]
+    pub async fn dir_metadata(&self) -> io::Result<Metadata> {
+        self.cap_std.dir_metadata().await
+    }
+
     /// Returns an iterator over the entries within `self`.
     #[inline]
     pub async fn entries(&self) -> io::Result<ReadDir> {

--- a/cap-async-std/src/fs_utf8/file.rs
+++ b/cap-async-std/src/fs_utf8/file.rs
@@ -92,8 +92,9 @@ impl File {
     ///
     /// This corresponds to [`async_std::fs::File::metadata`].
     #[inline]
-    pub fn metadata(&self) -> io::Result<Metadata> {
-        self.cap_std.metadata()
+    pub async fn metadata(&self) -> io::Result<Metadata> {
+        let clone = self.clone();
+        spawn_blocking(move || clone.metadata()).await
     }
 
     // async_std doesn't have `try_clone`.

--- a/cap-std/src/fs/dir.rs
+++ b/cap-std/src/fs/dir.rs
@@ -241,7 +241,7 @@ impl Dir {
     /// This corresponds to [`std::fs::metadata`], but only accesses paths
     /// relative to `self`.
     #[inline]
-    pub fn metadata<P: AsRef<Path>>(&self, path: P) -> io::Result<cap_primitives::fs::Metadata> {
+    pub fn metadata<P: AsRef<Path>>(&self, path: P) -> io::Result<Metadata> {
         stat(&self.std_file, path.as_ref(), FollowSymlinks::Yes)
     }
 

--- a/cap-std/src/fs_utf8/dir.rs
+++ b/cap-std/src/fs_utf8/dir.rs
@@ -191,6 +191,15 @@ impl Dir {
         self.cap_std.metadata(path)
     }
 
+    /// Queries metadata about the underlying directory.
+    ///
+    /// This is similar to [`std::fs::File::metadata`], but for `Dir` rather
+    /// than for `File`.
+    #[inline]
+    pub fn dir_metadata(&self) -> io::Result<Metadata> {
+        self.cap_std.dir_metadata()
+    }
+
     /// Returns an iterator over the entries within `self`.
     #[inline]
     pub fn entries(&self) -> io::Result<ReadDir> {

--- a/cap-std/src/fs_utf8/dir.rs
+++ b/cap-std/src/fs_utf8/dir.rs
@@ -604,10 +604,7 @@ impl Dir {
     ///
     /// This function accesses a directory outside of the `self` subtree.
     #[inline]
-    pub fn open_parent_dir<P: AsRef<Utf8Path>>(
-        &self,
-        ambient_authority: AmbientAuthority,
-    ) -> io::Result<Self> {
+    pub fn open_parent_dir(&self, ambient_authority: AmbientAuthority) -> io::Result<Self> {
         self.cap_std
             .open_parent_dir(ambient_authority)
             .map(Self::from_cap_std)


### PR DESCRIPTION
The `dir_metadata` on `Dir` wasn't defined for the `fs_utf8` version of `Dir`; add it.

Also, port it to cap-async-std's `Dir` types. cap-async-std is currently disabled, but keep it current as we can.