### PR TITLE
Use the `NtCreateFile` path for implementing `stat` on Windows.

### DIFF
--- a/cap-primitives/src/windows/fs/create_file_at_w.rs
+++ b/cap-primitives/src/windows/fs/create_file_at_w.rs
@@ -66,6 +66,10 @@ const FILE_ATTRIBUTE_VALID_FLAGS: FILE_FLAGS_AND_ATTRIBUTES = FILE_ATTRIBUTE_EA
 
 /// Like Windows' `CreateFileW`, but takes a `dir` argument to use as the
 /// root directory.
+///
+/// Also, the `lpfilename` is a Rust slice instead of a C-style NUL-terminated
+/// array, because that's what our callers have and it's closer to what
+/// `NtCreatePath` takes.
 #[allow(non_snake_case)]
 pub unsafe fn CreateFileAtW(
     dir: HANDLE,

--- a/cap-primitives/src/windows/fs/open_unchecked.rs
+++ b/cap-primitives/src/windows/fs/open_unchecked.rs
@@ -95,7 +95,10 @@ fn open_at(start: &fs::File, path: &Path, opts: &OpenOptions) -> io::Result<fs::
     // own `CreateFileAtW` so that it does the requisite magic for absolute
     // paths.
     if dir == 0 {
+        // We're calling the windows-sys `CreateFileW` which expects a
+        // NUL-terminated filename, so add a NUL terminator.
         wide.push(0);
+
         let handle = unsafe {
             CreateFileW(
                 wide.as_ptr(),
@@ -113,6 +116,9 @@ fn open_at(start: &fs::File, path: &Path, opts: &OpenOptions) -> io::Result<fs::
             Err(io::Error::last_os_error())
         }
     } else {
+        // Our own `CreateFileAtW` is similar to `CreateFileW` except it
+        // takes the filename as a Rust slice directly, so we can skip
+        // the NUL terminator.
         let handle = unsafe {
             CreateFileAtW(
                 dir,

--- a/cap-primitives/src/windows/fs/stat_unchecked.rs
+++ b/cap-primitives/src/windows/fs/stat_unchecked.rs
@@ -1,16 +1,12 @@
-#[cfg(windows_by_handle)]
-use super::get_path::concatenate;
 use crate::fs::{FollowSymlinks, Metadata};
 use std::path::Path;
 use std::{fs, io};
-#[cfg(not(windows_by_handle))]
-use windows_sys::Win32::Storage::FileSystem::{
-    FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
-};
-#[cfg(not(windows_by_handle))]
 use {
     crate::fs::{open_unchecked, OpenOptions},
     std::os::windows::fs::OpenOptionsExt,
+    windows_sys::Win32::Storage::FileSystem::{
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+    },
 };
 
 /// *Unsandboxed* function similar to `stat`, but which does not perform
@@ -20,35 +16,24 @@ pub(crate) fn stat_unchecked(
     path: &Path,
     follow: FollowSymlinks,
 ) -> io::Result<Metadata> {
-    // When we have `windows_by_handle`, we just call `fs::metadata` etc. and it
-    // has everything.
-    #[cfg(windows_by_handle)]
-    {
-        let full_path = concatenate(start, path)?;
-        match follow {
-            FollowSymlinks::Yes => fs::metadata(full_path),
-            FollowSymlinks::No => fs::symlink_metadata(full_path),
+    // Attempt to open the file to get the metadata that way, as that gives
+    // us all the info.
+    let mut opts = OpenOptions::new();
+
+    // Explicitly request no access, because we're just querying metadata.
+    opts.access_mode(0);
+
+    match follow {
+        FollowSymlinks::Yes => {
+            opts.custom_flags(FILE_FLAG_BACKUP_SEMANTICS);
+            opts.follow(FollowSymlinks::Yes);
         }
-        .map(Metadata::from_just_metadata)
+        FollowSymlinks::No => {
+            opts.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS);
+            opts.follow(FollowSymlinks::No);
+        }
     }
 
-    // Otherwise, attempt to open the file to get the metadata that way, as
-    // that gives us all the info.
-    #[cfg(not(windows_by_handle))]
-    {
-        let mut opts = OpenOptions::new();
-        opts.access_mode(0);
-        match follow {
-            FollowSymlinks::Yes => {
-                opts.custom_flags(FILE_FLAG_BACKUP_SEMANTICS);
-                opts.follow(FollowSymlinks::Yes);
-            }
-            FollowSymlinks::No => {
-                opts.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS);
-                opts.follow(FollowSymlinks::No);
-            }
-        }
-        let file = open_unchecked(start, path, &opts)?;
-        Metadata::from_file(&file)
-    }
+    let file = open_unchecked(start, path, &opts)?;
+    Metadata::from_file(&file)
 }


### PR DESCRIPTION
Always use `open_unchecked` with no access for implementing `stat` on Windows, as that now uses the new `NtCreateFile` path.