### PR TITLE
FreeBSD RESOLVE_BENEATH support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@
 task:
   name: stable x86_64-unknown-freebsd-13
   freebsd_instance:
-    image_family: freebsd-13-0-snap
+    image_family: freebsd-13-2
   setup_script:
     - pkg install -y curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh
@@ -18,7 +18,7 @@ task:
 task:
   name: stable x86_64-unknown-freebsd-12
   freebsd_instance:
-    image_family: freebsd-12-1
+    image_family: freebsd-12-4
   setup_script:
     - pkg install -y curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh

--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ utilize [`openat2`], [`O_PATH`], and [`/proc/self/fd`] (though only when /proc
 is mounted, it's really `procfs`, and there are no mounts on top of it) for
 fast path resolution as well.
 
+On FreeBSD 13.0 and newer, `cap-std` uses [`openat(O_RESOLVE_BENEATH)`] to
+implement `Dir::open` with a single system call in common cases.
+Several other operations internally utilize `AT_RESOLVE_BENEATH` and `O_PATH` for
+fast path resolution as well.
+
 Otherwise, `cap-std` opens each component of a path individually, in order to
 specially handle `..` and symlinks. The algorithm is carefully designed to
 minimize system calls, so opening `red/green/blue` performs just 5 system
@@ -177,6 +182,7 @@ and `green`.
 [`openat2`]: https://lwn.net/Articles/796868/
 [`O_PATH`]: https://man7.org/linux/man-pages/man2/open.2.html
 [`/proc/self/fd`]: https://man7.org/linux/man-pages/man5/proc.5.html
+[`openat(O_RESOLVE_BENEATH)`]: https://man.freebsd.org/cgi/man.cgi?openat
 
 ## What about networking?
 

--- a/cap-primitives/src/fs/manually/mod.rs
+++ b/cap-primitives/src/fs/manually/mod.rs
@@ -5,7 +5,7 @@ mod canonical_path;
 mod canonicalize;
 mod cow_component;
 mod open;
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_os = "freebsd")))]
 mod open_entry;
 mod read_link_one;
 
@@ -19,5 +19,5 @@ pub(super) use canonicalize::canonicalize_with;
 
 pub(crate) use canonicalize::canonicalize;
 pub(crate) use open::{open, stat};
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_os = "freebsd")))]
 pub(crate) use open_entry::open_entry;

--- a/cap-primitives/src/fs/manually/open.rs
+++ b/cap-primitives/src/fs/manually/open.rs
@@ -6,7 +6,7 @@ use crate::fs::{
     dir_options, errors, open_unchecked, path_has_trailing_dot, path_has_trailing_slash,
     stat_unchecked, FollowSymlinks, MaybeOwnedFile, Metadata, OpenOptions, OpenUncheckedError,
 };
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "freebsd"))]
 use rustix::fs::OFlags;
 use std::borrow::Cow;
 use std::ffi::OsStr;
