### PR TITLE
Give ambient authority arguments names.

### DIFF
--- a/cap-directories/src/project_dirs.rs
+++ b/cap-directories/src/project_dirs.rs
@@ -34,8 +34,9 @@ impl ProjectDirs {
         qualifier: &str,
         organization: &str,
         application: &str,
-        _: AmbientAuthority,
+        ambient_authority: AmbientAuthority,
     ) -> Option<Self> {
+        let _ = ambient_authority;
         let inner = directories_next::ProjectDirs::from(qualifier, organization, application)?;
         Some(Self { inner })
     }

--- a/cap-primitives/src/net/pool.rs
+++ b/cap-primitives/src/net/pool.rs
@@ -51,7 +51,14 @@ impl Pool {
     /// # Ambient Authority
     ///
     /// This function allows ambient access to any IP address.
-    pub fn insert_ip_net(&mut self, ip_net: ipnet::IpNet, port: u16, _: AmbientAuthority) {
+    pub fn insert_ip_net(
+        &mut self,
+        ip_net: ipnet::IpNet,
+        port: u16,
+        ambient_authority: AmbientAuthority,
+    ) {
+        let _ = ambient_authority;
+
         self.grants.push(IpGrant {
             set: AddrSet::Net(ip_net),
             port,
@@ -63,7 +70,13 @@ impl Pool {
     /// # Ambient Authority
     ///
     /// This function allows ambient access to any IP address.
-    pub fn insert_socket_addr(&mut self, addr: net::SocketAddr, _: AmbientAuthority) {
+    pub fn insert_socket_addr(
+        &mut self,
+        addr: net::SocketAddr,
+        ambient_authority: AmbientAuthority,
+    ) {
+        let _ = ambient_authority;
+
         self.grants.push(IpGrant {
             set: AddrSet::Net(addr.ip().into()),
             port: addr.port(),

--- a/cap-primitives/src/rustix/fs/dir_utils.rs
+++ b/cap-primitives/src/rustix/fs/dir_utils.rs
@@ -102,7 +102,12 @@ pub(crate) fn canonicalize_options() -> OpenOptions {
 ///
 /// This function is not sandboxed and may trivially access any path that the
 /// host process has access to.
-pub(crate) fn open_ambient_dir_impl(path: &Path, _: AmbientAuthority) -> io::Result<fs::File> {
+pub(crate) fn open_ambient_dir_impl(
+    path: &Path,
+    ambient_authority: AmbientAuthority,
+) -> io::Result<fs::File> {
+    let _ = ambient_authority;
+
     let mut options = fs::OpenOptions::new();
     options.read(true);
 

--- a/cap-primitives/src/time/monotonic_clock.rs
+++ b/cap-primitives/src/time/monotonic_clock.rs
@@ -17,7 +17,8 @@ impl MonotonicClock {
     ///
     /// This uses ambient authority to accesses clocks.
     #[inline]
-    pub const fn new(_: AmbientAuthority) -> Self {
+    pub const fn new(ambient_authority: AmbientAuthority) -> Self {
+        let _ = ambient_authority;
         Self(())
     }
 

--- a/cap-primitives/src/time/system_clock.rs
+++ b/cap-primitives/src/time/system_clock.rs
@@ -26,7 +26,8 @@ impl SystemClock {
     ///
     /// This uses ambient authority to accesses clocks.
     #[inline]
-    pub const fn new(_: AmbientAuthority) -> Self {
+    pub const fn new(ambient_authority: AmbientAuthority) -> Self {
+        let _ = ambient_authority;
         Self(())
     }
 

--- a/cap-primitives/src/windows/fs/dir_utils.rs
+++ b/cap-primitives/src/windows/fs/dir_utils.rs
@@ -92,7 +92,12 @@ pub(crate) fn canonicalize_options() -> OpenOptions {
 ///
 /// This function is not sandboxed and may trivially access any path that the
 /// host process has access to.
-pub(crate) fn open_ambient_dir_impl(path: &Path, _: AmbientAuthority) -> io::Result<fs::File> {
+pub(crate) fn open_ambient_dir_impl(
+    path: &Path,
+    ambient_authority: AmbientAuthority,
+) -> io::Result<fs::File> {
+    let _ = ambient_authority;
+
     // Set `FILE_FLAG_BACKUP_SEMANTICS` so that we can open directories. Unset
     // `FILE_SHARE_DELETE` so that directories can't be renamed or deleted
     // underneath us, since we use paths to implement many directory operations.

--- a/cap-rand/src/lib.rs
+++ b/cap-rand/src/lib.rs
@@ -74,7 +74,8 @@ pub mod rngs {
         /// This function makes use of ambient authority to access the platform
         /// entropy source.
         #[inline]
-        pub const fn default(_: AmbientAuthority) -> Self {
+        pub const fn default(ambient_authority: AmbientAuthority) -> Self {
+            let _ = ambient_authority;
             Self(())
         }
     }
@@ -161,7 +162,8 @@ pub mod rngs {
 /// This function makes use of ambient authority to access the platform entropy
 /// source.
 #[inline]
-pub fn thread_rng(_: AmbientAuthority) -> rngs::CapRng {
+pub fn thread_rng(ambient_authority: AmbientAuthority) -> rngs::CapRng {
+    let _ = ambient_authority;
     rngs::CapRng {
         inner: rand::thread_rng(),
     }
@@ -176,7 +178,8 @@ pub fn thread_rng(_: AmbientAuthority) -> rngs::CapRng {
 /// This function makes use of ambient authority to access the platform entropy
 /// source.
 #[inline]
-pub fn std_rng_from_entropy(_: AmbientAuthority) -> rngs::StdRng {
+pub fn std_rng_from_entropy(ambient_authority: AmbientAuthority) -> rngs::StdRng {
+    let _ = ambient_authority;
     rand::rngs::StdRng::from_entropy()
 }
 
@@ -189,9 +192,10 @@ pub fn std_rng_from_entropy(_: AmbientAuthority) -> rngs::StdRng {
 /// This function makes use of ambient authority to access the platform entropy
 /// source.
 #[inline]
-pub fn random<T>(_: AmbientAuthority) -> T
+pub fn random<T>(ambient_authority: AmbientAuthority) -> T
 where
     crate::distributions::Standard: crate::distributions::Distribution<T>,
 {
+    let _ = ambient_authority;
     rand::random()
 }


### PR DESCRIPTION
Use `let _ = ambient_authority;` to suppress unused argument warnings rather than naming arguments `_`, because argument names show up in the documentation, and the fact that these arguments are unused is not part of the public interface.