### PR TITLE
Backport changes to a new 1.x release branch.

### DIFF
--- a/cap-async-std/src/fs/mod.rs
+++ b/cap-async-std/src/fs/mod.rs
@@ -1,4 +1,4 @@
-//! A capability-based filesystem API modeled after `async_std::fs`.
+//! A capability-based filesystem API modeled after [`async_std::fs`].
 //!
 //! This corresponds to [`async_std::fs`].
 //!

--- a/cap-async-std/src/lib.rs
+++ b/cap-async-std/src/lib.rs
@@ -1,4 +1,4 @@
-//! A capability-based API modeled after `async_std`.
+//! A capability-based API modeled after [`async_std`].
 //!
 //! This corresponds to [`async_std`].
 //!

--- a/cap-async-std/src/net/mod.rs
+++ b/cap-async-std/src/net/mod.rs
@@ -1,4 +1,4 @@
-//! A capability-based network API modeled after `async_std::net`.
+//! A capability-based network API modeled after [`async_std::net`].
 //!
 //! This corresponds to [`async_std::net`].
 //!

--- a/cap-async-std/src/net/pool.rs
+++ b/cap-async-std/src/net/pool.rs
@@ -20,6 +20,36 @@ impl Pool {
         }
     }
 
+    /// Add a range of network addresses, accepting any port, to the pool.
+    ///
+    /// Unlike `insert_ip_net`, this function grants access to any requested
+    /// port.
+    ///
+    /// # Ambient Authority
+    ///
+    /// This function allows ambient access to any IP address.
+    pub fn insert_ip_net_port_any(&mut self, ip_net: ipnet::IpNet, ambient_authority: AmbientAuthority) {
+        self.cap.insert_ip_net_port_any(ip_net, ambient_authority)
+    }
+
+    /// Add a range of network addresses, accepting a range of ports, to the pool.
+    ///
+    /// This grants access to the port range starting at `ports_start` and,
+    /// if `ports_end` is provided, ending before `ports_end`.
+    ///
+    /// # Ambient Authority
+    ///
+    /// This function allows ambient access to any IP address.
+    pub fn insert_ip_net_port_range(
+        &mut self,
+        ip_net: ipnet::IpNet,
+        ports_start: u16,
+        ports_end: Option<u16>,
+        ambient_authority: AmbientAuthority,
+    ) {
+        self.cap.insert_ip_net_port_range(ip_net, ports_start, ports_end, ambient_authority)
+    }
+
     /// Add a range of network addresses with a specific port to the pool.
     ///
     /// # Ambient Authority

--- a/cap-async-std/src/time/mod.rs
+++ b/cap-async-std/src/time/mod.rs
@@ -1,4 +1,4 @@
-//! A capability-based clock API modeled after `std::time`.
+//! A capability-based clock API modeled after [`std::time`].
 //!
 //! This corresponds to [`std::time`].
 //!

--- a/cap-directories/src/project_dirs.rs
+++ b/cap-directories/src/project_dirs.rs
@@ -34,8 +34,9 @@ impl ProjectDirs {
         qualifier: &str,
         organization: &str,
         application: &str,
-        _: AmbientAuthority,
+        ambient_authority: AmbientAuthority,
     ) -> Option<Self> {
+        let _ = ambient_authority;
         let inner = directories_next::ProjectDirs::from(qualifier, organization, application)?;
         Some(Self { inner })
     }

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -33,7 +33,10 @@ winx = "0.35.0"
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.45.0"
 features = [
-    "Win32_Storage_FileSystem",
     "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Kernel",
     "Win32_System_SystemServices",
+    "Win32_System_WindowsProgramming",
 ]

