### PR TITLE
Add a `Pool::insert_ip_net_any_port` function.

### DIFF
--- a/cap-async-std/src/net/pool.rs
+++ b/cap-async-std/src/net/pool.rs
@@ -20,6 +20,18 @@ impl Pool {
         }
     }
 
+    /// Add a range of network addresses to the pool.
+    ///
+    /// Unlike `insert_ip_net`, this function grants access to any requested
+    /// port.
+    ///
+    /// # Ambient Authority
+    ///
+    /// This function allows ambient access to any IP address.
+    pub fn insert_ip_net_any_port(&mut self, ip_net: ipnet::IpNet, ambient_authority: AmbientAuthority) {
+        self.cap.insert_ip_net_any_port(ip_net, ambient_authority)
+    }
+
     /// Add a range of network addresses with a specific port to the pool.
     ///
     /// # Ambient Authority

--- a/cap-async-std/src/net/pool.rs
+++ b/cap-async-std/src/net/pool.rs
@@ -20,7 +20,7 @@ impl Pool {
         }
     }
 
-    /// Add a range of network addresses to the pool.
+    /// Add a range of network addresses, accepting any port, to the pool.
     ///
     /// Unlike `insert_ip_net`, this function grants access to any requested
     /// port.
@@ -28,8 +28,26 @@ impl Pool {
     /// # Ambient Authority
     ///
     /// This function allows ambient access to any IP address.
-    pub fn insert_ip_net_any_port(&mut self, ip_net: ipnet::IpNet, ambient_authority: AmbientAuthority) {
-        self.cap.insert_ip_net_any_port(ip_net, ambient_authority)
+    pub fn insert_ip_net_port_any(&mut self, ip_net: ipnet::IpNet, ambient_authority: AmbientAuthority) {
+        self.cap.insert_ip_net_port_any(ip_net, ambient_authority)
+    }
+
+    /// Add a range of network addresses, accepting a range of ports, to the pool.
+    ///
+    /// This grants access to the port range starting at `ports_start` and,
+    /// if `ports_end` is provided, ending before `ports_end`.
+    ///
+    /// # Ambient Authority
+    ///
+    /// This function allows ambient access to any IP address.
+    pub fn insert_ip_net_port_range(
+        &mut self,
+        ip_net: ipnet::IpNet,
+        ports_start: u16,
+        ports_end: Option<u16>,
+        ambient_authority: AmbientAuthority,
+    ) {
+        self.cap.insert_ip_net_port_range(ip_net, ports_start, ports_end, ambient_authority)
     }
 
     /// Add a range of network addresses with a specific port to the pool.

--- a/cap-std/src/net/pool.rs
+++ b/cap-std/src/net/pool.rs
@@ -21,6 +21,22 @@ impl Pool {
         }
     }
 
+    /// Add a range of network addresses to the pool.
+    ///
+    /// Unlike `insert_ip_net`, this function grants access to any requested
+    /// port.
+    ///
+    /// # Ambient Authority
+    ///
+    /// This function allows ambient access to any IP address.
+    pub fn insert_ip_net_any_port(
+        &mut self,
+        ip_net: ipnet::IpNet,
+        ambient_authority: AmbientAuthority,
+    ) {
+        self.cap.insert_ip_net_any_port(ip_net, ambient_authority)
+    }
+
     /// Add a range of network addresses with a specific port to the pool.
     ///
     /// # AmbientAuthority

--- a/cap-std/src/net/pool.rs
+++ b/cap-std/src/net/pool.rs
@@ -21,7 +21,7 @@ impl Pool {
         }
     }
 
-    /// Add a range of network addresses to the pool.
+    /// Add a range of network addresses, accepting any port, to the pool.
     ///
     /// Unlike `insert_ip_net`, this function grants access to any requested
     /// port.
@@ -29,12 +29,31 @@ impl Pool {
     /// # Ambient Authority
     ///
     /// This function allows ambient access to any IP address.
-    pub fn insert_ip_net_any_port(
+    pub fn insert_ip_net_port_any(
         &mut self,
         ip_net: ipnet::IpNet,
         ambient_authority: AmbientAuthority,
     ) {
-        self.cap.insert_ip_net_any_port(ip_net, ambient_authority)
+        self.cap.insert_ip_net_port_any(ip_net, ambient_authority)
+    }
+
+    /// Add a range of network addresses, accepting a range of ports, to the pool.
+    ///
+    /// This grants access to the port range starting at `ports_start` and,
+    /// if `ports_end` is provided, ending before `ports_end`.
+    ///
+    /// # Ambient Authority
+    ///
+    /// This function allows ambient access to any IP address.
+    pub fn insert_ip_net_port_range(
+        &mut self,
+        ip_net: ipnet::IpNet,
+        ports_start: u16,
+        ports_end: Option<u16>,
+        ambient_authority: AmbientAuthority,
+    ) {
+        self.cap
+            .insert_ip_net_port_range(ip_net, ports_start, ports_end, ambient_authority)
     }
 
     /// Add a range of network addresses with a specific port to the pool.


### PR DESCRIPTION
Add a function to `Pool` to allow inserting a network that can accept any port.