@@ -247,7 +247,7 @@ impl<'start> Context<'start> {
             Ok(file) => {
                 // Emulate `O_PATH` + `FollowSymlinks::Yes` on Linux. If `file`
                 // is a symlink, follow it.
-                #[cfg(any(target_os = "android", target_os = "linux"))]
+                #[cfg(any(target_os = "android", target_os = "linux", target_os = "freebsd"))]
                 if should_emulate_o_path(&use_options) {
                     match read_link_one(
                         &file,
@@ -527,7 +527,7 @@ pub(crate) fn stat(start: &fs::File, path: &Path, follow: FollowSymlinks) -> io:
 
 /// Test whether the given options imply that we should treat an open file as
 /// potentially being a symlink we need to follow, due to use of `O_PATH`.
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "freebsd"))]
 fn should_emulate_o_path(use_options: &OpenOptions) -> bool {
     (use_options.ext.custom_flags & (OFlags::PATH.bits() as i32)) == (OFlags::PATH.bits() as i32)
         && use_options.follow == FollowSymlinks::Yes

--- a/cap-primitives/src/fs/maybe_owned_file.rs
+++ b/cap-primitives/src/fs/maybe_owned_file.rs
@@ -120,7 +120,7 @@ impl<'borrow> MaybeOwnedFile<'borrow> {
     }
 
     /// Assuming `self` holds an owned `File`, return it.
-    #[cfg_attr(windows, allow(dead_code))]
+    #[cfg_attr(any(windows, target_os = "freebsd"), allow(dead_code))]
     pub(super) fn unwrap_owned(self) -> fs::File {
         match self.inner {
             MaybeOwned::Owned(file) => file,

--- a/cap-primitives/src/rustix/freebsd/fs/check.rs
+++ b/cap-primitives/src/rustix/freebsd/fs/check.rs
@@ -1,0 +1,26 @@
+use rustix::fs::{statat, AtFlags};
+use std::fs;
+use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
+
+static WORKING: AtomicBool = AtomicBool::new(false);
+static CHECKED: AtomicBool = AtomicBool::new(false);
+
+#[inline]
+pub(crate) fn beneath_supported(start: &fs::File) -> bool {
+    if WORKING.load(Relaxed) {
+        return true;
+    }
+    if CHECKED.load(Relaxed) {
+        return false;
+    }
+    // Unknown O_ flags get ignored but AT_ flags have strict checks, so we use that.
+    if let Err(rustix::io::Errno::INVAL) =
+        statat(start, "", AtFlags::EMPTY_PATH | AtFlags::RESOLVE_BENEATH)
+    {
+        CHECKED.store(true, Relaxed);
+        false
+    } else {
+        WORKING.store(true, Relaxed);
+        true
+    }
+}

--- a/cap-primitives/src/rustix/freebsd/fs/mod.rs
+++ b/cap-primitives/src/rustix/freebsd/fs/mod.rs
@@ -1,0 +1,18 @@
+mod check;
+mod open_entry_impl;
+mod open_impl;
+mod remove_dir_impl;
+mod remove_file_impl;
+mod set_permissions_impl;
+mod set_times_impl;
+mod stat_impl;
+
+pub(crate) use crate::fs::manually::canonicalize as canonicalize_impl;
+pub(crate) use check::beneath_supported;
+pub(crate) use open_entry_impl::open_entry_impl;
+pub(crate) use open_impl::open_impl;
+pub(crate) use remove_dir_impl::remove_dir_impl;
+pub(crate) use remove_file_impl::remove_file_impl;
+pub(crate) use set_permissions_impl::set_permissions_impl;
+pub(crate) use set_times_impl::{set_times_impl, set_times_nofollow_impl};
+pub(crate) use stat_impl::stat_impl;

--- a/cap-primitives/src/rustix/freebsd/fs/open_entry_impl.rs
+++ b/cap-primitives/src/rustix/freebsd/fs/open_entry_impl.rs
@@ -1,0 +1,12 @@
+use crate::fs::{open_impl, OpenOptions};
+use std::ffi::OsStr;
+use std::{fs, io};
+
+#[inline(always)]
+pub(crate) fn open_entry_impl(
+    start: &fs::File,
+    path: &OsStr,
+    options: &OpenOptions,
+) -> io::Result<fs::File> {
+    open_impl(start, path.as_ref(), options)
+}

--- a/cap-primitives/src/rustix/freebsd/fs/open_impl.rs
+++ b/cap-primitives/src/rustix/freebsd/fs/open_impl.rs
@@ -1,0 +1,30 @@
+use super::super::super::fs::compute_oflags;
+use crate::fs::{errors, manually, OpenOptions};
+use io_lifetimes::FromFd;
+use rustix::fs::{openat, Mode, OFlags, RawMode};
+use std::path::Path;
+use std::{fs, io};
+
+pub(crate) fn open_impl(
+    start: &fs::File,
+    path: &Path,
+    options: &OpenOptions,
+) -> io::Result<fs::File> {
+    if !super::beneath_supported(start) {
+        return manually::open(start, path, options);
+    }
+
+    let oflags = compute_oflags(options)? | OFlags::RESOLVE_BENEATH;
+
+    let mode = if oflags.contains(OFlags::CREATE) {
+        Mode::from_bits((options.ext.mode & 0o7777) as RawMode).unwrap()
+    } else {
+        Mode::empty()
+    };
+
+    match openat(start, path, oflags, mode) {
+        Ok(file) => Ok(fs::File::from_into_fd(file)),
+        Err(rustix::io::Errno::NOTCAPABLE) => Err(errors::escape_attempt()),
+        Err(err) => Err(err.into()),
+    }
+}

--- a/cap-primitives/src/rustix/freebsd/fs/remove_dir_impl.rs
+++ b/cap-primitives/src/rustix/freebsd/fs/remove_dir_impl.rs
@@ -1,0 +1,16 @@
+use crate::fs::via_parent;
+use rustix::fs::{unlinkat, AtFlags};
+use std::path::Path;
+use std::{fs, io};
+
+pub(crate) fn remove_dir_impl(start: &fs::File, path: &Path) -> io::Result<()> {
+    if !super::beneath_supported(start) {
+        return via_parent::remove_dir(start, path);
+    }
+
+    Ok(unlinkat(
+        start,
+        path,
+        AtFlags::RESOLVE_BENEATH | AtFlags::REMOVEDIR,
+    )?)
+}

--- a/cap-primitives/src/rustix/freebsd/fs/remove_file_impl.rs
+++ b/cap-primitives/src/rustix/freebsd/fs/remove_file_impl.rs
@@ -1,0 +1,12 @@
+use crate::fs::via_parent;
+use rustix::fs::{unlinkat, AtFlags};
+use std::path::Path;
+use std::{fs, io};
+
+pub(crate) fn remove_file_impl(start: &fs::File, path: &Path) -> io::Result<()> {
+    if !super::beneath_supported(start) {
+        return via_parent::remove_file(start, path);
+    }
+
+    Ok(unlinkat(start, path, AtFlags::RESOLVE_BENEATH)?)
+}

--- a/cap-primitives/src/rustix/freebsd/fs/set_permissions_impl.rs
+++ b/cap-primitives/src/rustix/freebsd/fs/set_permissions_impl.rs
@@ -1,0 +1,22 @@
+use crate::fs::Permissions;
+use rustix::fs::{chmodat, AtFlags, Mode};
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::{fs, io};
+
+pub(crate) fn set_permissions_impl(
+    start: &fs::File,
+    path: &Path,
+    perm: Permissions,
+) -> io::Result<()> {
+    if !super::beneath_supported(start) {
+        return super::super::super::fs::set_permissions_manually(start, path, perm);
+    }
+
+    Ok(chmodat(
+        start,
+        path,
+        Mode::from_raw_mode(perm.mode() as _),
+        AtFlags::RESOLVE_BENEATH,
+    )?)
+}

--- a/cap-primitives/src/rustix/freebsd/fs/set_times_impl.rs
+++ b/cap-primitives/src/rustix/freebsd/fs/set_times_impl.rs
@@ -1,0 +1,45 @@
+use crate::fs::{to_timespec, via_parent, SystemTimeSpec};
+use rustix::fs::{utimensat, AtFlags, Timestamps};
+use std::path::Path;
+use std::{fs, io};
+
+pub(crate) fn set_times_impl(
+    start: &fs::File,
+    path: &Path,
+    atime: Option<SystemTimeSpec>,
+    mtime: Option<SystemTimeSpec>,
+) -> io::Result<()> {
+    if !super::beneath_supported(start) {
+        return super::super::super::fs::set_times_manually(start, path, atime, mtime);
+    }
+
+    let times = Timestamps {
+        last_access: to_timespec(atime)?,
+        last_modification: to_timespec(mtime)?,
+    };
+
+    Ok(utimensat(start, path, &times, AtFlags::RESOLVE_BENEATH)?)
+}
+
+pub(crate) fn set_times_nofollow_impl(
+    start: &fs::File,
+    path: &Path,
+    atime: Option<SystemTimeSpec>,
+    mtime: Option<SystemTimeSpec>,
+) -> io::Result<()> {
+    if !super::beneath_supported(start) {
+        return via_parent::set_times_nofollow(start, path, atime, mtime);
+    }
+
+    let times = Timestamps {
+        last_access: to_timespec(atime)?,
+        last_modification: to_timespec(mtime)?,
+    };
+
+    Ok(utimensat(
+        start,
+        path,
+        &times,
+        AtFlags::RESOLVE_BENEATH | AtFlags::SYMLINK_NOFOLLOW,
+    )?)
+}

--- a/cap-primitives/src/rustix/freebsd/fs/stat_impl.rs
+++ b/cap-primitives/src/rustix/freebsd/fs/stat_impl.rs
@@ -1,0 +1,22 @@
+use crate::fs::{manually, FollowSymlinks, Metadata, MetadataExt};
+use rustix::fs::{statat, AtFlags};
+use std::path::Path;
+use std::{fs, io};
+
+pub(crate) fn stat_impl(
+    start: &fs::File,
+    path: &Path,
+    follow: FollowSymlinks,
+) -> io::Result<Metadata> {
+    if !super::beneath_supported(start) {
+        return manually::stat(start, path, follow);
+    }
+
+    let flags = AtFlags::RESOLVE_BENEATH
+        | if follow == FollowSymlinks::Yes {
+            AtFlags::empty()
+        } else {
+            AtFlags::SYMLINK_NOFOLLOW
+        };
+    Ok(MetadataExt::from_rustix(statat(start, path, flags)?))
+}

--- a/cap-primitives/src/rustix/freebsd/mod.rs
+++ b/cap-primitives/src/rustix/freebsd/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod fs;

--- a/cap-primitives/src/rustix/fs/dir_utils.rs
+++ b/cap-primitives/src/rustix/fs/dir_utils.rs
@@ -127,6 +127,7 @@ pub(crate) const fn target_o_path() -> OFlags {
     #[cfg(any(
         target_os = "android",
         target_os = "emscripten",
+        target_os = "freebsd",
         target_os = "fuchsia",
         target_os = "linux",
         target_os = "redox",
@@ -137,7 +138,6 @@ pub(crate) const fn target_o_path() -> OFlags {
 
     #[cfg(any(
         target_os = "dragonfly",
-        target_os = "freebsd",
         target_os = "ios",
         target_os = "macos",
         target_os = "netbsd",

--- a/cap-primitives/src/rustix/fs/times.rs
+++ b/cap-primitives/src/rustix/fs/times.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use std::{fs, io};
 
 #[allow(clippy::useless_conversion)]
-fn to_timespec(ft: Option<SystemTimeSpec>) -> io::Result<Timespec> {
+pub(crate) fn to_timespec(ft: Option<SystemTimeSpec>) -> io::Result<Timespec> {
     Ok(match ft {
         None => Timespec {
             tv_sec: 0,
@@ -33,6 +33,7 @@ fn to_timespec(ft: Option<SystemTimeSpec>) -> io::Result<Timespec> {
     })
 }
 
+#[allow(dead_code)]
 pub(crate) fn set_times_nofollow_unchecked(
     start: &fs::File,
     path: &Path,

--- a/cap-primitives/src/rustix/mod.rs
+++ b/cap-primitives/src/rustix/mod.rs
@@ -5,5 +5,7 @@ pub(crate) mod fs;
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 mod darwin;
+#[cfg(target_os = "freebsd")]
+mod freebsd;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod linux;

--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -454,33 +454,16 @@ fn check_dot_access() {
     check!(tmpdir.metadata("dir/"));
     check!(tmpdir.metadata("dir//"));
 
-    #[cfg(not(target_os = "freebsd"))]
-    {
-        assert!(tmpdir.metadata("dir/.").is_err());
-        assert!(tmpdir.metadata("dir/./").is_err());
-        assert!(tmpdir.metadata("dir/.//").is_err());
-        assert!(tmpdir.metadata("dir/./.").is_err());
-        assert!(tmpdir.metadata("dir/.//.").is_err());
-        assert!(tmpdir.metadata("dir/..").is_err());
-        assert!(tmpdir.metadata("dir/../").is_err());
-        assert!(tmpdir.metadata("dir/..//").is_err());
-        assert!(tmpdir.metadata("dir/../.").is_err());
-        assert!(tmpdir.metadata("dir/..//.").is_err());
-    }
-
-    #[cfg(target_os = "freebsd")]
-    {
-        assert!(tmpdir.metadata("dir/.").is_ok());
-        assert!(tmpdir.metadata("dir/./").is_ok());
-        assert!(tmpdir.metadata("dir/.//").is_ok());
-        assert!(tmpdir.metadata("dir/./.").is_ok());
-        assert!(tmpdir.metadata("dir/.//.").is_ok());
-        assert!(tmpdir.metadata("dir/..").is_ok());
-        assert!(tmpdir.metadata("dir/../").is_ok());
-        assert!(tmpdir.metadata("dir/..//").is_ok());
-        assert!(tmpdir.metadata("dir/../.").is_ok());
-        assert!(tmpdir.metadata("dir/..//.").is_ok());
-    }
+    assert!(tmpdir.metadata("dir/.").is_err());
+    assert!(tmpdir.metadata("dir/./").is_err());
+    assert!(tmpdir.metadata("dir/.//").is_err());
+    assert!(tmpdir.metadata("dir/./.").is_err());
+    assert!(tmpdir.metadata("dir/.//.").is_err());
+    assert!(tmpdir.metadata("dir/..").is_err());
+    assert!(tmpdir.metadata("dir/../").is_err());
+    assert!(tmpdir.metadata("dir/..//").is_err());
+    assert!(tmpdir.metadata("dir/../.").is_err());
+    assert!(tmpdir.metadata("dir/..//.").is_err());
 }
 
 /// This test is the same as `check_dot_access` but uses `std::fs`'
@@ -503,33 +486,16 @@ fn check_dot_access_ambient() {
     check!(fs::metadata(dir.path().join("dir/")));
     check!(fs::metadata(dir.path().join("dir//")));
 
-    #[cfg(not(target_os = "freebsd"))]
-    {
-        assert!(fs::metadata(dir.path().join("dir/.")).is_err());
-        assert!(fs::metadata(dir.path().join("dir/./")).is_err());
-        assert!(fs::metadata(dir.path().join("dir/.//")).is_err());
-        assert!(fs::metadata(dir.path().join("dir/./.")).is_err());
-        assert!(fs::metadata(dir.path().join("dir/.//.")).is_err());
-        assert!(fs::metadata(dir.path().join("dir/..")).is_err());
-        assert!(fs::metadata(dir.path().join("dir/../")).is_err());
-        assert!(fs::metadata(dir.path().join("dir/..//")).is_err());
-        assert!(fs::metadata(dir.path().join("dir/../.")).is_err());
-        assert!(fs::metadata(dir.path().join("dir/..//.")).is_err());
-    }
-
-    #[cfg(target_os = "freebsd")]
-    {
-        assert!(fs::metadata(dir.path().join("dir/.")).is_ok());
-        assert!(fs::metadata(dir.path().join("dir/./")).is_ok());
-        assert!(fs::metadata(dir.path().join("dir/.//")).is_ok());
-        assert!(fs::metadata(dir.path().join("dir/./.")).is_ok());
-        assert!(fs::metadata(dir.path().join("dir/.//.")).is_ok());
-        assert!(fs::metadata(dir.path().join("dir/..")).is_ok());
-        assert!(fs::metadata(dir.path().join("dir/../")).is_ok());
-        assert!(fs::metadata(dir.path().join("dir/..//")).is_ok());
-        assert!(fs::metadata(dir.path().join("dir/../.")).is_ok());
-        assert!(fs::metadata(dir.path().join("dir/..//.")).is_ok());
-    }
+    assert!(fs::metadata(dir.path().join("dir/.")).is_err());
+    assert!(fs::metadata(dir.path().join("dir/./")).is_err());
+    assert!(fs::metadata(dir.path().join("dir/.//")).is_err());
+    assert!(fs::metadata(dir.path().join("dir/./.")).is_err());
+    assert!(fs::metadata(dir.path().join("dir/.//.")).is_err());
+    assert!(fs::metadata(dir.path().join("dir/..")).is_err());
+    assert!(fs::metadata(dir.path().join("dir/../")).is_err());
+    assert!(fs::metadata(dir.path().join("dir/..//")).is_err());
+    assert!(fs::metadata(dir.path().join("dir/../.")).is_err());
+    assert!(fs::metadata(dir.path().join("dir/..//.")).is_err());
 }
 
 // Windows allows one to open "file/." and "file/.." and similar, however it
@@ -689,17 +655,13 @@ fn dir_unsearchable_unreadable() {
     // below confirming this.
     if cfg!(any(
         target_os = "android",
+        target_os = "freebsd",
         target_os = "linux",
         target_os = "redox",
     )) {
         let dir = check!(tmpdir.open_dir("dir"));
         assert!(dir.entries().is_err());
         assert!(dir.open_dir(".").is_err());
-    } else if cfg!(target_os = "freebsd") {
-        let dir = check!(tmpdir.open_dir("dir"));
-        check!(dir.metadata("."));
-        check!(dir.entries());
-        check!(dir.open_dir("."));
     } else {
         assert!(tmpdir.open_dir("dir").is_err());
     }
@@ -719,19 +681,15 @@ fn dir_unsearchable_unreadable_ambient() {
     options.mode(0o000);
     check!(options.create(dir.path().join("dir")));
 
-    // FreeBSD seems able to open directories with 0o000 permissions.
     if cfg!(any(
         target_os = "android",
         target_os = "linux",
+        target_os = "freebsd",
         target_os = "redox",
     )) {
         assert!(std::fs::File::open(dir.path().join("dir")).is_err());
         assert!(std::fs::read_dir(dir.path().join("dir")).is_err());
         assert!(std::fs::File::open(dir.path().join("dir/.")).is_err());
-    } else if cfg!(target_os = "freebsd") {
-        check!(std::fs::File::open(dir.path().join("dir")));
-        check!(std::fs::read_dir(dir.path().join("dir")));
-        check!(std::fs::File::open(dir.path().join("dir/.")));
     }
 }
 


### PR DESCRIPTION
wheeeee! Overall the code is pretty simple but `rustix::fs` is getting a bit messier.

- the support check I've implemented simply by probing `AT_RESOLVE_BENEATH` support because it seems the simplest, I don't want to copy version parsing code from the Android thing…
  - we technically could also support older FreeBSD versions in capability mode by checking that, even if `AT_RESOLVE_BENEATH` is not a thing, `openat(fd, "/")` results in `ENOTCAPABLE`, but this would also require making the `AT_RESOLVE_BENEATH` flag conditional on the result, the detection state would be like an [atomic enum](https://github.com/brain0/atomic_enum) `Unknown | FullSupport | OldSandboxed | NoSupport` and aghhhh old versions aren't worth it at all
- `linkat` could be supported too, but it only sandboxes `fd1`, i.e. `linkat(fd1, "../one", fd2, "two")` is rejected, but `linkat(fd1, "one", fd2, "../two")` just does it, so `via_parent::open_parent` would need to be used on the target, and that's currently `pub(super)` along with the `MaybeOwnedFd` type and everything :/
  - that escape wasn't getting caught by the tests when I tried to just use an implementation without doing that! I hope the test suite don't miss other possible escapes
- yeah, `openat(openat(AT_FDCWD, "/"), "..")` does not return an error because we're already at the root and going `..` doesn't actually escape anything, we're still at the root, haha

Waiting for: https://github.com/bytecodealliance/rustix/pull/541