--- a/cap-primitives/src/fs/maybe_owned_file.rs
+++ b/cap-primitives/src/fs/maybe_owned_file.rs
@@ -106,6 +106,7 @@ impl<'borrow> MaybeOwnedFile<'borrow> {
 
     /// Produce an owned `File`. This uses `open` on "." if needed to convert a
     /// borrowed `File` to an owned one.
+    #[cfg_attr(windows, allow(dead_code))]
     pub(super) fn into_file(self, options: &OpenOptions) -> io::Result<fs::File> {
         match self.inner {
             MaybeOwned::Owned(file) => Ok(file),

--- a/cap-primitives/src/net/pool.rs
+++ b/cap-primitives/src/net/pool.rs
@@ -51,7 +51,14 @@ impl Pool {
     /// # Ambient Authority
     ///
     /// This function allows ambient access to any IP address.
-    pub fn insert_ip_net(&mut self, ip_net: ipnet::IpNet, port: u16, _: AmbientAuthority) {
+    pub fn insert_ip_net(
+        &mut self,
+        ip_net: ipnet::IpNet,
+        port: u16,
+        ambient_authority: AmbientAuthority,
+    ) {
+        let _ = ambient_authority;
+
         self.grants.push(IpGrant {
             set: AddrSet::Net(ip_net),
             port,
@@ -63,7 +70,13 @@ impl Pool {
     /// # Ambient Authority
     ///
     /// This function allows ambient access to any IP address.
-    pub fn insert_socket_addr(&mut self, addr: net::SocketAddr, _: AmbientAuthority) {
+    pub fn insert_socket_addr(
+        &mut self,
+        addr: net::SocketAddr,
+        ambient_authority: AmbientAuthority,
+    ) {
+        let _ = ambient_authority;
+
         self.grants.push(IpGrant {
             set: AddrSet::Net(addr.ip().into()),
             port: addr.port(),

--- a/cap-primitives/src/net/pool.rs
+++ b/cap-primitives/src/net/pool.rs
@@ -1,5 +1,9 @@
-use ambient_authority::AmbientAuthority;
+#[cfg(test)]
+use crate::ambient_authority;
+use crate::AmbientAuthority;
 use ipnet::IpNet;
+#[cfg(test)]
+use std::str::FromStr;
 use std::{io, net};
 
 // TODO: Perhaps we should have our own version of `ToSocketAddrs` which
@@ -21,12 +25,27 @@ impl AddrSet {
 #[derive(Clone)]
 struct IpGrant {
     set: AddrSet,
-    port: u16, // TODO: IANA port names, TODO: range
+    ports_start: u16,
+    ports_end: Option<u16>,
 }
 
 impl IpGrant {
     fn contains(&self, addr: &net::SocketAddr) -> bool {
-        self.set.contains(addr.ip()) && addr.port() == self.port
+        if !self.set.contains(addr.ip()) {
+            return false;
+        }
+
+        let port = addr.port();
+        if port < self.ports_start {
+            return false;
+        }
+        if let Some(ports_end) = self.ports_end {
+            if port >= ports_end {
+                return false;
+            }
+        }
+
+        true
     }
 }
 
@@ -46,6 +65,43 @@ impl Pool {
         Self { grants: Vec::new() }
     }
 
+    /// Add a range of network addresses, accepting any port, to the pool.
+    ///
+    /// # Ambient Authority
+    ///
+    /// This function allows ambient access to any IP address.
+    pub fn insert_ip_net_port_any(
+        &mut self,
+        ip_net: ipnet::IpNet,
+        ambient_authority: AmbientAuthority,
+    ) {
+        self.insert_ip_net_port_range(ip_net, 0, None, ambient_authority)
+    }
+
+    /// Add a range of network addresses, accepting a range of ports, to the pool.
+    ///
+    /// This grants access to the port range starting at `ports_start` and,
+    /// if `ports_end` is provided, ending before `ports_end`.
+    ///
+    /// # Ambient Authority
+    ///
+    /// This function allows ambient access to any IP address.
+    pub fn insert_ip_net_port_range(
+        &mut self,
+        ip_net: ipnet::IpNet,
+        ports_start: u16,
+        ports_end: Option<u16>,
+        ambient_authority: AmbientAuthority,
+    ) {
+        let _ = ambient_authority;
+
+        self.grants.push(IpGrant {
+            set: AddrSet::Net(ip_net),
+            ports_start,
+            ports_end,
+        })
+    }
+
     /// Add a range of network addresses with a specific port to the pool.
     ///
     /// # Ambient Authority
@@ -57,12 +113,7 @@ impl Pool {
         port: u16,
         ambient_authority: AmbientAuthority,
     ) {
-        let _ = ambient_authority;
-
-        self.grants.push(IpGrant {
-            set: AddrSet::Net(ip_net),
-            port,
-        })
+        self.insert_ip_net_port_range(ip_net, port, port.checked_add(1), ambient_authority)
     }
 
     /// Add a specific [`net::SocketAddr`] to the pool.
@@ -75,12 +126,7 @@ impl Pool {
         addr: net::SocketAddr,
         ambient_authority: AmbientAuthority,
     ) {
-        let _ = ambient_authority;
-
-        self.grants.push(IpGrant {
-            set: AddrSet::Net(addr.ip().into()),
-            port: addr.port(),
-        })
+        self.insert_ip_net(addr.ip().into(), addr.port(), ambient_authority)
     }
 
     /// Check whether the given address is within the pool.
@@ -98,3 +144,82 @@ impl Pool {
 
 /// An empty array of `SocketAddr`s.
 pub const NO_SOCKET_ADDRS: &[net::SocketAddr] = &[];
+
+#[test]
+fn test_empty() {
+    let p = Pool::new();
+
+    p.check_addr(&net::SocketAddr::from_str("[::1]:0").unwrap())
+        .unwrap_err();
+    p.check_addr(&net::SocketAddr::from_str("[::1]:1023").unwrap())
+        .unwrap_err();
+    p.check_addr(&net::SocketAddr::from_str("[::1]:1024").unwrap())
+        .unwrap_err();
+    p.check_addr(&net::SocketAddr::from_str("[::1]:8080").unwrap())
+        .unwrap_err();
+    p.check_addr(&net::SocketAddr::from_str("[::1]:65535").unwrap())
+        .unwrap_err();
+}
+
+#[test]
+fn test_port_any() {
+    let mut p = Pool::new();
+    p.insert_ip_net_port_any(
+        IpNet::new(net::IpAddr::V6(net::Ipv6Addr::LOCALHOST), 48).unwrap(),
+        ambient_authority(),
+    );
+
+    p.check_addr(&net::SocketAddr::from_str("[::1]:0").unwrap())
+        .unwrap();
+    p.check_addr(&net::SocketAddr::from_str("[::1]:1023").unwrap())
+        .unwrap();
+    p.check_addr(&net::SocketAddr::from_str("[::1]:1024").unwrap())
+        .unwrap();
+    p.check_addr(&net::SocketAddr::from_str("[::1]:8080").unwrap())
+        .unwrap();
+    p.check_addr(&net::SocketAddr::from_str("[::1]:65535").unwrap())
+        .unwrap();
+}
+
+#[test]
+fn test_port_range() {
+    let mut p = Pool::new();
+    p.insert_ip_net_port_range(
+        IpNet::new(net::IpAddr::V6(net::Ipv6Addr::LOCALHOST), 48).unwrap(),
+        1024,
+        Some(9000),
+        ambient_authority(),
+    );
+
+    p.check_addr(&net::SocketAddr::from_str("[::1]:0").unwrap())
+        .unwrap_err();
+    p.check_addr(&net::SocketAddr::from_str("[::1]:1023").unwrap())
+        .unwrap_err();
+    p.check_addr(&net::SocketAddr::from_str("[::1]:1024").unwrap())
+        .unwrap();
+    p.check_addr(&net::SocketAddr::from_str("[::1]:8080").unwrap())
+        .unwrap();
+    p.check_addr(&net::SocketAddr::from_str("[::1]:65535").unwrap())
+        .unwrap_err();
+}
+
+#[test]
+fn test_port_one() {
+    let mut p = Pool::new();
+    p.insert_ip_net(
+        IpNet::new(net::IpAddr::V6(net::Ipv6Addr::LOCALHOST), 48).unwrap(),
+        8080,
+        ambient_authority(),
+    );
+
+    p.check_addr(&net::SocketAddr::from_str("[::1]:0").unwrap())
+        .unwrap_err();
+    p.check_addr(&net::SocketAddr::from_str("[::1]:1023").unwrap())
+        .unwrap_err();
+    p.check_addr(&net::SocketAddr::from_str("[::1]:1024").unwrap())
+        .unwrap_err();
+    p.check_addr(&net::SocketAddr::from_str("[::1]:8080").unwrap())
+        .unwrap();
+    p.check_addr(&net::SocketAddr::from_str("[::1]:65535").unwrap())
+        .unwrap_err();
+}

--- a/cap-primitives/src/rustix/fs/dir_utils.rs
+++ b/cap-primitives/src/rustix/fs/dir_utils.rs
@@ -102,7 +102,12 @@ pub(crate) fn canonicalize_options() -> OpenOptions {
 ///
 /// This function is not sandboxed and may trivially access any path that the
 /// host process has access to.
-pub(crate) fn open_ambient_dir_impl(path: &Path, _: AmbientAuthority) -> io::Result<fs::File> {
+pub(crate) fn open_ambient_dir_impl(
+    path: &Path,
+    ambient_authority: AmbientAuthority,
+) -> io::Result<fs::File> {
+    let _ = ambient_authority;
+
     let mut options = fs::OpenOptions::new();
     options.read(true);
 

--- a/cap-primitives/src/time/monotonic_clock.rs
+++ b/cap-primitives/src/time/monotonic_clock.rs
@@ -17,7 +17,8 @@ impl MonotonicClock {
     ///
     /// This uses ambient authority to accesses clocks.
     #[inline]
-    pub const fn new(_: AmbientAuthority) -> Self {
+    pub const fn new(ambient_authority: AmbientAuthority) -> Self {
+        let _ = ambient_authority;
         Self(())
     }
 

--- a/cap-primitives/src/time/system_clock.rs
+++ b/cap-primitives/src/time/system_clock.rs
@@ -26,7 +26,8 @@ impl SystemClock {
     ///
     /// This uses ambient authority to accesses clocks.
     #[inline]
-    pub const fn new(_: AmbientAuthority) -> Self {
+    pub const fn new(ambient_authority: AmbientAuthority) -> Self {
+        let _ = ambient_authority;
         Self(())
     }
 

--- a/cap-primitives/src/windows/fs/create_file_at_w.rs
+++ b/cap-primitives/src/windows/fs/create_file_at_w.rs
@@ -1,0 +1,270 @@
+#![allow(unsafe_code)]
+
+use std::convert::TryInto;
+use std::mem;
+use std::os::windows::io::HandleOrInvalid;
+use std::ptr::null_mut;
+use windows_sys::Win32::Foundation::{
+    RtlNtStatusToDosError, SetLastError, ERROR_ALREADY_EXISTS, ERROR_FILE_EXISTS,
+    ERROR_INVALID_NAME, ERROR_INVALID_PARAMETER, ERROR_NOT_SUPPORTED, HANDLE, INVALID_HANDLE_VALUE,
+    STATUS_OBJECT_NAME_COLLISION, STATUS_PENDING, STATUS_SUCCESS, SUCCESS, UNICODE_STRING,
+};
+use windows_sys::Win32::Security::{
+    SECURITY_ATTRIBUTES, SECURITY_DYNAMIC_TRACKING, SECURITY_QUALITY_OF_SERVICE,
+    SECURITY_STATIC_TRACKING,
+};
+use windows_sys::Win32::Storage::FileSystem::{
+    NtCreateFile, CREATE_ALWAYS, CREATE_NEW, DELETE, FILE_ACCESS_FLAGS, FILE_ATTRIBUTE_ARCHIVE,
+    FILE_ATTRIBUTE_COMPRESSED, FILE_ATTRIBUTE_DEVICE, FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_EA,
+    FILE_ATTRIBUTE_ENCRYPTED, FILE_ATTRIBUTE_HIDDEN, FILE_ATTRIBUTE_INTEGRITY_STREAM,
+    FILE_ATTRIBUTE_NORMAL, FILE_ATTRIBUTE_NOT_CONTENT_INDEXED, FILE_ATTRIBUTE_NO_SCRUB_DATA,
+    FILE_ATTRIBUTE_OFFLINE, FILE_ATTRIBUTE_PINNED, FILE_ATTRIBUTE_READONLY,
+    FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS, FILE_ATTRIBUTE_RECALL_ON_OPEN,
+    FILE_ATTRIBUTE_REPARSE_POINT, FILE_ATTRIBUTE_SPARSE_FILE, FILE_ATTRIBUTE_SYSTEM,
+    FILE_ATTRIBUTE_TEMPORARY, FILE_ATTRIBUTE_UNPINNED, FILE_ATTRIBUTE_VIRTUAL, FILE_CREATE,
+    FILE_CREATION_DISPOSITION, FILE_FLAGS_AND_ATTRIBUTES, FILE_FLAG_BACKUP_SEMANTICS,
+    FILE_FLAG_DELETE_ON_CLOSE, FILE_FLAG_NO_BUFFERING, FILE_FLAG_OPEN_NO_RECALL,
+    FILE_FLAG_OPEN_REPARSE_POINT, FILE_FLAG_OVERLAPPED, FILE_FLAG_POSIX_SEMANTICS,
+    FILE_FLAG_RANDOM_ACCESS, FILE_FLAG_SEQUENTIAL_SCAN, FILE_FLAG_SESSION_AWARE,
+    FILE_FLAG_WRITE_THROUGH, FILE_OPEN, FILE_OPEN_IF, FILE_OVERWRITE, FILE_OVERWRITE_IF,
+    FILE_READ_ATTRIBUTES, FILE_SHARE_MODE, OPEN_ALWAYS, OPEN_EXISTING, SECURITY_CONTEXT_TRACKING,
+    SECURITY_EFFECTIVE_ONLY, SECURITY_SQOS_PRESENT, SYNCHRONIZE, TRUNCATE_EXISTING,
+};
+use windows_sys::Win32::System::Kernel::{OBJ_CASE_INSENSITIVE, OBJ_INHERIT};
+use windows_sys::Win32::System::SystemServices::{GENERIC_ALL, GENERIC_READ, GENERIC_WRITE};
+use windows_sys::Win32::System::WindowsProgramming::{
+    FILE_DELETE_ON_CLOSE, FILE_NON_DIRECTORY_FILE, FILE_NO_INTERMEDIATE_BUFFERING, FILE_OPENED,
+    FILE_OPEN_FOR_BACKUP_INTENT, FILE_OPEN_NO_RECALL, FILE_OPEN_REMOTE_INSTANCE,
+    FILE_OPEN_REPARSE_POINT, FILE_OVERWRITTEN, FILE_RANDOM_ACCESS, FILE_SEQUENTIAL_ONLY,
+    FILE_SYNCHRONOUS_IO_NONALERT, FILE_WRITE_THROUGH, IO_STATUS_BLOCK, OBJECT_ATTRIBUTES,
+};
+
+// All currently known `FILE_ATTRIBUTE_*` constants, according to
+// windows-sys' documentation.
+const FILE_ATTRIBUTE_VALID_FLAGS: FILE_FLAGS_AND_ATTRIBUTES = FILE_ATTRIBUTE_EA
+    | FILE_ATTRIBUTE_DEVICE
+    | FILE_ATTRIBUTE_HIDDEN
+    | FILE_ATTRIBUTE_NORMAL
+    | FILE_ATTRIBUTE_PINNED
+    | FILE_ATTRIBUTE_SYSTEM
+    | FILE_ATTRIBUTE_ARCHIVE
+    | FILE_ATTRIBUTE_OFFLINE
+    | FILE_ATTRIBUTE_VIRTUAL
+    | FILE_ATTRIBUTE_READONLY
+    | FILE_ATTRIBUTE_UNPINNED
+    | FILE_ATTRIBUTE_DIRECTORY
+    | FILE_ATTRIBUTE_ENCRYPTED
+    | FILE_ATTRIBUTE_TEMPORARY
+    | FILE_ATTRIBUTE_COMPRESSED
+    | FILE_ATTRIBUTE_SPARSE_FILE
+    | FILE_ATTRIBUTE_NO_SCRUB_DATA
+    | FILE_ATTRIBUTE_REPARSE_POINT
+    | FILE_ATTRIBUTE_RECALL_ON_OPEN
+    | FILE_ATTRIBUTE_INTEGRITY_STREAM
+    | FILE_ATTRIBUTE_NOT_CONTENT_INDEXED
+    | FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS;
+
+/// Like Windows' `CreateFileW`, but takes a `dir` argument to use as the
+/// root directory.
+#[allow(non_snake_case)]
+pub unsafe fn CreateFileAtW(
+    dir: HANDLE,
+    lpfilename: &[u16],
+    dwdesiredaccess: FILE_ACCESS_FLAGS,
+    dwsharemode: FILE_SHARE_MODE,
+    lpsecurityattributes: *const SECURITY_ATTRIBUTES,
+    dwcreationdisposition: FILE_CREATION_DISPOSITION,
+    dwflagsandattributes: FILE_FLAGS_AND_ATTRIBUTES,
+    htemplatefile: HANDLE,
+) -> HandleOrInvalid {
+    // Absolute paths are not yet implemented here.
+    //
+    // It seems like `NtCreatePath` needs the apparently NT-internal `\??\`
+    // prefix prepended to absolute paths. It's possible it needs other
+    // path transforms as well. `RtlDosPathNameToNtPathName_U` may be a
+    // function that does these things, though it's not available in
+    // windows-sys and not documented, though one can find
+    // [unofficial blog posts], though even they say things like "I`m
+    // sorry that I cannot give more details on these functions".
+    //
+    // [unofficial blog posts]: https://mecanik.dev/en/posts/convert-dos-and-nt-paths-using-rtl-functions/
+    assert!(dir != 0);
+
+    // Extended attributes are not implemented yet.
+    if htemplatefile != 0 {
+        SetLastError(ERROR_NOT_SUPPORTED);
+        return HandleOrInvalid::from_raw_handle(INVALID_HANDLE_VALUE as _);
+    }
+
+    // Convert `dwcreationdisposition` to the `createdisposition` argument
+    // to `NtCreateFile`. Do this before converting `lpfilename` so that
+    // we can return early on failure.
+    let createdisposition = match dwcreationdisposition {
+        CREATE_NEW => FILE_CREATE,
+        CREATE_ALWAYS => FILE_OVERWRITE_IF,
+        OPEN_EXISTING => FILE_OPEN,
+        OPEN_ALWAYS => FILE_OPEN_IF,
+        TRUNCATE_EXISTING => FILE_OVERWRITE,
+        _ => {
+            SetLastError(ERROR_INVALID_PARAMETER);
+            return HandleOrInvalid::from_raw_handle(INVALID_HANDLE_VALUE as _);
+        }
+    };
+
+    // Convert `lpfilename` to a `UNICODE_STRING`.
+    let byte_length = lpfilename.len() * mem::size_of::<u16>();
+    let length: u16 = match byte_length.try_into() {
+        Ok(length) => length,
+        Err(_) => {
+            SetLastError(ERROR_INVALID_NAME);
+            return HandleOrInvalid::from_raw_handle(INVALID_HANDLE_VALUE as _);
+        }
+    };
+    let mut unicode_string = UNICODE_STRING {
+        Buffer: lpfilename.as_ptr() as *mut u16,
+        Length: length,
+        MaximumLength: length,
+    };
+
+    let mut handle = INVALID_HANDLE_VALUE;
+
+    // Convert `dwdesiredaccess` and `dwflagsandattributes` to the
+    // `desiredaccess` argument to `NtCreateFile`.
+    let mut desiredaccess = dwdesiredaccess | SYNCHRONIZE | FILE_READ_ATTRIBUTES;
+    if dwflagsandattributes & FILE_FLAG_DELETE_ON_CLOSE != 0 {
+        desiredaccess |= DELETE;
+    }
+
+    // Compute `objectattributes`' `Attributes` field. Case-insensitive is
+    // the expected behavior on Windows.
+    let mut attributes = 0;
+    if dwflagsandattributes & FILE_FLAG_POSIX_SEMANTICS != 0 {
+        attributes |= OBJ_CASE_INSENSITIVE as u32;
+    };
+    if !lpsecurityattributes.is_null() && (*lpsecurityattributes).bInheritHandle != 0 {
+        attributes |= OBJ_INHERIT as u32;
+    }
+
+    // Compute the `objectattributes` argument to `NtCreateFile`.
+    let mut objectattributes = mem::zeroed::<OBJECT_ATTRIBUTES>();
+    objectattributes.Length = mem::size_of::<OBJECT_ATTRIBUTES>() as _;
+    objectattributes.RootDirectory = dir;
+    objectattributes.ObjectName = &mut unicode_string;
+    objectattributes.Attributes = attributes;
+    if !lpsecurityattributes.is_null() {
+        objectattributes.SecurityDescriptor = (*lpsecurityattributes).lpSecurityDescriptor;
+    }
+
+    // If needed, set `objectattributes`' `SecurityQualityOfService` field.
+    let mut qos;
+    if dwflagsandattributes & SECURITY_SQOS_PRESENT != 0 {
+        qos = mem::zeroed::<SECURITY_QUALITY_OF_SERVICE>();
+        qos.Length = mem::size_of::<SECURITY_QUALITY_OF_SERVICE>() as _;
+        qos.ImpersonationLevel = ((dwflagsandattributes >> 16) & 0x3) as _;
+        qos.ContextTrackingMode = if dwflagsandattributes & SECURITY_CONTEXT_TRACKING != 0 {
+            SECURITY_DYNAMIC_TRACKING
+        } else {
+            SECURITY_STATIC_TRACKING
+        };
+        qos.EffectiveOnly = ((dwflagsandattributes & SECURITY_EFFECTIVE_ONLY) != 0) as _;
+
+        objectattributes.SecurityQualityOfService =
+            (&mut qos as *mut SECURITY_QUALITY_OF_SERVICE).cast();
+    }
+
+    let mut iostatusblock = mem::zeroed::<IO_STATUS_BLOCK>();
+    iostatusblock.Anonymous.Status = STATUS_PENDING;
+
+    // Compute the `fileattributes` argument to `NtCreateFile`. Mask off
+    // unrecognized flags.
+    let mut fileattributes = dwflagsandattributes & FILE_ATTRIBUTE_VALID_FLAGS;
+    if fileattributes == 0 {
+        fileattributes = FILE_ATTRIBUTE_NORMAL;
+    }
+
+    // Compute the `createoptions` argument to `NtCreateFile`.
+    let mut createoptions = 0;
+    if dwflagsandattributes & FILE_FLAG_BACKUP_SEMANTICS == 0 {
+        createoptions |= FILE_NON_DIRECTORY_FILE;
+    } else {
+        if dwdesiredaccess & GENERIC_ALL != 0 {
+            createoptions |= FILE_OPEN_FOR_BACKUP_INTENT | FILE_OPEN_REMOTE_INSTANCE;
+        } else {
+            if dwdesiredaccess & GENERIC_READ != 0 {
+                createoptions |= FILE_OPEN_FOR_BACKUP_INTENT;
+            }
+            if dwdesiredaccess & GENERIC_WRITE != 0 {
+                createoptions |= FILE_OPEN_REMOTE_INSTANCE;
+            }
+        }
+    }
+    if dwflagsandattributes & FILE_FLAG_DELETE_ON_CLOSE != 0 {
+        createoptions |= FILE_DELETE_ON_CLOSE;
+    }
+    if dwflagsandattributes & FILE_FLAG_NO_BUFFERING != 0 {
+        createoptions |= FILE_NO_INTERMEDIATE_BUFFERING;
+    }
+    if dwflagsandattributes & FILE_FLAG_OPEN_NO_RECALL != 0 {
+        createoptions |= FILE_OPEN_NO_RECALL;
+    }
+    if dwflagsandattributes & FILE_FLAG_OPEN_REPARSE_POINT != 0 {
+        createoptions |= FILE_OPEN_REPARSE_POINT;
+    }
+    if dwflagsandattributes & FILE_FLAG_OVERLAPPED == 0 {
+        createoptions |= FILE_SYNCHRONOUS_IO_NONALERT;
+    }
+    // FILE_FLAG_POSIX_SEMANTICS is handled above.
+    if dwflagsandattributes & FILE_FLAG_RANDOM_ACCESS != 0 {
+        createoptions |= FILE_RANDOM_ACCESS;
+    }
+    if dwflagsandattributes & FILE_FLAG_SESSION_AWARE != 0 {
+        // TODO: How should we handle FILE_FLAG_SESSION_AWARE?
+        SetLastError(ERROR_NOT_SUPPORTED);
+        return HandleOrInvalid::from_raw_handle(INVALID_HANDLE_VALUE as _);
+    }
+    if dwflagsandattributes & FILE_FLAG_SEQUENTIAL_SCAN != 0 {
+        createoptions |= FILE_SEQUENTIAL_ONLY;
+    }
+    if dwflagsandattributes & FILE_FLAG_WRITE_THROUGH != 0 {
+        createoptions |= FILE_WRITE_THROUGH;
+    }
+
+    // Ok, we have what we need to call `NtCreateFile` now!
+    let status = NtCreateFile(
+        &mut handle,
+        desiredaccess,
+        &mut objectattributes,
+        &mut iostatusblock,
+        null_mut(),
+        fileattributes,
+        dwsharemode,
+        createdisposition,
+        createoptions,
+        null_mut(),
+        0,
+    );
+
+    // Check for errors.
+    if status != STATUS_SUCCESS {
+        handle = INVALID_HANDLE_VALUE;
+        if status == STATUS_OBJECT_NAME_COLLISION {
+            SetLastError(ERROR_FILE_EXISTS);
+        } else {
+            SetLastError(RtlNtStatusToDosError(status));
+        }
+    } else if (dwcreationdisposition == CREATE_ALWAYS
+        && iostatusblock.Information == FILE_OVERWRITTEN as _)
+        || (dwcreationdisposition == OPEN_ALWAYS && iostatusblock.Information == FILE_OPENED as _)
+    {
+        // Set `ERROR_ALREADY_EXISTS` according to the table for
+        // `dwCreationDisposition` in the [`CreateFileW` docs].
+        //
+        // [`CreateFileW` docs]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
+        SetLastError(ERROR_ALREADY_EXISTS);
+    } else {
+        // Otherwise indicate that we succeeded.
+        SetLastError(SUCCESS);
+    }
+
+    HandleOrInvalid::from_raw_handle(handle as _)
+}

--- a/cap-primitives/src/windows/fs/create_file_at_w.rs
+++ b/cap-primitives/src/windows/fs/create_file_at_w.rs
@@ -66,6 +66,10 @@ const FILE_ATTRIBUTE_VALID_FLAGS: FILE_FLAGS_AND_ATTRIBUTES = FILE_ATTRIBUTE_EA
 
 /// Like Windows' `CreateFileW`, but takes a `dir` argument to use as the
 /// root directory.
+///
+/// Also, the `lpfilename` is a Rust slice instead of a C-style NUL-terminated
+/// array, because that's what our callers have and it's closer to what
+/// `NtCreatePath` takes.
 #[allow(non_snake_case)]
 pub unsafe fn CreateFileAtW(
     dir: HANDLE,

--- a/cap-primitives/src/windows/fs/dir_utils.rs
+++ b/cap-primitives/src/windows/fs/dir_utils.rs
@@ -92,7 +92,12 @@ pub(crate) fn canonicalize_options() -> OpenOptions {
 ///
 /// This function is not sandboxed and may trivially access any path that the
 /// host process has access to.
-pub(crate) fn open_ambient_dir_impl(path: &Path, _: AmbientAuthority) -> io::Result<fs::File> {
+pub(crate) fn open_ambient_dir_impl(
+    path: &Path,
+    ambient_authority: AmbientAuthority,
+) -> io::Result<fs::File> {
+    let _ = ambient_authority;
+
     // Set `FILE_FLAG_BACKUP_SEMANTICS` so that we can open directories. Unset
     // `FILE_SHARE_DELETE` so that directories can't be renamed or deleted
     // underneath us, since we use paths to implement many directory operations.

--- a/cap-primitives/src/windows/fs/dir_utils.rs
+++ b/cap-primitives/src/windows/fs/dir_utils.rs
@@ -100,7 +100,7 @@ pub(crate) fn open_ambient_dir_impl(path: &Path, _: AmbientAuthority) -> io::Res
         .read(true)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
         .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
-        .open(&path)?;
+        .open(path)?;
 
     // Require a directory. It may seem possible to eliminate this `metadata()`
     // call by appending a slash to the path before opening it so that the OS

--- a/cap-primitives/src/windows/fs/mod.rs
+++ b/cap-primitives/src/windows/fs/mod.rs
@@ -1,5 +1,6 @@
 mod copy;
 mod create_dir_unchecked;
+mod create_file_at_w;
 mod dir_entry_inner;
 mod dir_options_ext;
 mod dir_utils;
@@ -74,7 +75,6 @@ pub(crate) use symlink_unchecked::*;
 // <https://docs.microsoft.com/en-us/windows/win32/fileio/reparse-points>
 pub(crate) const MAX_SYMLINK_EXPANSIONS: u8 = 63;
 
-#[cfg(any(test, racy_asserts))]
 pub(crate) fn file_path(file: &std::fs::File) -> Option<std::path::PathBuf> {
     get_path::get_path(file).ok()
 }

--- a/cap-primitives/src/windows/fs/oflags.rs
+++ b/cap-primitives/src/windows/fs/oflags.rs
@@ -6,10 +6,11 @@ use windows_sys::Win32::Storage::FileSystem::{
     FILE_SHARE_DELETE,
 };
 
-/// Translate the given `cap_std` into `std` options. Also return a bool
+/// Adjust an `OpenOptions` after all the flags are set, in preparation
+/// for the to call a Windows API `open` function. Also return a bool
 /// indicating that the `trunc` flag was requested but could not be set,
 /// so the file should be truncated manually after opening.
-pub(in super::super) fn open_options_to_std(opts: &OpenOptions) -> (fs::OpenOptions, bool) {
+pub(in super::super) fn prepare_open_options_for_open(opts: &mut OpenOptions) -> bool {
     let mut trunc = opts.truncate;
     let mut manually_trunc = false;
 
@@ -40,16 +41,31 @@ pub(in super::super) fn open_options_to_std(opts: &OpenOptions) -> (fs::OpenOpti
     if opts.sync || opts.dsync {
         custom_flags |= FILE_FLAG_WRITE_THROUGH;
     }
+
+    opts.truncate(trunc)
+        .share_mode(share_mode)
+        .custom_flags(custom_flags);
+
+    manually_trunc
+}
+
+/// Translate the given `cap_std` into `std` options. Also return a bool
+/// indicating that the `trunc` flag was requested but could not be set,
+/// so the file should be truncated manually after opening.
+pub(in super::super) fn open_options_to_std(opts: &OpenOptions) -> (fs::OpenOptions, bool) {
+    let mut opts = opts.clone();
+    let manually_trunc = prepare_open_options_for_open(&mut opts);
+
     let mut std_opts = fs::OpenOptions::new();
     std_opts
         .read(opts.read)
         .write(opts.write)
         .append(opts.append)
-        .truncate(trunc)
+        .truncate(opts.truncate)
         .create(opts.create)
         .create_new(opts.create_new)
-        .share_mode(share_mode)
-        .custom_flags(custom_flags)
+        .share_mode(opts.ext.share_mode)
+        .custom_flags(opts.ext.custom_flags)
         .attributes(opts.ext.attributes);
 
     // Calling `sequence_qos_flags` with a value of 0 has the side effect

--- a/cap-primitives/src/windows/fs/open_options_ext.rs
+++ b/cap-primitives/src/windows/fs/open_options_ext.rs
@@ -1,6 +1,16 @@
+#![allow(unsafe_code)]
+
+use crate::fs::OpenOptions;
+use std::io;
+use std::ptr::null_mut;
+use windows_sys::Win32::Foundation::ERROR_INVALID_PARAMETER;
+use windows_sys::Win32::Security::SECURITY_ATTRIBUTES;
 use windows_sys::Win32::Storage::FileSystem::{
-    FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, SECURITY_SQOS_PRESENT,
+    CREATE_ALWAYS, CREATE_NEW, FILE_FLAG_OPEN_REPARSE_POINT, FILE_GENERIC_WRITE, FILE_SHARE_DELETE,
+    FILE_SHARE_READ, FILE_SHARE_WRITE, FILE_WRITE_DATA, OPEN_ALWAYS, OPEN_EXISTING,
+    SECURITY_SQOS_PRESENT, TRUNCATE_EXISTING,
 };
+use windows_sys::Win32::System::SystemServices::{GENERIC_READ, GENERIC_WRITE};
 
 #[derive(Debug, Clone)]
 pub(crate) struct OpenOptionsExt {
@@ -8,8 +18,12 @@ pub(crate) struct OpenOptionsExt {
     pub(super) share_mode: u32,
     pub(super) custom_flags: u32,
     pub(super) attributes: u32,
+    pub(super) security_attributes: *mut SECURITY_ATTRIBUTES,
     pub(super) security_qos_flags: u32,
 }
+
+unsafe impl Send for OpenOptionsExt {}
+unsafe impl Sync for OpenOptionsExt {}
 
 impl OpenOptionsExt {
     pub(crate) const fn new() -> Self {
@@ -18,6 +32,7 @@ impl OpenOptionsExt {
             share_mode: FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
             custom_flags: 0,
             attributes: 0,
+            security_attributes: null_mut(),
             security_qos_flags: 0,
         }
     }
@@ -46,4 +61,62 @@ impl OpenOptionsExt {
         self.security_qos_flags = flags | SECURITY_SQOS_PRESENT;
         self
     }
+}
+
+pub(crate) fn get_access_mode(options: &OpenOptions) -> io::Result<u32> {
+    match (
+        options.read,
+        options.write,
+        options.append,
+        options.ext.access_mode,
+    ) {
+        (.., Some(mode)) => Ok(mode),
+        (true, false, false, None) => Ok(GENERIC_READ),
+        (false, true, false, None) => Ok(GENERIC_WRITE),
+        (true, true, false, None) => Ok(GENERIC_READ | GENERIC_WRITE),
+        (false, _, true, None) => Ok(FILE_GENERIC_WRITE & !FILE_WRITE_DATA),
+        (true, _, true, None) => Ok(GENERIC_READ | (FILE_GENERIC_WRITE & !FILE_WRITE_DATA)),
+        (false, false, false, None) => {
+            Err(io::Error::from_raw_os_error(ERROR_INVALID_PARAMETER as i32))
+        }
+    }
+}
+
+pub(crate) fn get_flags_and_attributes(options: &OpenOptions) -> u32 {
+    options.ext.custom_flags
+        | options.ext.attributes
+        | options.ext.security_qos_flags
+        | if options.create_new {
+            FILE_FLAG_OPEN_REPARSE_POINT
+        } else {
+            0
+        }
+}
+
+pub(crate) fn get_creation_mode(options: &OpenOptions) -> io::Result<u32> {
+    const ERROR_INVALID_PARAMETER: i32 = 87;
+
+    match (options.write, options.append) {
+        (true, false) => {}
+        (false, false) => {
+            if options.truncate || options.create || options.create_new {
+                return Err(io::Error::from_raw_os_error(ERROR_INVALID_PARAMETER));
+            }
+        }
+        (_, true) => {
+            if options.truncate && !options.create_new {
+                return Err(io::Error::from_raw_os_error(ERROR_INVALID_PARAMETER));
+            }
+        }
+    }
+
+    Ok(
+        match (options.create, options.truncate, options.create_new) {
+            (false, false, false) => OPEN_EXISTING,
+            (true, false, false) => OPEN_ALWAYS,
+            (false, true, false) => TRUNCATE_EXISTING,
+            (true, true, false) => CREATE_ALWAYS,
+            (_, _, true) => CREATE_NEW,
+        },
+    )
 }

--- a/cap-primitives/src/windows/fs/open_unchecked.rs
+++ b/cap-primitives/src/windows/fs/open_unchecked.rs
@@ -95,7 +95,10 @@ fn open_at(start: &fs::File, path: &Path, opts: &OpenOptions) -> io::Result<fs::
     // own `CreateFileAtW` so that it does the requisite magic for absolute
     // paths.
     if dir == 0 {
+        // We're calling the windows-sys `CreateFileW` which expects a
+        // NUL-terminated filename, so add a NUL terminator.
         wide.push(0);
+
         let handle = unsafe {
             CreateFileW(
                 wide.as_ptr(),
@@ -113,6 +116,9 @@ fn open_at(start: &fs::File, path: &Path, opts: &OpenOptions) -> io::Result<fs::
             Err(io::Error::last_os_error())
         }
     } else {
+        // Our own `CreateFileAtW` is similar to `CreateFileW` except it
+        // takes the filename as a Rust slice directly, so we can skip
+        // the NUL terminator.
         let handle = unsafe {
             CreateFileAtW(
                 dir,

--- a/cap-primitives/src/windows/fs/open_unchecked.rs
+++ b/cap-primitives/src/windows/fs/open_unchecked.rs
@@ -1,13 +1,24 @@
-use super::get_path::concatenate;
-use super::open_options_to_std;
-use crate::fs::{errors, FollowSymlinks, OpenOptions, OpenUncheckedError, SymlinkKind};
+//! Windows implementation of `openat` functionality.
+
+#![allow(unsafe_code)]
+
+use super::create_file_at_w::CreateFileAtW;
+use super::{open_options_to_std, prepare_open_options_for_open};
+use crate::fs::{
+    errors, file_path, get_access_mode, get_creation_mode, get_flags_and_attributes,
+    FollowSymlinks, OpenOptions, OpenUncheckedError, SymlinkKind,
+};
 use crate::{ambient_authority, AmbientAuthority};
+use std::convert::TryInto;
+use std::ffi::OsStr;
+use std::os::windows::ffi::OsStrExt;
 use std::os::windows::fs::MetadataExt;
-use std::path::Path;
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+use std::path::{Component, Path, PathBuf};
 use std::{fs, io};
-use windows_sys::Win32::Foundation;
+use windows_sys::Win32::Foundation::{self, ERROR_ACCESS_DENIED, HANDLE, INVALID_HANDLE_VALUE};
 use windows_sys::Win32::Storage::FileSystem::{
-    FILE_ATTRIBUTE_DIRECTORY, FILE_FLAG_OPEN_REPARSE_POINT,
+    CreateFileW, FILE_ATTRIBUTE_DIRECTORY, FILE_FLAG_OPEN_REPARSE_POINT,
 };
 
 /// *Unsandboxed* function similar to `open`, but which does not perform
@@ -17,8 +28,110 @@ pub(crate) fn open_unchecked(
     path: &Path,
     options: &OpenOptions,
 ) -> Result<fs::File, OpenUncheckedError> {
-    let full_path = concatenate(start, path).map_err(OpenUncheckedError::Other)?;
-    open_ambient_impl(&full_path, options, ambient_authority())
+    let _ = ambient_authority;
+
+    // We have the final `OpenOptions`; now prepare it for an `open`.
+    let mut prepared_opts = options.clone();
+    let manually_trunc = prepare_open_options_for_open(&mut prepared_opts);
+
+    handle_open_result(
+        open_at(start, path, &prepared_opts),
+        options,
+        manually_trunc,
+    )
+}
+
+// The following is derived from Rust's library/std/src/sys/windows/fs.rs
+// at revision 56888c1e9b4135b511abd2d8e907099003d12281, except with a
+// directory `start` parameter added and using `CreateFileAtW` instead of
+// `CreateFileW`.
+
+fn open_at(start: &fs::File, path: &Path, opts: &OpenOptions) -> io::Result<fs::File> {
+    let mut dir = start.as_raw_handle() as HANDLE;
+
+    // `PathCchCanonicalizeEx` and friends don't seem to work with relative
+    // paths. Or at least, when I tried it, they canonicalized "a" to "",
+    // which isn't what we want. So we manually canonicalize `..` and `.`.
+    // Hopefully there aren't other mysterious Windows path conventions that
+    // we're missing here.
+    let mut rebuilt = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => {
+                rebuilt.push(component);
+                dir = 0;
+            }
+            Component::Normal(_) => {
+                rebuilt.push(component);
+            }
+            Component::ParentDir => {
+                if !rebuilt.pop() {
+                    // We popped past the beginning of `path`. Substitute in
+                    // the path of `start` and convert this to an ambient
+                    // path by dropping the directory base. It's ok to do
+                    // this because we're not sandboxing at this level of the
+                    // code.
+                    if dir == 0 {
+                        return Err(io::Error::from_raw_os_error(ERROR_ACCESS_DENIED as _));
+                    }
+                    rebuilt = match file_path(start) {
+                        Some(path) => path,
+                        None => {
+                            return Err(io::Error::from_raw_os_error(ERROR_ACCESS_DENIED as _));
+                        }
+                    };
+                    dir = 0;
+                    // And then pop the last component of that.
+                    let _ = rebuilt.pop();
+                }
+            }
+            Component::CurDir => (),
+        }
+    }
+
+    let mut wide = OsStr::encode_wide(rebuilt.as_os_str()).collect::<Vec<u16>>();
+
+    // If we ended up re-rooting, use Windows' `CreateFileW` instead of our
+    // own `CreateFileAtW` so that it does the requisite magic for absolute
+    // paths.
+    if dir == 0 {
+        wide.push(0);
+        let handle = unsafe {
+            CreateFileW(
+                wide.as_ptr(),
+                get_access_mode(opts)?,
+                opts.ext.share_mode,
+                opts.ext.security_attributes,
+                get_creation_mode(opts)?,
+                get_flags_and_attributes(opts),
+                0 as HANDLE,
+            )
+        };
+        if handle != INVALID_HANDLE_VALUE {
+            Ok(unsafe { fs::File::from_raw_handle(handle as _) })
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    } else {
+        let handle = unsafe {
+            CreateFileAtW(
+                dir,
+                &wide,
+                get_access_mode(opts)?,
+                opts.ext.share_mode,
+                opts.ext.security_attributes,
+                get_creation_mode(opts)?,
+                get_flags_and_attributes(opts),
+                0 as HANDLE,
+            )
+        };
+
+        if let Ok(handle) = handle.try_into() {
+            Ok(<fs::File as From<OwnedHandle>>::from(handle))
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
 }
 
 /// *Unsandboxed* function similar to `open_unchecked`, but which just operates
@@ -29,8 +142,16 @@ pub(crate) fn open_ambient_impl(
     ambient_authority: AmbientAuthority,
 ) -> Result<fs::File, OpenUncheckedError> {
     let _ = ambient_authority;
-    let (opts, manually_trunc) = open_options_to_std(options);
-    match opts.open(path) {
+    let (std_opts, manually_trunc) = open_options_to_std(options);
+    handle_open_result(std_opts.open(path), options, manually_trunc)
+}
+
+fn handle_open_result(
+    result: io::Result<fs::File>,
+    options: &OpenOptions,
+    manually_trunc: bool,
+) -> Result<fs::File, OpenUncheckedError> {
+    match result {
         Ok(f) => {
             let enforce_dir = options.dir_required;
             let enforce_nofollow = options.follow == FollowSymlinks::No

--- a/cap-primitives/src/windows/fs/stat_unchecked.rs
+++ b/cap-primitives/src/windows/fs/stat_unchecked.rs
@@ -1,16 +1,12 @@
-#[cfg(windows_by_handle)]
-use super::get_path::concatenate;
 use crate::fs::{FollowSymlinks, Metadata};
 use std::path::Path;
 use std::{fs, io};
-#[cfg(not(windows_by_handle))]
-use windows_sys::Win32::Storage::FileSystem::{
-    FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
-};
-#[cfg(not(windows_by_handle))]
 use {
     crate::fs::{open_unchecked, OpenOptions},
     std::os::windows::fs::OpenOptionsExt,
+    windows_sys::Win32::Storage::FileSystem::{
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+    },
 };
 
 /// *Unsandboxed* function similar to `stat`, but which does not perform
@@ -20,35 +16,24 @@ pub(crate) fn stat_unchecked(
     path: &Path,
     follow: FollowSymlinks,
 ) -> io::Result<Metadata> {
-    // When we have `windows_by_handle`, we just call `fs::metadata` etc. and it
-    // has everything.
-    #[cfg(windows_by_handle)]
-    {
-        let full_path = concatenate(start, path)?;
-        match follow {
-            FollowSymlinks::Yes => fs::metadata(full_path),
-            FollowSymlinks::No => fs::symlink_metadata(full_path),
+    // Attempt to open the file to get the metadata that way, as that gives
+    // us all the info.
+    let mut opts = OpenOptions::new();
+
+    // Explicitly request no access, because we're just querying metadata.
+    opts.access_mode(0);
+
+    match follow {
+        FollowSymlinks::Yes => {
+            opts.custom_flags(FILE_FLAG_BACKUP_SEMANTICS);
+            opts.follow(FollowSymlinks::Yes);
         }
-        .map(Metadata::from_just_metadata)
+        FollowSymlinks::No => {
+            opts.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS);
+            opts.follow(FollowSymlinks::No);
+        }
     }
 
-    // Otherwise, attempt to open the file to get the metadata that way, as
-    // that gives us all the info.
-    #[cfg(not(windows_by_handle))]
-    {
-        let mut opts = OpenOptions::new();
-        opts.access_mode(0);
-        match follow {
-            FollowSymlinks::Yes => {
-                opts.custom_flags(FILE_FLAG_BACKUP_SEMANTICS);
-                opts.follow(FollowSymlinks::Yes);
-            }
-            FollowSymlinks::No => {
-                opts.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS);
-                opts.follow(FollowSymlinks::No);
-            }
-        }
-        let file = open_unchecked(start, path, &opts)?;
-        Metadata::from_file(&file)
-    }
+    let file = open_unchecked(start, path, &opts)?;
+    Metadata::from_file(&file)
 }

--- a/cap-rand/src/lib.rs
+++ b/cap-rand/src/lib.rs
@@ -74,7 +74,8 @@ pub mod rngs {
         /// This function makes use of ambient authority to access the platform
         /// entropy source.
         #[inline]
-        pub const fn default(_: AmbientAuthority) -> Self {
+        pub const fn default(ambient_authority: AmbientAuthority) -> Self {
+            let _ = ambient_authority;
             Self(())
         }
     }
@@ -161,7 +162,8 @@ pub mod rngs {
 /// This function makes use of ambient authority to access the platform entropy
 /// source.
 #[inline]
-pub fn thread_rng(_: AmbientAuthority) -> rngs::CapRng {
+pub fn thread_rng(ambient_authority: AmbientAuthority) -> rngs::CapRng {
+    let _ = ambient_authority;
     rngs::CapRng {
         inner: rand::thread_rng(),
     }
@@ -176,7 +178,8 @@ pub fn thread_rng(_: AmbientAuthority) -> rngs::CapRng {
 /// This function makes use of ambient authority to access the platform entropy
 /// source.
 #[inline]
-pub fn std_rng_from_entropy(_: AmbientAuthority) -> rngs::StdRng {
+pub fn std_rng_from_entropy(ambient_authority: AmbientAuthority) -> rngs::StdRng {
+    let _ = ambient_authority;
     rand::rngs::StdRng::from_entropy()
 }
 
@@ -189,9 +192,10 @@ pub fn std_rng_from_entropy(_: AmbientAuthority) -> rngs::StdRng {
 /// This function makes use of ambient authority to access the platform entropy
 /// source.
 #[inline]
-pub fn random<T>(_: AmbientAuthority) -> T
+pub fn random<T>(ambient_authority: AmbientAuthority) -> T
 where
     crate::distributions::Standard: crate::distributions::Distribution<T>,
 {
+    let _ = ambient_authority;
     rand::random()
 }

--- a/cap-std/src/fs/mod.rs
+++ b/cap-std/src/fs/mod.rs
@@ -1,4 +1,4 @@
-//! A capability-based filesystem API modeled after `std::fs`.
+//! A capability-based filesystem API modeled after [`std::fs`].
 //!
 //! This corresponds to [`std::fs`].
 //!

--- a/cap-std/src/lib.rs
+++ b/cap-std/src/lib.rs
@@ -1,4 +1,4 @@
-//! A capability-based API modeled after `std`.
+//! A capability-based API modeled after [`std`].
 //!
 //! This corresponds to [`std`].
 //!

--- a/cap-std/src/net/mod.rs
+++ b/cap-std/src/net/mod.rs
@@ -1,4 +1,4 @@
-//! A capability-based network API modeled after `std::net`.
+//! A capability-based network API modeled after [`std::net`].
 //!
 //! This corresponds to [`std::net`].
 //!

--- a/cap-std/src/net/pool.rs
+++ b/cap-std/src/net/pool.rs
@@ -21,6 +21,41 @@ impl Pool {
         }
     }
 
+    /// Add a range of network addresses, accepting any port, to the pool.
+    ///
+    /// Unlike `insert_ip_net`, this function grants access to any requested
+    /// port.
+    ///
+    /// # Ambient Authority
+    ///
+    /// This function allows ambient access to any IP address.
+    pub fn insert_ip_net_port_any(
+        &mut self,
+        ip_net: ipnet::IpNet,
+        ambient_authority: AmbientAuthority,
+    ) {
+        self.cap.insert_ip_net_port_any(ip_net, ambient_authority)
+    }
+
+    /// Add a range of network addresses, accepting a range of ports, to the pool.
+    ///
+    /// This grants access to the port range starting at `ports_start` and,
+    /// if `ports_end` is provided, ending before `ports_end`.
+    ///
+    /// # Ambient Authority
+    ///
+    /// This function allows ambient access to any IP address.
+    pub fn insert_ip_net_port_range(
+        &mut self,
+        ip_net: ipnet::IpNet,
+        ports_start: u16,
+        ports_end: Option<u16>,
+        ambient_authority: AmbientAuthority,
+    ) {
+        self.cap
+            .insert_ip_net_port_range(ip_net, ports_start, ports_end, ambient_authority)
+    }
+
     /// Add a range of network addresses with a specific port to the pool.
     ///
     /// # AmbientAuthority

--- a/cap-std/src/time/mod.rs
+++ b/cap-std/src/time/mod.rs
@@ -1,4 +1,4 @@
-//! A capability-based clock API modeled after `std::time`.
+//! A capability-based clock API modeled after [`std::time`].
 //!
 //! This corresponds to [`std::time`].
 //!

--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -127,9 +127,9 @@ fn trailing_slash() {
         assert!(check!(check!(tmpdir.open("file/../file")).metadata()).is_file());
         assert!(check!(check!(tmpdir.open_dir("file/..")).dir_metadata()).is_dir());
         assert!(check!(check!(tmpdir.open("file/.")).metadata()).is_file());
-        error!(tmpdir.open("file/../file/"), 123);
-        error!(tmpdir.open("file/"), 123);
-        error!(tmpdir.open_dir("file/../file/"), 123);
+        assert!(tmpdir.open_dir("file/../file/").is_err());
+        assert!(tmpdir.open_dir("file/./").is_err());
+        assert!(tmpdir.open_dir("file//").is_err());
         assert!(tmpdir.open_dir("file/../file").is_err());
         assert!(tmpdir.open_dir("file/.").is_err());
         assert!(tmpdir.open_dir("file/").is_err());
@@ -161,11 +161,22 @@ fn trailing_slash_in_dir() {
         assert!(check!(check!(tmpdir.open("dir/file/../file")).metadata()).is_file());
         assert!(check!(check!(tmpdir.open_dir("dir/file/..")).dir_metadata()).is_dir());
         assert!(check!(check!(tmpdir.open("dir/file/.")).metadata()).is_file());
-        error!(tmpdir.open("dir/file/../file/"), 123);
-        error!(tmpdir.open("dir/file/"), 123);
-        error!(tmpdir.open_dir("dir/file/../file/"), 123);
+        assert!(tmpdir.open("dir/file/../file/").is_err());
+        let _ = check!(tmpdir.open("dir/file/../file/."));
+        assert!(tmpdir.open("dir/file/../file/./").is_err());
+        assert!(tmpdir.open("dir/file/").is_err());
+        let _ = check!(tmpdir.open("dir/file/."));
+        let _ = check!(tmpdir.open("dir/file/../file/."));
+        assert!(tmpdir.open("dir/file/../file/./").is_err());
+        assert!(tmpdir.open("dir/file/").is_err());
+        let _ = check!(tmpdir.open("dir/file/."));
+        assert!(tmpdir.open("dir/file/./").is_err());
+        assert!(tmpdir.open_dir("dir/file/../file/").is_err());
+        assert!(tmpdir.open_dir("dir/file/../file/.").is_err());
+        assert!(tmpdir.open_dir("dir/file/../file/./").is_err());
         assert!(tmpdir.open_dir("dir/file/../file").is_err());
         assert!(tmpdir.open_dir("dir/file/.").is_err());
+        assert!(tmpdir.open_dir("dir/file/./").is_err());
         assert!(tmpdir.open_dir("dir/file/").is_err());
     }
 }
@@ -927,7 +938,6 @@ fn sync() {
 }
 
 #[test]
-#[cfg(not(windows))]
 fn reopen_fd() {
     use io_lifetimes::AsFilelike;
     let tmpdir = tmpdir();

--- a/tests/paths-containing-nul.rs
+++ b/tests/paths-containing-nul.rs
@@ -18,12 +18,19 @@ fn assert_invalid_input<T>(on: &str, result: io::Result<T>) {
     fn inner(on: &str, result: io::Result<()>) {
         match result {
             Ok(()) => panic!("{} didn't return an error on a path with NUL", on),
-            Err(e) => assert!(
-                e.kind() == io::ErrorKind::InvalidInput,
-                "{} returned a strange {:?} on a path with NUL",
-                on,
-                e
-            ),
+            Err(_e) => {
+                // TODO: Re-enable this assertion once the `io_error_more`
+                // feature is available.
+                /*
+                assert_eq!(
+                    e.kind(),
+                    io::ErrorKind::InvalidInput || io::ErrorKind::InvalidFilename,
+                    "{} returned a strange {:?} on a path with NUL",
+                    on,
+                    e
+                );
+                */
+            }
         }
     }
     inner(on, result.map(drop))

--- a/tests/reopendir.rs
+++ b/tests/reopendir.rs
@@ -1,0 +1,66 @@
+//! Tests for various forms of reopening a directory handle.
+
+#[macro_use]
+mod sys_common;
+
+use sys_common::io::tmpdir;
+
+#[test]
+fn reopendir_a() {
+    let tmpdir = tmpdir();
+    check!(tmpdir.create_dir_all("dir/inner"));
+
+    let inner = check!(tmpdir.open_dir("dir/inner"));
+
+    check!(inner.open_dir("."));
+}
+
+#[test]
+fn reopendir_b() {
+    let tmpdir = tmpdir();
+    check!(tmpdir.create_dir_all("dir/inner"));
+
+    let inner = check!(tmpdir.open_dir("dir/inner"));
+
+    check!(inner.open_dir("./"));
+}
+
+#[test]
+fn reopendir_c() {
+    let tmpdir = tmpdir();
+    check!(tmpdir.create_dir_all("dir/inner"));
+
+    let inner = check!(tmpdir.open_dir("dir/inner"));
+
+    check!(inner.open_dir("./."));
+}
+
+#[test]
+fn reopendir_d() {
+    let tmpdir = tmpdir();
+    check!(tmpdir.create_dir_all("dir/inner"));
+
+    let _inner = check!(tmpdir.open_dir("dir/inner"));
+
+    check!(tmpdir.open_dir("dir/inner"));
+}
+
+#[test]
+fn reopendir_e() {
+    let tmpdir = tmpdir();
+    check!(tmpdir.create_dir_all("dir/inner"));
+
+    let _inner = check!(tmpdir.open_dir("dir/inner"));
+
+    check!(tmpdir.open_dir("dir/inner/."));
+}
+
+#[test]
+fn reopendir_f() {
+    let tmpdir = tmpdir();
+    check!(tmpdir.create_dir_all("dir/inner"));
+
+    let _inner = check!(tmpdir.open_dir("dir/inner"));
+
+    check!(tmpdir.open_dir("dir/inner/"));
+}


### PR DESCRIPTION
This backports everything except #297 which is the update to rustix 0.37 to a new 1.x release branch. I don't think rustix is a public dependency of cap-std, but at this moment I'm not sufficiently sure about that, so to be safe for now, I'm omitting that so that it doesn't block other patches.