### PR TITLE
Add a new crate, "cap-net-ext".

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rust-version = "1.56"
 anyhow = "1.0.37"
 #cap-async-std = { path = "cap-async-std", version = "^0.25.0" }
 cap-fs-ext = { path = "cap-fs-ext", version = "^1.0.10" }
+cap-net-ext = { path = "cap-net-ext", version = "^1.0.10" }
 cap-directories = { path = "cap-directories", version = "^1.0.10" }
 cap-std = { path = "cap-std", version = "^1.0.10" }
 cap-tempfile = { path = "cap-tempfile", version = "^1.0.10" }
@@ -32,7 +33,7 @@ libc = "0.2.100"
 io-lifetimes = "1.0.0"
 
 [target.'cfg(not(windows))'.dev-dependencies]
-rustix = { version = "0.37.0", features = ["fs"] }
+rustix = { version = "0.37.9", features = ["fs"] }
 
 [target.'cfg(windows)'.dev-dependencies]
 # nt_version uses internal Windows APIs, however we're only using it
@@ -72,6 +73,7 @@ arf_strings = [
 members = [
   #"cap-async-std",
   "cap-fs-ext",
+  "cap-net-ext",
   "cap-directories",
   "cap-primitives",
   "cap-rand",

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ develops libraries to make it easy to write capability-based code, including:
    what's available in `std`
  - [`cap-rand`], which provides capability-based access to
    [random number generators]
+ - [`cap-net-ext`], which provides additional network features beyond
+   what's available in `std`
 
 There is also a [`cap-std-ext`](https://crates.io/crates/cap-std-ext) crate available
 which is maintained independently, and includes further extension APIs for
@@ -49,6 +51,7 @@ Linux.
 [`cap-fs-ext`]: https://github.com/bytecodealliance/cap-std/blob/main/cap-fs-ext/README.md
 [`cap-time-ext`]: https://github.com/bytecodealliance/cap-std/blob/main/cap-time-ext/README.md
 [`cap-rand`]: https://github.com/bytecodealliance/cap-std/blob/main/cap-rand/README.md
+[`cap-net-ext`]: https://github.com/bytecodealliance/cap-std/blob/main/cap-net-ext/README.md
 [`cap_std::fs`]: https://docs.rs/cap-std/latest/cap_std/fs/index.html
 [`async-std`]: https://docs.rs/async-std/
 [standard application directories]: https://docs.rs/directories-next/

--- a/cap-async-std/Cargo.toml
+++ b/cap-async-std/Cargo.toml
@@ -23,7 +23,7 @@ io-extras = { version = "0.17.0", features = ["use_async_std"] }
 camino = { version = "1.0.5", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.37.0", features = ["fs"] }
+rustix = { version = "0.37.9", features = ["fs"] }
 
 [features]
 default = []

--- a/cap-async-std/src/net/pool.rs
+++ b/cap-async-std/src/net/pool.rs
@@ -20,6 +20,32 @@ impl Pool {
         }
     }
 
+    /// Add addresses to the pool.
+    ///
+    /// # Ambient Authority
+    ///
+    /// This function allows ambient access to any IP address.
+    pub fn insert<A: ToSocketAddrs>(
+        &mut self,
+        addrs: A,
+        ambient_authority: AmbientAuthority,
+    ) -> io::Result<()> {
+        self.cap.insert(addrs, ambient_authority)
+    }
+
+    /// Add a specific [`net::SocketAddr`] to the pool.
+    ///
+    /// # Ambient Authority
+    ///
+    /// This function allows ambient access to any IP address.
+    pub fn insert_socket_addr(
+        &mut self,
+        addr: net::SocketAddr,
+        ambient_authority: AmbientAuthority,
+    ) {
+        self.cap.insert_socket_addr(addr, ambient_authority)
+    }
+
     /// Add a range of network addresses, accepting any port, to the pool.
     ///
     /// Unlike `insert_ip_net`, this function grants access to any requested
@@ -62,19 +88,6 @@ impl Pool {
         ambient_authority: AmbientAuthority,
     ) {
         self.cap.insert_ip_net(ip_net, port, ambient_authority)
-    }
-
-    /// Add a specific [`net::SocketAddr`] to the pool.
-    ///
-    /// # Ambient Authority
-    ///
-    /// This function allows ambient access to any IP address.
-    pub fn insert_socket_addr(
-        &mut self,
-        addr: net::SocketAddr,
-        ambient_authority: AmbientAuthority,
-    ) {
-        self.cap.insert_socket_addr(addr, ambient_authority)
     }
 
     /// Creates a new `TcpListener` which will be bound to the specified

--- a/cap-directories/Cargo.toml
+++ b/cap-directories/Cargo.toml
@@ -17,7 +17,7 @@ cap-std = { path = "../cap-std", version = "^1.0.10" }
 directories-next = "2.0.0"
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.37.0" }
+rustix = { version = "0.37.9" }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.48.0"

--- a/cap-net-ext/COPYRIGHT
+++ b/cap-net-ext/COPYRIGHT
@@ -1,0 +1,29 @@
+Short version for non-lawyers:
+
+`cap-net-ext` is triple-licensed under Apache 2.0 with the LLVM Exception,
+Apache 2.0, and MIT terms.
+
+
+Longer version:
+
+Copyrights in the `cap-net-ext` project are retained by their contributors.
+No copyright assignment is required to contribute to the `cap-net-ext`
+project.
+
+Some files include code derived from Rust's `libstd`; see the comments in
+the code for details.
+
+Except as otherwise noted (below and/or in individual files), `cap-net-ext`
+is licensed under:
+
+ - the Apache License, Version 2.0, with the LLVM Exception
+   <LICENSE-Apache-2.0_WITH_LLVM-exception> or
+   <http://llvm.org/foundation/relicensing/LICENSE.txt>
+ - the Apache License, Version 2.0
+   <LICENSE-APACHE> or
+   <http://www.apache.org/licenses/LICENSE-2.0>,
+ - or the MIT license
+   <LICENSE-MIT> or
+   <http://opensource.org/licenses/MIT>,
+
+at your option.

--- a/cap-net-ext/Cargo.toml
+++ b/cap-net-ext/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "cap-net-ext"
+version = "1.0.10"
+description = "Extension traits for `TcpListener`, `Pool`, etc."
+authors = [
+    "Dan Gohman <dev@sunfishcode.online>",
+    "Jakub Konka <kubkon@jakubkonka.com>",
+]
+license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
+keywords = ["filesystem"]
+categories = ["filesystem"]
+repository = "https://github.com/bytecodealliance/cap-std"
+edition = "2018"
+
+[dependencies]
+cap-std = { path = "../cap-std", version = "^1.0.10" }
+cap-primitives = { path = "../cap-primitives", version = "^1.0.10" }
+rustix = { version = "0.37.9", features = ["net"] }

--- a/cap-net-ext/LICENSE-APACHE
+++ b/cap-net-ext/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/cap-net-ext/LICENSE-Apache-2.0_WITH_LLVM-exception
+++ b/cap-net-ext/LICENSE-Apache-2.0_WITH_LLVM-exception
@@ -1,0 +1,220 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+--- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+

--- a/cap-net-ext/LICENSE-MIT
+++ b/cap-net-ext/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/cap-net-ext/README.md
+++ b/cap-net-ext/README.md
@@ -1,0 +1,24 @@
+<div align="center">
+  <h1><code>cap-net-ext</code></h1>
+
+  <p>
+    <strong>Extension traits for `TcpListener`, `UdpSocket`, `Pool`, etc.</strong>
+  </p>
+
+  <p>
+    <a href="https://github.com/bytecodealliance/cap-std/actions?query=workflow%3ACI"><img src="https://github.com/bytecodealliance/cap-std/workflows/CI/badge.svg" alt="Github Actions CI Status" /></a>
+    <a href="https://crates.io/crates/cap-net-ext"><img src="https://img.shields.io/crates/v/cap-net-ext.svg" alt="crates.io page" /></a>
+    <a href="https://docs.rs/cap-net-ext"><img src="https://docs.rs/cap-net-ext/badge.svg" alt="docs.rs docs" /></a>
+  </p>
+</div>
+
+The `cap-net-ext` crate provides extension traits adding extra features
+to types such as [`TcpListener`], [`UdpSocket`], and [`Pool`].
+
+It provides split-out operations corresponding to `socket`, `bind`, `listen`,
+`accept`, and `connect`, and it exposes more options for enabling non-blocking
+mode.
+
+[`TcpListener`]: https://docs.rs/cap-std/latest/cap_std/net/struct.TcpListener.html
+[`UdpSocket`]: https://docs.rs/cap-std/latest/cap_std/net/struct.UdpSocket.html
+[`Pool`]: https://docs.rs/cap-std/latest/cap_std/net/struct.Pool.html

--- a/cap-net-ext/src/lib.rs
+++ b/cap-net-ext/src/lib.rs
@@ -44,7 +44,8 @@ use cap_std::net::{IpAddr, Pool, SocketAddr, TcpListener, TcpStream, ToSocketAdd
 use rustix::fd::OwnedFd;
 use std::io;
 
-/// Address families supported by `TcpListener`.
+/// Address families supported by [`TcpListenerExt::new`] and
+/// [`UdpSocketExt::new`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum AddressFamily {
     /// IPv4
@@ -97,8 +98,8 @@ pub trait TcpListenerExt: private::Sealed + Sized {
     ///
     /// The created socket is not bound or connected to any address and may be
     /// used for either listening or connecting. Use
-    /// [`PoolExt::bind_existing_tcp_listener`] to bind it in preparation
-    /// for listening, or [`PoolExt::connect_into_tcp_stream`] to initiate a
+    /// [`PoolExt::bind_existing_tcp_listener`] to bind it in preparation for
+    /// listening, or [`PoolExt::connect_into_tcp_stream`] to initiate a
     /// connection.
     ///
     /// This is similar to [`Pool::bind_tcp_listener`] in that it creates a TCP
@@ -107,9 +108,9 @@ pub trait TcpListenerExt: private::Sealed + Sized {
     /// for the created socket.
     ///
     /// And it's similar to [`Pool::connect_tcp_stream`] in that it creates a
-    /// TCP socket, however it does not perform the `connect` step. And,
-    /// it has a `blocking` argument to select blocking or non-blocking mode
-    /// for the created socket.
+    /// TCP socket, however it does not perform the `connect` step. And, it has
+    /// a `blocking` argument to select blocking or non-blocking mode for the
+    /// created socket.
     fn new(address_family: AddressFamily, blocking: Blocking) -> io::Result<Self>;
 
     /// Enble listening in a `TcpListener`.
@@ -181,9 +182,9 @@ pub trait UdpSocketExt: private::Sealed + Sized {
     /// created socket.
     ///
     /// And it's similar to [`Pool::connect_udp_socket`] in that it creates a
-    /// UDP socket, however it does not perform the `connect` step. And,
-    /// it has a `blocking` argument to select blocking or non-blocking mode
-    /// for the created socket.
+    /// UDP socket, however it does not perform the `connect` step. And, it has
+    /// a `blocking` argument to select blocking or non-blocking mode for the
+    /// created socket.
     fn new(address_family: AddressFamily, blocking: Blocking) -> io::Result<Self>;
 }
 
@@ -219,8 +220,8 @@ pub trait PoolExt: private::Sealed {
 
     /// Bind a [`UdpSocket`] to the specified address.
     ///
-    /// A newly-created `UdpSocket` created with [`UdpSocketExt::new`]
-    /// has not been bound yet; this function binds it.
+    /// A newly-created `UdpSocket` created with [`UdpSocketExt::new`] has not
+    /// been bound yet; this function binds it.
     ///
     /// This is similar to [`Pool::bind_udp_socket`] in that it binds a UDP
     /// socket, however it does not create the socket itself.
@@ -353,9 +354,9 @@ fn socket(
     blocking: Blocking,
     socket_type: rustix::net::SocketType,
 ) -> io::Result<OwnedFd> {
-    // The Rust standard library has code to call `WSAStartup`, which is
-    // needed on Windows before we do any other Winsock2 calls, so just
-    // make a useless API call once.
+    // The Rust standard library has code to call `WSAStartup`, which is needed
+    // on Windows before we do any other Winsock2 calls, so just make a useless
+    // API call once.
     #[cfg(windows)]
     {
         use std::sync::Once;
@@ -420,8 +421,8 @@ fn socket_flags(blocking: Blocking) -> rustix::net::SocketFlags {
     socket_flags
 }
 
-/// On platforms which don't support `SOCK_CLOEXEC` or `SOCK_NONBLOCK, set
-/// them after creating the socket.
+/// On platforms which don't support `SOCK_CLOEXEC` or `SOCK_NONBLOCK, set them
+/// after creating the socket.
 fn set_socket_flags(fd: &OwnedFd, blocking: Blocking) -> io::Result<()> {
     let _ = fd;
     let _ = blocking;

--- a/cap-net-ext/src/lib.rs
+++ b/cap-net-ext/src/lib.rs
@@ -1,0 +1,513 @@
+//! Extension traits for `TcpListener`, `UdpSocket`, and `Pool`.
+//!
+//! cap-std's [`TcpListener`], following the Rust standard library
+//! `TcpListener`, combines the `socket`, `bind`, `listen`, and `connect`
+//! operations of the POSIX socket API into a single `bind` or `connect`
+//! operation. In some use cases, it's desirable to perform the steps
+//! separately.
+//!
+//! This API adds extension traits to cap-std's `TcpListener`, `UdpSocket`,
+//! and `Pool` which support the following sequence for accepting incoming
+//! connections:
+//!
+//!  - [`TcpListenerExt::new`] performs a `socket` and returns a new
+//!    `TcpListener` that is not yet bound.
+//!  - [`Pool::bind_existing_tcp_listener`] performs a `bind`, checking that
+//!    the address is in the `Pool`.
+//!  - [`TcpListenerExt::listen`] performs a `listen`.
+//!  - Then, the regular [`TcpListener::accept`] may be used to accept new
+//!    connections. Alternatively, [`TcpListener::accept_with`] may be used.
+//!
+//! and the following sequence for initiating outgoing connections:
+//!
+//!  - [`TcpListenerExt::new`] performs a `socket` and returns a new
+//!    `TcpListener` that is not yet connected.
+//!  - [`Pool::connect_into_tcp_stream`] performs a `connect`, checking that
+//!    the address is in the `Pool`.
+//!
+//! [`TcpListenerExt::new`] and [`TcpListener::accept_with`] additionally
+//! have [`Blocking`] arguments for requesting non-blocking operation.
+//!
+//! Similar API adaptations are available for UDP sockets as well.
+
+#![deny(missing_docs)]
+#![forbid(unsafe_code)]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/bytecodealliance/cap-std/main/media/cap-std.svg"
+)]
+#![doc(
+    html_favicon_url = "https://raw.githubusercontent.com/bytecodealliance/cap-std/main/media/cap-std.ico"
+)]
+
+use cap_primitives::net::NO_SOCKET_ADDRS;
+use cap_std::net::{IpAddr, Pool, SocketAddr, TcpListener, TcpStream, ToSocketAddrs, UdpSocket};
+use rustix::fd::OwnedFd;
+use std::io;
+
+/// Address families supported by `TcpListener`.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum AddressFamily {
+    /// IPv4
+    Ipv4,
+
+    /// IPv6
+    Ipv6,
+}
+
+impl AddressFamily {
+    /// Return the `AddressFamily` of an IP address.
+    pub fn of_ip_addr(ip_addr: IpAddr) -> Self {
+        match ip_addr {
+            IpAddr::V4(_) => AddressFamily::Ipv4,
+            IpAddr::V6(_) => AddressFamily::Ipv6,
+        }
+    }
+
+    /// Return the `AddressFamily` of a socket address.
+    pub fn of_socket_addr(socket_addr: SocketAddr) -> Self {
+        match socket_addr {
+            SocketAddr::V4(_) => AddressFamily::Ipv4,
+            SocketAddr::V6(_) => AddressFamily::Ipv6,
+        }
+    }
+}
+
+impl From<AddressFamily> for rustix::net::AddressFamily {
+    fn from(address_family: AddressFamily) -> Self {
+        match address_family {
+            AddressFamily::Ipv4 => rustix::net::AddressFamily::INET,
+            AddressFamily::Ipv6 => rustix::net::AddressFamily::INET6,
+        }
+    }
+}
+
+/// Select blocking or non-blocking mode.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Blocking {
+    /// Non-blocking
+    No,
+
+    /// Blocking
+    Yes,
+}
+
+/// A trait for extending `TcpListener` types.
+pub trait TcpListenerExt: private::Sealed + Sized {
+    /// Creates a new TCP socket with the given address family.
+    ///
+    /// The created socket is not bound or connected to any address and may be
+    /// used for either listening or connecting. Use
+    /// [`PoolExt::bind_existing_tcp_listener`] to bind it in preparation
+    /// for listening, or [`PoolExt::connect_into_tcp_stream`] to initiate a
+    /// connection.
+    ///
+    /// This is similar to [`Pool::bind_tcp_listener`] in that it creates a TCP
+    /// socket, however it does not perform the `bind` or `listen` steps. And,
+    /// it has a `blocking` argument to select blocking or non-blocking mode
+    /// for the created socket.
+    ///
+    /// And it's similar to [`Pool::connect_tcp_stream`] in that it creates a
+    /// TCP socket, however it does not perform the `connect` step. And,
+    /// it has a `blocking` argument to select blocking or non-blocking mode
+    /// for the created socket.
+    fn new(address_family: AddressFamily, blocking: Blocking) -> io::Result<Self>;
+
+    /// Enble listening in a `TcpListener`.
+    ///
+    /// A newly-created [`TcpListener`] created with [`TcpListenerExt::new`]
+    /// and bound with [`PoolExt::bind_existing_tcp_listener`] is not yet
+    /// listening; this function enables listening. After this, the listener
+    /// may accept new connections with [`accept`] or [`accept_with`].
+    ///
+    /// This is similar to [`TcpListener::bind_tcp_listener`] in that it
+    /// performs the `listen` step, however it does not create the socket
+    /// itself, or bind it.
+    ///
+    /// The `backlog` argument specifies an optional hint to the implementation
+    /// about how many connections can be waiting before new connections are
+    /// refused or ignored.
+    ///
+    /// [`accept`]: TcpListener::accept
+    /// [`accept_with`]: TcpListenerExt::accept_with
+    fn listen(&self, backlog: Option<i32>) -> io::Result<()>;
+
+    /// Similar to [`accept`], but the resulting TCP connection are optionally
+    /// set to non-blocking mode.
+    ///
+    /// The `accept` call itself may still block, if the socket is in blocking
+    /// mode.
+    ///
+    /// [`accept`]: TcpListener::accept
+    fn accept_with(&self, blocking: Blocking) -> io::Result<(TcpStream, SocketAddr)>;
+}
+
+impl TcpListenerExt for TcpListener {
+    fn new(address_family: AddressFamily, blocking: Blocking) -> io::Result<Self> {
+        socket(address_family, blocking, rustix::net::SocketType::STREAM).map(Self::from)
+    }
+
+    fn listen(&self, backlog: Option<i32>) -> io::Result<()> {
+        let backlog = backlog.unwrap_or_else(default_backlog);
+
+        Ok(rustix::net::listen(self, backlog)?)
+    }
+
+    fn accept_with(&self, blocking: Blocking) -> io::Result<(TcpStream, SocketAddr)> {
+        let (stream, addr) = rustix::net::acceptfrom_with(&self, socket_flags(blocking))?;
+        set_socket_flags(&stream, blocking)?;
+
+        // We know have a TCP socket, so we know we'll get an IP address.
+        let addr = match addr {
+            Some(rustix::net::SocketAddrAny::V4(v4)) => SocketAddr::V4(v4),
+            Some(rustix::net::SocketAddrAny::V6(v6)) => SocketAddr::V6(v6),
+            _ => unreachable!(),
+        };
+
+        Ok((TcpStream::from(stream), addr))
+    }
+}
+
+/// A trait for extending `UdpSocket` types.
+pub trait UdpSocketExt: private::Sealed + Sized {
+    /// Creates a new `UdpSocket` with the given address family.
+    ///
+    /// The created socket is initially not bound or connected to any address.
+    /// Use [`PoolExt::bind_existing_udp_socket`] to bind it, or
+    /// [`PoolExt::connect_existing_udp_socket`] to initiate a connection.
+    ///
+    /// This is similar to [`TcpListener::bind_udp_socket`] in that it creates
+    /// a UDP socket, however it does not perform the `bind`. And, it has a
+    /// `blocking` argument to select blocking or non-blocking mode for the
+    /// created socket.
+    ///
+    /// And it's similar to [`Pool::connect_udp_socket`] in that it creates a
+    /// UDP socket, however it does not perform the `connect` step. And,
+    /// it has a `blocking` argument to select blocking or non-blocking mode
+    /// for the created socket.
+    fn new(address_family: AddressFamily, blocking: Blocking) -> io::Result<Self>;
+}
+
+impl UdpSocketExt for UdpSocket {
+    fn new(address_family: AddressFamily, blocking: Blocking) -> io::Result<Self> {
+        socket(address_family, blocking, rustix::net::SocketType::DGRAM).map(Self::from)
+    }
+}
+
+/// A trait for extending `Pool` types.
+///
+/// These functions have a `ToSocketAddrs` argument, which can return either
+/// IPv4 or IPv6 addresses, however they also require the socket to be created
+/// with a specific address family up front. Consequently, it's recommended to
+/// do address resolution outside of this API and just pass resolved
+/// `SocketAddr`s in.
+pub trait PoolExt: private::Sealed {
+    /// Bind a [`TcpListener`] to the specified address.
+    ///
+    /// A newly-created `TcpListener` created with [`TcpListenerExt::new`]
+    /// has not been bound yet; this function binds it. Before it can accept
+    /// connections, it must be marked for listening with
+    /// [`TcpListenerExt::listen`].
+    ///
+    /// This is similar to [`Pool::bind_tcp_listener`] in that it binds a TCP
+    /// socket, however it does not create the socket itself, or perform the
+    /// `listen` step.
+    fn bind_existing_tcp_listener<A: ToSocketAddrs>(
+        &self,
+        listener: &TcpListener,
+        addrs: A,
+    ) -> io::Result<()>;
+
+    /// Bind a [`UdpSocket`] to the specified address.
+    ///
+    /// A newly-created `UdpSocket` created with [`UdpSocketExt::new`]
+    /// has not been bound yet; this function binds it.
+    ///
+    /// This is similar to [`Pool::bind_udp_socket`] in that it binds a UDP
+    /// socket, however it does not create the socket itself.
+    fn bind_existing_udp_socket<A: ToSocketAddrs>(
+        &self,
+        socket: &UdpSocket,
+        addrs: A,
+    ) -> io::Result<()>;
+
+    /// Initiate a TCP connection, converting a [`TcpListener`] to a [`TcpStream`].
+    ///
+    /// This is simlar to to [`Pool::connect_tcp_stream`] in that it performs a
+    /// TCP connection, but instead of creating a new socket itself it takes a
+    /// [`TcpListener`], such as one created with [`TcpListenerExt::new`].
+    ///
+    /// Despite the name, this function uses the `TcpListener` type as a
+    /// generic socket container.
+    fn connect_into_tcp_stream<A: ToSocketAddrs>(
+        &self,
+        socket: TcpListener,
+        addrs: A,
+    ) -> io::Result<TcpStream>;
+
+    /// Initiate a UDP connection.
+    ///
+    /// This is simlar to to [`Pool::connect_udp_socket`] in that it performs a
+    /// UDP connection, but instead of creating a new socket itself it takes a
+    /// [`UdpSocket`], such as one created with [`UdpSocketExt::new`].
+    fn connect_existing_udp_socket<A: ToSocketAddrs>(
+        &self,
+        socket: &UdpSocket,
+        addrs: A,
+    ) -> io::Result<()>;
+}
+
+impl PoolExt for Pool {
+    fn bind_existing_tcp_listener<A: ToSocketAddrs>(
+        &self,
+        listener: &TcpListener,
+        addrs: A,
+    ) -> io::Result<()> {
+        let addrs = addrs.to_socket_addrs()?;
+
+        let mut last_err = None;
+        for addr in addrs {
+            self._pool().check_addr(&addr)?;
+
+            set_reuseaddr(listener)?;
+
+            match rustix::net::bind(listener, &addr) {
+                Ok(()) => return Ok(()),
+                Err(err) => last_err = Some(err.into()),
+            }
+        }
+        match last_err {
+            Some(err) => Err(err),
+            None => Err(std::net::TcpListener::bind(NO_SOCKET_ADDRS).unwrap_err()),
+        }
+    }
+
+    fn bind_existing_udp_socket<A: ToSocketAddrs>(
+        &self,
+        socket: &UdpSocket,
+        addrs: A,
+    ) -> io::Result<()> {
+        let addrs = addrs.to_socket_addrs()?;
+
+        let mut last_err = None;
+        for addr in addrs {
+            self._pool().check_addr(&addr)?;
+
+            match rustix::net::bind(socket, &addr) {
+                Ok(()) => return Ok(()),
+                Err(err) => last_err = Some(err),
+            }
+        }
+        match last_err {
+            Some(err) => Err(err.into()),
+            None => Err(std::net::TcpListener::bind(NO_SOCKET_ADDRS).unwrap_err()),
+        }
+    }
+
+    fn connect_into_tcp_stream<A: ToSocketAddrs>(
+        &self,
+        socket: TcpListener,
+        addrs: A,
+    ) -> io::Result<TcpStream> {
+        let addrs = addrs.to_socket_addrs()?;
+
+        let mut last_err = None;
+        for addr in addrs {
+            self._pool().check_addr(&addr)?;
+
+            match rustix::net::connect(&socket, &addr) {
+                Ok(()) => return Ok(TcpStream::from(OwnedFd::from(socket))),
+                Err(err) => last_err = Some(err),
+            }
+        }
+        match last_err {
+            Some(err) => Err(err.into()),
+            None => Err(std::net::TcpStream::connect(NO_SOCKET_ADDRS).unwrap_err()),
+        }
+    }
+
+    fn connect_existing_udp_socket<A: ToSocketAddrs>(
+        &self,
+        socket: &UdpSocket,
+        addrs: A,
+    ) -> io::Result<()> {
+        let addrs = addrs.to_socket_addrs()?;
+
+        let mut last_err = None;
+        for addr in addrs {
+            self._pool().check_addr(&addr)?;
+
+            match rustix::net::connect(socket, &addr) {
+                Ok(()) => return Ok(()),
+                Err(err) => last_err = Some(err),
+            }
+        }
+        match last_err {
+            Some(err) => Err(err.into()),
+            None => Err(std::net::TcpStream::connect(NO_SOCKET_ADDRS).unwrap_err()),
+        }
+    }
+}
+
+fn socket(
+    address_family: AddressFamily,
+    blocking: Blocking,
+    socket_type: rustix::net::SocketType,
+) -> io::Result<OwnedFd> {
+    // The Rust standard library has code to call `WSAStartup`, which is
+    // needed on Windows before we do any other Winsock2 calls, so just
+    // make a useless API call once.
+    #[cfg(windows)]
+    {
+        use std::sync::Once;
+        static START: Once = Once::new();
+        START.call_once(|| {
+            std::net::TcpStream::connect(std::net::SocketAddrV4::new(
+                std::net::Ipv4Addr::UNSPECIFIED,
+                0,
+            ))
+            .unwrap_err();
+        });
+    }
+
+    // Create the socket, using the desired flags if we can.
+    let socket = rustix::net::socket_with(
+        address_family.into(),
+        socket_type,
+        socket_flags(blocking),
+        rustix::net::Protocol::default(),
+    )?;
+
+    // Set the desired flags if we couldn't set them at creation.
+    set_socket_flags(&socket, blocking)?;
+
+    Ok(socket)
+}
+
+/// Compute flags to pass to socket calls.
+fn socket_flags(blocking: Blocking) -> rustix::net::SocketFlags {
+    let _ = blocking;
+
+    #[allow(unused_mut)]
+    let mut socket_flags = rustix::net::SocketFlags::empty();
+
+    // On platforms which do support `SOCK_CLOEXEC`, use it.
+    #[cfg(not(any(
+        windows,
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "haiku"
+    )))]
+    {
+        socket_flags |= rustix::net::SocketFlags::CLOEXEC;
+    }
+
+    // On platforms which do support `SOCK_NONBLOCK`, use it.
+    #[cfg(not(any(
+        windows,
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "haiku"
+    )))]
+    match blocking {
+        Blocking::Yes => (),
+        Blocking::No => socket_flags |= rustix::net::SocketFlags::NONBLOCK,
+    }
+
+    socket_flags
+}
+
+/// On platforms which don't support `SOCK_CLOEXEC` or `SOCK_NONBLOCK, set
+/// them after creating the socket.
+fn set_socket_flags(fd: &OwnedFd, blocking: Blocking) -> io::Result<()> {
+    let _ = fd;
+    let _ = blocking;
+
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos"
+    ))]
+    {
+        rustix::io::ioctl_fioclex(fd)?;
+    }
+
+    #[cfg(any(
+        windows,
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos"
+    ))]
+    match blocking {
+        Blocking::Yes => (),
+        Blocking::No => rustix::io::ioctl_fionbio(fd, true)?,
+    }
+
+    #[cfg(target_os = "haiku")]
+    {
+        let mut flags = rustix::fs::fcntl_getfd(fd)?;
+        flags |= rustix::fs::OFlags::CLOEXEC;
+        match blocking {
+            Blocking::Yes => (),
+            Blocking::No => flags |= rustix::fs::OFlags::NONBLOCK,
+        }
+        rustix::fs::fcntl_setfd(fd, flags)?;
+    }
+
+    Ok(())
+}
+
+/// On platforms where it's desirable, set the `SO_REUSEADDR` option.
+fn set_reuseaddr(listener: &TcpListener) -> io::Result<()> {
+    let _ = listener;
+
+    // The following logic is from
+    // <https://github.com/rust-lang/rust/blob/master/library/std/src/sys_common/net.rs>
+    // at revision defa2456246a8272ceace9c1cdccdf2e4c36175e.
+
+    // On platforms with Berkeley-derived sockets, this allows to quickly
+    // rebind a socket, without needing to wait for the OS to clean up the
+    // previous one.
+    //
+    // On Windows, this allows rebinding sockets which are actively in use,
+    // which allows “socket hijacking”, so we explicitly don't set it here.
+    // https://docs.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse
+    #[cfg(not(windows))]
+    rustix::net::sockopt::set_socket_reuseaddr(listener, true)?;
+
+    Ok(())
+}
+
+/// Determine the platform-specific default backlog value.
+fn default_backlog() -> i32 {
+    // The following logic is from
+    // <https://github.com/rust-lang/rust/blob/master/library/std/src/sys_common/net.rs>
+    // at revision defa2456246a8272ceace9c1cdccdf2e4c36175e.
+
+    // The 3DS doesn't support a big connection backlog. Sometimes
+    // it allows up to about 37, but other times it doesn't even
+    // accept 32. There may be a global limitation causing this.
+    #[cfg(target_os = "horizon")]
+    let backlog = 20;
+
+    // The default for all other platforms
+    #[cfg(not(target_os = "horizon"))]
+    let backlog = 128;
+
+    backlog
+}
+
+/// Seal the public traits for [future-proofing].
+///
+/// [future-proofing]: https://rust-lang.github.io/api-guidelines/future-proofing.html
+mod private {
+    pub trait Sealed {}
+    impl Sealed for super::TcpListener {}
+    impl Sealed for super::UdpSocket {}
+    impl Sealed for super::Pool {}
+}

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -25,7 +25,7 @@ io-lifetimes = { version = "1.0.0", default-features = false }
 cap-tempfile = { path = "../cap-tempfile" }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.37.0", features = ["fs", "process", "procfs", "termios", "time"] }
+rustix = { version = "0.37.9", features = ["fs", "process", "procfs", "termios", "time"] }
 
 [target.'cfg(windows)'.dependencies]
 winx = "0.35.0"

--- a/cap-std/Cargo.toml
+++ b/cap-std/Cargo.toml
@@ -24,7 +24,7 @@ io-lifetimes = { version = "1.0.0", default-features = false }
 camino = { version = "1.0.5", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.37.0", features = ["fs"] }
+rustix = { version = "0.37.9", features = ["fs"] }
 
 [features]
 default = []

--- a/cap-std/src/net/pool.rs
+++ b/cap-std/src/net/pool.rs
@@ -21,6 +21,32 @@ impl Pool {
         }
     }
 
+    /// Add addresses to the pool.
+    ///
+    /// # Ambient Authority
+    ///
+    /// This function allows ambient access to any IP address.
+    pub fn insert<A: ToSocketAddrs>(
+        &mut self,
+        addrs: A,
+        ambient_authority: AmbientAuthority,
+    ) -> io::Result<()> {
+        self.cap.insert(addrs, ambient_authority)
+    }
+
+    /// Add a specific [`net::SocketAddr`] to the pool.
+    ///
+    /// # AmbientAuthority
+    ///
+    /// This function allows ambient access to any IP address.
+    pub fn insert_socket_addr(
+        &mut self,
+        addr: net::SocketAddr,
+        ambient_authority: AmbientAuthority,
+    ) {
+        self.cap.insert_socket_addr(addr, ambient_authority)
+    }
+
     /// Add a range of network addresses, accepting any port, to the pool.
     ///
     /// Unlike `insert_ip_net`, this function grants access to any requested
@@ -37,7 +63,8 @@ impl Pool {
         self.cap.insert_ip_net_port_any(ip_net, ambient_authority)
     }
 
-    /// Add a range of network addresses, accepting a range of ports, to the pool.
+    /// Add a range of network addresses, accepting a range of ports, to the
+    /// pool.
     ///
     /// This grants access to the port range starting at `ports_start` and,
     /// if `ports_end` is provided, ending before `ports_end`.
@@ -68,19 +95,6 @@ impl Pool {
         ambient_authority: AmbientAuthority,
     ) {
         self.cap.insert_ip_net(ip_net, port, ambient_authority)
-    }
-
-    /// Add a specific [`net::SocketAddr`] to the pool.
-    ///
-    /// # AmbientAuthority
-    ///
-    /// This function allows ambient access to any IP address.
-    pub fn insert_socket_addr(
-        &mut self,
-        addr: net::SocketAddr,
-        ambient_authority: AmbientAuthority,
-    ) {
-        self.cap.insert_socket_addr(addr, ambient_authority)
     }
 
     /// Creates a new `TcpListener` which will be bound to the specified
@@ -209,5 +223,11 @@ impl Pool {
             Some(e) => Err(e),
             None => Err(net::UdpSocket::bind(NO_SOCKET_ADDRS).unwrap_err()),
         }
+    }
+
+    /// This is for cap-net-ext.
+    #[doc(hidden)]
+    pub fn _pool(&self) -> &cap_primitives::net::Pool {
+        &self.cap
     }
 }

--- a/cap-tempfile/Cargo.toml
+++ b/cap-tempfile/Cargo.toml
@@ -21,7 +21,7 @@ camino = { version = "1.0.5", optional = true }
 rand = "0.8.1"
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.37.0", features = ["procfs"] }
+rustix = { version = "0.37.9", features = ["procfs"] }
 
 [target.'cfg(windows)'.dev-dependencies.windows-sys]
 version = "0.48.0"

--- a/cap-time-ext/Cargo.toml
+++ b/cap-time-ext/Cargo.toml
@@ -17,7 +17,7 @@ cap-primitives = { path = "../cap-primitives", version = "^1.0.10" }
 cap-std = { path = "../cap-std", optional = true, version = "^1.0.10" }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.37.0", features = ["time"] }
+rustix = { version = "0.37.9", features = ["time"] }
 
 [target.'cfg(windows)'.dependencies]
 once_cell = "1.5.2"

--- a/tests/cap-net-ext-tcp.rs
+++ b/tests/cap-net-ext-tcp.rs
@@ -1,0 +1,1177 @@
+// This file is derived from Rust's library/std/src/net/tcp/tests.rs at
+// revision 377d1a984cd2a53327092b90aa1d8b7e22d1e347.
+
+mod net;
+
+use cap_net_ext::{AddressFamily, Blocking, PoolExt, TcpListenerExt};
+use cap_std::ambient_authority;
+use cap_std::net::*;
+use net::{next_test_ip4, next_test_ip6};
+use std::io::prelude::*;
+use std::io::{ErrorKind, IoSlice, IoSliceMut};
+use std::sync::mpsc::channel;
+use std::time::{Duration, Instant};
+use std::{fmt, thread};
+
+fn each_ip(f: &mut dyn FnMut(SocketAddr)) {
+    f(next_test_ip4());
+    f(next_test_ip6());
+}
+
+macro_rules! t {
+    ($e:expr) => {
+        match $e {
+            Ok(t) => t,
+            Err(e) => panic!("received error for `{}`: {}", stringify!($e), e),
+        }
+    };
+}
+
+#[test]
+fn bind_error() {
+    let mut pool = Pool::new();
+    pool.insert_socket_addr("1.1.1.1:9999".parse().unwrap(), ambient_authority());
+
+    let listener = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    match pool.bind_existing_tcp_listener(&listener, "1.1.1.1:9999") {
+        Ok(..) => panic!(),
+        Err(e) => assert_eq!(e.kind(), ErrorKind::AddrNotAvailable),
+    }
+}
+
+#[test]
+fn connect_error() {
+    let mut pool = Pool::new();
+    pool.insert_socket_addr("0.0.0.0:1".parse().unwrap(), ambient_authority());
+
+    let socket = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    match pool.connect_into_tcp_stream(socket, "0.0.0.0:1") {
+        Ok(..) => panic!(),
+        Err(e) => assert!(
+            e.kind() == ErrorKind::ConnectionRefused
+                || e.kind() == ErrorKind::InvalidInput
+                || e.kind() == ErrorKind::AddrInUse
+                || e.kind() == ErrorKind::AddrNotAvailable
+                || e.kind() == ErrorKind::TimedOut,
+            "bad error: {} {:?}",
+            e,
+            e.kind()
+        ),
+    }
+}
+
+#[test]
+fn listen_localhost() {
+    let socket_addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    pool.insert_socket_addr(socket_addr, ambient_authority());
+    for resolved in format!("localhost:{}", socket_addr.port())
+        .to_socket_addrs()
+        .unwrap()
+    {
+        pool.insert_socket_addr(resolved, ambient_authority());
+    }
+
+    let listener = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    t!(pool.bind_existing_tcp_listener(&listener, &socket_addr));
+    listener.listen(None).unwrap();
+
+    let _t = thread::spawn(move || {
+        let socket = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+        let mut stream =
+            t!(pool.connect_into_tcp_stream(socket, &("localhost", socket_addr.port())));
+        t!(stream.write(&[144]));
+    });
+
+    let mut stream = t!(listener.accept()).0;
+    let mut buf = [0];
+    t!(stream.read(&mut buf));
+    assert!(buf[0] == 144);
+}
+
+#[test]
+fn connect_loopback() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let acceptor =
+            TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&acceptor, &addr));
+        acceptor.listen(None).unwrap();
+
+        let _t = thread::spawn(move || {
+            let host = match addr {
+                SocketAddr::V4(..) => "127.0.0.1",
+                SocketAddr::V6(..) => "::1",
+            };
+            let socket =
+                TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+            let mut stream = t!(pool.connect_into_tcp_stream(socket, &(host, addr.port())));
+            t!(stream.write(&[66]));
+        });
+
+        let mut stream = t!(acceptor.accept()).0;
+        let mut buf = [0];
+        t!(stream.read(&mut buf));
+        assert!(buf[0] == 66);
+    })
+}
+
+#[test]
+fn smoke_test() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let acceptor =
+            TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&acceptor, &addr));
+        acceptor.listen(None).unwrap();
+
+        let (tx, rx) = channel();
+        let _t = thread::spawn(move || {
+            let socket =
+                TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+            let mut stream = t!(pool.connect_into_tcp_stream(socket, &addr));
+            t!(stream.write(&[99]));
+            tx.send(t!(stream.local_addr())).unwrap();
+        });
+
+        let (mut stream, addr) = t!(acceptor.accept());
+        let mut buf = [0];
+        t!(stream.read(&mut buf));
+        assert!(buf[0] == 99);
+        assert_eq!(addr, t!(rx.recv()));
+    })
+}
+
+#[test]
+fn read_eof() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let acceptor =
+            TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&acceptor, &addr));
+        acceptor.listen(None).unwrap();
+
+        let _t = thread::spawn(move || {
+            let socket =
+                TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+            let _stream = t!(pool.connect_into_tcp_stream(socket, &addr));
+            // Close
+        });
+
+        let mut stream = t!(acceptor.accept()).0;
+        let mut buf = [0];
+        let nread = t!(stream.read(&mut buf));
+        assert_eq!(nread, 0);
+        let nread = t!(stream.read(&mut buf));
+        assert_eq!(nread, 0);
+    })
+}
+
+#[test]
+fn write_close() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let acceptor =
+            TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&acceptor, &addr));
+        acceptor.listen(None).unwrap();
+
+        let (tx, rx) = channel();
+        let _t = thread::spawn(move || {
+            let socket =
+                TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+            drop(t!(pool.connect_into_tcp_stream(socket, &addr)));
+            tx.send(()).unwrap();
+        });
+
+        let mut stream = t!(acceptor.accept()).0;
+        rx.recv().unwrap();
+        let buf = [0];
+        match stream.write(&buf) {
+            Ok(..) => {}
+            Err(e) => {
+                assert!(
+                    e.kind() == ErrorKind::ConnectionReset
+                        || e.kind() == ErrorKind::BrokenPipe
+                        || e.kind() == ErrorKind::ConnectionAborted,
+                    "unknown error: {}",
+                    e
+                );
+            }
+        }
+    })
+}
+
+#[test]
+fn multiple_connect_serial() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let max = 10;
+        let acceptor =
+            TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&acceptor, &addr));
+        acceptor.listen(None).unwrap();
+
+        let _t = thread::spawn(move || {
+            for _ in 0..max {
+                let socket =
+                    TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+                let mut stream = t!(pool.connect_into_tcp_stream(socket, &addr));
+                t!(stream.write(&[99]));
+            }
+        });
+
+        for stream in acceptor.incoming().take(max) {
+            let mut stream = t!(stream);
+            let mut buf = [0];
+            t!(stream.read(&mut buf));
+            assert_eq!(buf[0], 99);
+        }
+    })
+}
+
+#[test]
+fn multiple_connect_interleaved_greedy_schedule() {
+    const MAX: usize = 10;
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let acceptor =
+            TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&acceptor, &addr));
+        acceptor.listen(None).unwrap();
+
+        let _t = thread::spawn(move || {
+            let acceptor = acceptor;
+            for (i, stream) in acceptor.incoming().enumerate().take(MAX) {
+                // Start another thread to handle the connection
+                let _t = thread::spawn(move || {
+                    let mut stream = t!(stream);
+                    let mut buf = [0];
+                    t!(stream.read(&mut buf));
+                    assert!(buf[0] == i as u8);
+                });
+            }
+        });
+
+        connect(0, addr, pool);
+    });
+
+    fn connect(i: usize, addr: SocketAddr, pool: Pool) {
+        if i == MAX {
+            return;
+        }
+
+        let t = thread::spawn(move || {
+            let socket =
+                TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+            let mut stream = t!(pool.connect_into_tcp_stream(socket, &addr));
+            // Connect again before writing
+            connect(i + 1, addr, pool);
+            t!(stream.write(&[i as u8]));
+        });
+        t.join().ok().expect("thread panicked");
+    }
+}
+
+#[test]
+fn multiple_connect_interleaved_lazy_schedule() {
+    const MAX: usize = 10;
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let acceptor =
+            TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&acceptor, &addr));
+        acceptor.listen(None).unwrap();
+
+        let _t = thread::spawn(move || {
+            for stream in acceptor.incoming().take(MAX) {
+                // Start another thread to handle the connection
+                let _t = thread::spawn(move || {
+                    let mut stream = t!(stream);
+                    let mut buf = [0];
+                    t!(stream.read(&mut buf));
+                    assert!(buf[0] == 99);
+                });
+            }
+        });
+
+        connect(0, addr, pool);
+    });
+
+    fn connect(i: usize, addr: SocketAddr, pool: Pool) {
+        if i == MAX {
+            return;
+        }
+
+        let t = thread::spawn(move || {
+            let socket =
+                TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+            let mut stream = t!(pool.connect_into_tcp_stream(socket, &addr));
+            connect(i + 1, addr, pool);
+            t!(stream.write(&[99]));
+        });
+        t.join().ok().expect("thread panicked");
+    }
+}
+
+#[test]
+fn socket_and_peer_name() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let listener =
+            TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&listener, &addr));
+        listener.listen(None).unwrap();
+        let so_name = t!(listener.local_addr());
+        assert_eq!(addr, so_name);
+        let _t = thread::spawn(move || {
+            t!(listener.accept());
+        });
+
+        let socket = TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        let stream = t!(pool.connect_into_tcp_stream(socket, &addr));
+        assert_eq!(addr, t!(stream.peer_addr()));
+    })
+}
+
+#[test]
+fn partial_read() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let (tx, rx) = channel();
+        let srv = TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&srv, &addr));
+        srv.listen(None).unwrap();
+        let _t = thread::spawn(move || {
+            let mut cl = t!(srv.accept()).0;
+            cl.write(&[10]).unwrap();
+            let mut b = [0];
+            t!(cl.read(&mut b));
+            tx.send(()).unwrap();
+        });
+
+        let socket = TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        let mut c = t!(pool.connect_into_tcp_stream(socket, &addr));
+        let mut b = [0; 10];
+        assert_eq!(c.read(&mut b).unwrap(), 1);
+        t!(c.write(&[1]));
+        rx.recv().unwrap();
+    })
+}
+
+#[test]
+fn read_vectored() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let srv = TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&srv, &addr));
+        srv.listen(None).unwrap();
+        let socket = TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        let mut s1 = t!(pool.connect_into_tcp_stream(socket, &addr));
+        let mut s2 = t!(srv.accept()).0;
+
+        let len = s1.write(&[10, 11, 12]).unwrap();
+        assert_eq!(len, 3);
+
+        let mut a = [];
+        let mut b = [0];
+        let mut c = [0; 3];
+        let len = t!(s2.read_vectored(&mut [
+            IoSliceMut::new(&mut a),
+            IoSliceMut::new(&mut b),
+            IoSliceMut::new(&mut c)
+        ],));
+        assert!(len > 0);
+        assert_eq!(b, [10]);
+        // some implementations don't support readv, so we may only fill the first
+        // buffer
+        assert!(len == 1 || c == [11, 12, 0]);
+    })
+}
+
+#[test]
+fn write_vectored() {
+    let mut pool = Pool::new();
+
+    each_ip(&mut |addr| {
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let srv = TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&srv, &addr));
+        srv.listen(None).unwrap();
+        let socket = TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        let mut s1 = t!(pool.connect_into_tcp_stream(socket, &addr));
+        let mut s2 = t!(srv.accept()).0;
+
+        let a = [];
+        let b = [10];
+        let c = [11, 12];
+        t!(s1.write_vectored(&[IoSlice::new(&a), IoSlice::new(&b), IoSlice::new(&c)]));
+
+        let mut buf = [0; 4];
+        let len = t!(s2.read(&mut buf));
+        // some implementations don't support writev, so we may only write the first
+        // buffer
+        if len == 1 {
+            assert_eq!(buf, [10, 0, 0, 0]);
+        } else {
+            assert_eq!(len, 3);
+            assert_eq!(buf, [10, 11, 12, 0]);
+        }
+    })
+}
+
+#[test]
+fn double_bind() {
+    let mut pool = Pool::new();
+
+    each_ip(&mut |addr| {
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let listener1 =
+            TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&listener1, &addr));
+        listener1.listen(None).unwrap();
+        let listener2 =
+            TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        match pool.bind_existing_tcp_listener(&listener2, &addr) {
+            Ok(()) => panic!(
+                "This system (perhaps due to options set by pool.bind_existing_tcp_listener) \
+                 permits double binding: {:?} and {:?}",
+                listener1, listener2
+            ),
+            Err(e) => {
+                assert!(
+                    e.kind() == ErrorKind::ConnectionRefused
+                        || e.kind() == ErrorKind::Other
+                        || e.kind() == ErrorKind::AddrInUse,
+                    "unknown error: {} {:?}",
+                    e,
+                    e.kind()
+                );
+            }
+        }
+    })
+}
+
+#[test]
+fn tcp_clone_smoke() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let acceptor =
+            TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&acceptor, &addr));
+        acceptor.listen(None).unwrap();
+
+        let _t = thread::spawn(move || {
+            let socket =
+                TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+            let mut s = t!(pool.connect_into_tcp_stream(socket, &addr));
+            let mut buf = [0, 0];
+            assert_eq!(s.read(&mut buf).unwrap(), 1);
+            assert_eq!(buf[0], 1);
+            t!(s.write(&[2]));
+        });
+
+        let mut s1 = t!(acceptor.accept()).0;
+        let s2 = t!(s1.try_clone());
+
+        let (tx1, rx1) = channel();
+        let (tx2, rx2) = channel();
+        let _t = thread::spawn(move || {
+            let mut s2 = s2;
+            rx1.recv().unwrap();
+            t!(s2.write(&[1]));
+            tx2.send(()).unwrap();
+        });
+        tx1.send(()).unwrap();
+        let mut buf = [0, 0];
+        assert_eq!(s1.read(&mut buf).unwrap(), 1);
+        rx2.recv().unwrap();
+    })
+}
+
+#[test]
+fn tcp_clone_two_read() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let acceptor =
+            TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&acceptor, &addr));
+        acceptor.listen(None).unwrap();
+        let (tx1, rx) = channel();
+        let tx2 = tx1.clone();
+
+        let _t = thread::spawn(move || {
+            let socket =
+                TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+            let mut s = t!(pool.connect_into_tcp_stream(socket, &addr));
+            t!(s.write(&[1]));
+            rx.recv().unwrap();
+            t!(s.write(&[2]));
+            rx.recv().unwrap();
+        });
+
+        let mut s1 = t!(acceptor.accept()).0;
+        let s2 = t!(s1.try_clone());
+
+        let (done, rx) = channel();
+        let _t = thread::spawn(move || {
+            let mut s2 = s2;
+            let mut buf = [0, 0];
+            t!(s2.read(&mut buf));
+            tx2.send(()).unwrap();
+            done.send(()).unwrap();
+        });
+        let mut buf = [0, 0];
+        t!(s1.read(&mut buf));
+        tx1.send(()).unwrap();
+
+        rx.recv().unwrap();
+    })
+}
+
+#[test]
+fn tcp_clone_two_write() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let acceptor =
+            TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&acceptor, &addr));
+        acceptor.listen(None).unwrap();
+
+        let _t = thread::spawn(move || {
+            let socket =
+                TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+            let mut s = t!(pool.connect_into_tcp_stream(socket, &addr));
+            let mut buf = [0, 1];
+            t!(s.read(&mut buf));
+            t!(s.read(&mut buf));
+        });
+
+        let mut s1 = t!(acceptor.accept()).0;
+        let s2 = t!(s1.try_clone());
+
+        let (done, rx) = channel();
+        let _t = thread::spawn(move || {
+            let mut s2 = s2;
+            t!(s2.write(&[1]));
+            done.send(()).unwrap();
+        });
+        t!(s1.write(&[2]));
+
+        rx.recv().unwrap();
+    })
+}
+
+#[test]
+// FIXME: https://github.com/fortanix/rust-sgx/issues/110
+#[cfg_attr(target_env = "sgx", ignore)]
+fn shutdown_smoke() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let a = TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&a, &addr));
+        a.listen(None).unwrap();
+        let _t = thread::spawn(move || {
+            let mut c = t!(a.accept()).0;
+            let mut b = [0];
+            assert_eq!(c.read(&mut b).unwrap(), 0);
+            t!(c.write(&[1]));
+        });
+
+        let socket = TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        let mut s = t!(pool.connect_into_tcp_stream(socket, &addr));
+        t!(s.shutdown(Shutdown::Write));
+        assert!(s.write(&[1]).is_err());
+        let mut b = [0, 0];
+        assert_eq!(t!(s.read(&mut b)), 1);
+        assert_eq!(b[0], 1);
+    })
+}
+
+#[test]
+// FIXME: https://github.com/fortanix/rust-sgx/issues/110
+#[cfg_attr(target_env = "sgx", ignore)]
+fn close_readwrite_smoke() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let a = TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&a, &addr));
+        a.listen(None).unwrap();
+        let (tx, rx) = channel::<()>();
+        let _t = thread::spawn(move || {
+            let _s = t!(a.accept());
+            let _ = rx.recv();
+        });
+
+        let mut b = [0];
+        let socket = TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        let mut s = t!(pool.connect_into_tcp_stream(socket, &addr));
+        let mut s2 = t!(s.try_clone());
+
+        // closing should prevent reads/writes
+        t!(s.shutdown(Shutdown::Write));
+        assert!(s.write(&[0]).is_err());
+        t!(s.shutdown(Shutdown::Read));
+        assert_eq!(s.read(&mut b).unwrap(), 0);
+
+        // closing should affect previous handles
+        assert!(s2.write(&[0]).is_err());
+        assert_eq!(s2.read(&mut b).unwrap(), 0);
+
+        // closing should affect new handles
+        let mut s3 = t!(s.try_clone());
+        assert!(s3.write(&[0]).is_err());
+        assert_eq!(s3.read(&mut b).unwrap(), 0);
+
+        // make sure these don't die
+        let _ = s2.shutdown(Shutdown::Read);
+        let _ = s2.shutdown(Shutdown::Write);
+        let _ = s3.shutdown(Shutdown::Read);
+        let _ = s3.shutdown(Shutdown::Write);
+        drop(tx);
+    })
+}
+
+#[test]
+#[cfg(unix)] // test doesn't work on Windows, see #31657
+fn close_read_wakes_up() {
+    let mut pool = Pool::new();
+
+    each_ip(&mut |addr| {
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let a = TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&a, &addr));
+        a.listen(None).unwrap();
+        let (tx1, rx) = channel::<()>();
+        let _t = thread::spawn(move || {
+            let _s = t!(a.accept());
+            let _ = rx.recv();
+        });
+
+        let socket = TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        let s = t!(pool.connect_into_tcp_stream(socket, &addr));
+        let s2 = t!(s.try_clone());
+        let (tx, rx) = channel();
+        let _t = thread::spawn(move || {
+            let mut s2 = s2;
+            assert_eq!(t!(s2.read(&mut [0])), 0);
+            tx.send(()).unwrap();
+        });
+        // this should wake up the child thread
+        t!(s.shutdown(Shutdown::Read));
+
+        // this test will never finish if the child doesn't wake up
+        rx.recv().unwrap();
+        drop(tx1);
+    })
+}
+
+#[test]
+fn clone_while_reading() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let accept = TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&accept, &addr));
+        accept.listen(None).unwrap();
+
+        // Enqueue a thread to write to a socket
+        let (tx, rx) = channel();
+        let (txdone, rxdone) = channel();
+        let txdone2 = txdone.clone();
+        let _t = thread::spawn(move || {
+            let socket =
+                TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+            let mut tcp = t!(pool.connect_into_tcp_stream(socket, &addr));
+            rx.recv().unwrap();
+            t!(tcp.write(&[0]));
+            txdone2.send(()).unwrap();
+        });
+
+        // Spawn off a reading clone
+        let tcp = t!(accept.accept()).0;
+        let tcp2 = t!(tcp.try_clone());
+        let txdone3 = txdone.clone();
+        let _t = thread::spawn(move || {
+            let mut tcp2 = tcp2;
+            t!(tcp2.read(&mut [0]));
+            txdone3.send(()).unwrap();
+        });
+
+        // Try to ensure that the reading clone is indeed reading
+        for _ in 0..50 {
+            thread::yield_now();
+        }
+
+        // clone the handle again while it's reading, then let it finish the
+        // read.
+        let _ = t!(tcp.try_clone());
+        tx.send(()).unwrap();
+        rxdone.recv().unwrap();
+        rxdone.recv().unwrap();
+    })
+}
+
+#[test]
+fn clone_accept_smoke() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let a = TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&a, &addr));
+        a.listen(None).unwrap();
+        let a2 = t!(a.try_clone());
+
+        let p = pool.clone();
+        let _t = thread::spawn(move || {
+            let socket =
+                TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+            let _ = p.connect_into_tcp_stream(socket, &addr);
+        });
+        let p = pool.clone();
+        let _t = thread::spawn(move || {
+            let socket =
+                TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+            let _ = p.connect_into_tcp_stream(socket, &addr);
+        });
+
+        t!(a.accept());
+        t!(a2.accept());
+    })
+}
+
+#[test]
+fn clone_accept_concurrent() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let a = TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&a, &addr));
+        a.listen(None).unwrap();
+        let a2 = t!(a.try_clone());
+
+        let (tx, rx) = channel();
+        let tx2 = tx.clone();
+
+        let _t = thread::spawn(move || {
+            tx.send(t!(a.accept())).unwrap();
+        });
+        let _t = thread::spawn(move || {
+            tx2.send(t!(a2.accept())).unwrap();
+        });
+
+        let p = pool.clone();
+        let _t = thread::spawn(move || {
+            let socket =
+                TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+            let _ = p.connect_into_tcp_stream(socket, &addr);
+        });
+        let p = pool.clone();
+        let _t = thread::spawn(move || {
+            let socket =
+                TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+            let _ = p.connect_into_tcp_stream(socket, &addr);
+        });
+
+        rx.recv().unwrap();
+        rx.recv().unwrap();
+    })
+}
+
+#[test]
+fn debug() {
+    let mut pool = Pool::new();
+
+    #[cfg(not(target_env = "sgx"))]
+    fn render_socket_addr<'a>(addr: &'a SocketAddr) -> impl fmt::Debug + 'a {
+        addr
+    }
+    #[cfg(target_env = "sgx")]
+    fn render_socket_addr<'a>(addr: &'a SocketAddr) -> impl fmt::Debug + 'a {
+        addr.to_string()
+    }
+
+    #[cfg(target_env = "sgx")]
+    use std::os::fortanix_sgx::io::AsRawFd;
+    #[cfg(unix)]
+    use std::os::unix::io::AsRawFd;
+    #[cfg(not(windows))]
+    fn render_inner(addr: &dyn AsRawFd) -> impl fmt::Debug {
+        addr.as_raw_fd()
+    }
+    #[cfg(windows)]
+    fn render_inner(addr: &dyn std::os::windows::io::AsRawSocket) -> impl fmt::Debug {
+        addr.as_raw_socket()
+    }
+
+    let inner_name = if cfg!(windows) { "socket" } else { "fd" };
+    let socket_addr = next_test_ip4();
+    pool.insert_socket_addr(socket_addr, ambient_authority());
+    for resolved in format!("localhost:{}", socket_addr.port())
+        .to_socket_addrs()
+        .unwrap()
+    {
+        pool.insert_socket_addr(resolved, ambient_authority());
+    }
+
+    let listener = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    t!(pool.bind_existing_tcp_listener(&listener, &socket_addr));
+    listener.listen(None).unwrap();
+    let compare = format!(
+        "TcpListener {{ addr: {:?}, {}: {:?} }}",
+        render_socket_addr(&socket_addr),
+        inner_name,
+        render_inner(&listener)
+    );
+    assert_eq!(format!("{:?}", listener), compare);
+
+    let socket = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    let stream = t!(pool.connect_into_tcp_stream(socket, &("localhost", socket_addr.port())));
+    let compare = format!(
+        "TcpStream {{ addr: {:?}, peer: {:?}, {}: {:?} }}",
+        render_socket_addr(&stream.local_addr().unwrap()),
+        render_socket_addr(&stream.peer_addr().unwrap()),
+        inner_name,
+        render_inner(&stream)
+    );
+    assert_eq!(format!("{:?}", stream), compare);
+}
+
+// FIXME: re-enabled openbsd tests once their socket timeout code
+//        no longer has rounding errors.
+// VxWorks ignores SO_SNDTIMEO.
+#[cfg_attr(
+    any(target_os = "netbsd", target_os = "openbsd", target_os = "vxworks"),
+    ignore
+)]
+#[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
+#[test]
+fn timeouts() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    pool.insert_socket_addr(addr, ambient_authority());
+    for resolved in format!("localhost:{}", addr.port())
+        .to_socket_addrs()
+        .unwrap()
+    {
+        pool.insert_socket_addr(resolved, ambient_authority());
+    }
+
+    let listener = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    t!(pool.bind_existing_tcp_listener(&listener, &addr));
+    listener.listen(None).unwrap();
+
+    let socket = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    let stream = t!(pool.connect_into_tcp_stream(socket, &("localhost", addr.port())));
+    let dur = Duration::new(15410, 0);
+
+    assert_eq!(None, t!(stream.read_timeout()));
+
+    t!(stream.set_read_timeout(Some(dur)));
+    assert_eq!(Some(dur), t!(stream.read_timeout()));
+
+    assert_eq!(None, t!(stream.write_timeout()));
+
+    t!(stream.set_write_timeout(Some(dur)));
+    assert_eq!(Some(dur), t!(stream.write_timeout()));
+
+    t!(stream.set_read_timeout(None));
+    assert_eq!(None, t!(stream.read_timeout()));
+
+    t!(stream.set_write_timeout(None));
+    assert_eq!(None, t!(stream.write_timeout()));
+    drop(listener);
+}
+
+#[test]
+#[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
+fn test_read_timeout() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    pool.insert_socket_addr(addr, ambient_authority());
+    for resolved in format!("localhost:{}", addr.port())
+        .to_socket_addrs()
+        .unwrap()
+    {
+        pool.insert_socket_addr(resolved, ambient_authority());
+    }
+
+    let listener = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    t!(pool.bind_existing_tcp_listener(&listener, &addr));
+    listener.listen(None).unwrap();
+
+    let socket = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    let mut stream = t!(pool.connect_into_tcp_stream(socket, &("localhost", addr.port())));
+    t!(stream.set_read_timeout(Some(Duration::from_millis(1000))));
+
+    let mut buf = [0; 10];
+    let start = Instant::now();
+    let kind = stream
+        .read_exact(&mut buf)
+        .err()
+        .expect("expected error")
+        .kind();
+    assert!(
+        kind == ErrorKind::WouldBlock || kind == ErrorKind::TimedOut,
+        "unexpected_error: {:?}",
+        kind
+    );
+    assert!(start.elapsed() > Duration::from_millis(400));
+    drop(listener);
+}
+
+#[test]
+#[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
+fn test_read_with_timeout() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    pool.insert_socket_addr(addr, ambient_authority());
+    for resolved in format!("localhost:{}", addr.port())
+        .to_socket_addrs()
+        .unwrap()
+    {
+        pool.insert_socket_addr(resolved, ambient_authority());
+    }
+
+    let listener = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    t!(pool.bind_existing_tcp_listener(&listener, &addr));
+    listener.listen(None).unwrap();
+
+    let socket = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    let mut stream = t!(pool.connect_into_tcp_stream(socket, &("localhost", addr.port())));
+    t!(stream.set_read_timeout(Some(Duration::from_millis(1000))));
+
+    let mut other_end = t!(listener.accept()).0;
+    t!(other_end.write_all(b"hello world"));
+
+    let mut buf = [0; 11];
+    t!(stream.read(&mut buf));
+    assert_eq!(b"hello world", &buf[..]);
+
+    let start = Instant::now();
+    let kind = stream
+        .read_exact(&mut buf)
+        .err()
+        .expect("expected error")
+        .kind();
+    assert!(
+        kind == ErrorKind::WouldBlock || kind == ErrorKind::TimedOut,
+        "unexpected_error: {:?}",
+        kind
+    );
+    assert!(start.elapsed() > Duration::from_millis(400));
+    drop(listener);
+}
+
+// Ensure the `set_read_timeout` and `set_write_timeout` calls return errors
+// when passed zero Durations
+#[test]
+fn test_timeout_zero_duration() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    pool.insert_socket_addr(addr, ambient_authority());
+
+    let listener = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    t!(pool.bind_existing_tcp_listener(&listener, &addr));
+    listener.listen(None).unwrap();
+    let socket = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    let stream = t!(pool.connect_into_tcp_stream(socket, &addr));
+
+    let result = stream.set_write_timeout(Some(Duration::new(0, 0)));
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidInput);
+
+    let result = stream.set_read_timeout(Some(Duration::new(0, 0)));
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidInput);
+
+    drop(listener);
+}
+
+#[test]
+#[cfg_attr(target_env = "sgx", ignore)]
+fn nodelay() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    pool.insert_socket_addr(addr, ambient_authority());
+    for resolved in format!("localhost:{}", addr.port())
+        .to_socket_addrs()
+        .unwrap()
+    {
+        pool.insert_socket_addr(resolved, ambient_authority());
+    }
+
+    let _listener = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    t!(pool.bind_existing_tcp_listener(&_listener, &addr));
+    _listener.listen(None).unwrap();
+
+    let socket = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    let stream = t!(pool.connect_into_tcp_stream(socket, &("localhost", addr.port())));
+
+    assert_eq!(false, t!(stream.nodelay()));
+    t!(stream.set_nodelay(true));
+    assert_eq!(true, t!(stream.nodelay()));
+    t!(stream.set_nodelay(false));
+    assert_eq!(false, t!(stream.nodelay()));
+}
+
+#[test]
+#[cfg_attr(target_env = "sgx", ignore)]
+fn ttl() {
+    let ttl = 100;
+
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    pool.insert_socket_addr(addr, ambient_authority());
+    for resolved in format!("localhost:{}", addr.port())
+        .to_socket_addrs()
+        .unwrap()
+    {
+        pool.insert_socket_addr(resolved, ambient_authority());
+    }
+
+    let listener = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    t!(pool.bind_existing_tcp_listener(&listener, &addr));
+    listener.listen(None).unwrap();
+
+    t!(listener.set_ttl(ttl));
+    assert_eq!(ttl, t!(listener.ttl()));
+
+    let socket = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    let stream = t!(pool.connect_into_tcp_stream(socket, &("localhost", addr.port())));
+
+    t!(stream.set_ttl(ttl));
+    assert_eq!(ttl, t!(stream.ttl()));
+}
+
+#[test]
+#[cfg_attr(target_env = "sgx", ignore)]
+fn set_nonblocking() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    pool.insert_socket_addr(addr, ambient_authority());
+    for resolved in format!("localhost:{}", addr.port())
+        .to_socket_addrs()
+        .unwrap()
+    {
+        pool.insert_socket_addr(resolved, ambient_authority());
+    }
+
+    let listener = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    t!(pool.bind_existing_tcp_listener(&listener, &addr));
+    listener.listen(None).unwrap();
+
+    t!(listener.set_nonblocking(true));
+    t!(listener.set_nonblocking(false));
+
+    let socket = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    let mut stream = t!(pool.connect_into_tcp_stream(socket, &("localhost", addr.port())));
+
+    t!(stream.set_nonblocking(false));
+    t!(stream.set_nonblocking(true));
+
+    let mut buf = [0];
+    match stream.read(&mut buf) {
+        Ok(_) => panic!("expected error"),
+        Err(ref e) if e.kind() == ErrorKind::WouldBlock => {}
+        Err(e) => panic!("unexpected error {}", e),
+    }
+}
+
+#[test]
+#[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
+fn peek() {
+    each_ip(&mut |addr| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let (txdone, rxdone) = channel();
+
+        let srv = TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_tcp_listener(&srv, &addr));
+        srv.listen(None).unwrap();
+        let _t = thread::spawn(move || {
+            let mut cl = t!(srv.accept()).0;
+            cl.write(&[1, 3, 3, 7]).unwrap();
+            t!(rxdone.recv());
+        });
+
+        let socket = TcpListener::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        let mut c = t!(pool.connect_into_tcp_stream(socket, &addr));
+        let mut b = [0; 10];
+        for _ in 1..3 {
+            let len = c.peek(&mut b).unwrap();
+            assert_eq!(len, 4);
+        }
+        let len = c.read(&mut b).unwrap();
+        assert_eq!(len, 4);
+
+        t!(c.set_nonblocking(true));
+        match c.peek(&mut b) {
+            Ok(_) => panic!("expected error"),
+            Err(ref e) if e.kind() == ErrorKind::WouldBlock => {}
+            Err(e) => panic!("unexpected error {}", e),
+        }
+        t!(txdone.send(()));
+    })
+}
+
+#[test]
+#[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
+fn connect_timeout_valid() {
+    let mut pool = Pool::new();
+    pool.insert_socket_addr("127.0.0.1:0".parse().unwrap(), ambient_authority());
+    let listener = TcpListener::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    pool.bind_existing_tcp_listener(&listener, "127.0.0.1:0")
+        .unwrap();
+    listener.listen(None).unwrap();
+    let addr = listener.local_addr().unwrap();
+    let mut pool = Pool::new();
+    pool.insert_socket_addr(addr, ambient_authority());
+    pool.connect_timeout_tcp_stream(&addr, Duration::from_secs(2))
+        .unwrap();
+}

--- a/tests/cap-net-ext-udp.rs
+++ b/tests/cap-net-ext-udp.rs
@@ -1,0 +1,474 @@
+// This file is derived from Rust's library/std/src/net/udp/tests.rs at
+// revision 377d1a984cd2a53327092b90aa1d8b7e22d1e347.
+
+mod net;
+mod sys_common;
+
+use cap_net_ext::{AddressFamily, Blocking, PoolExt, UdpSocketExt};
+use cap_std::ambient_authority;
+use cap_std::net::*;
+use net::{next_test_ip4, next_test_ip6};
+use std::io::ErrorKind;
+use std::sync::mpsc::channel;
+//use sys_common::AsInner;
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn each_ip(f: &mut dyn FnMut(SocketAddr, SocketAddr)) {
+    f(next_test_ip4(), next_test_ip4());
+    f(next_test_ip6(), next_test_ip6());
+}
+
+macro_rules! t {
+    ($e:expr) => {
+        match $e {
+            Ok(t) => t,
+            Err(e) => panic!("received error for `{}`: {}", stringify!($e), e),
+        }
+    };
+}
+
+#[test]
+fn bind_error() {
+    let mut pool = Pool::new();
+    pool.insert_socket_addr("1.1.1.1:9999".parse().unwrap(), ambient_authority());
+
+    let socket = UdpSocket::new(AddressFamily::Ipv4, Blocking::Yes).unwrap();
+    match pool.bind_existing_udp_socket(&socket, "1.1.1.1:9999") {
+        Ok(..) => panic!(),
+        Err(e) => assert_eq!(e.kind(), ErrorKind::AddrNotAvailable),
+    }
+}
+
+#[test]
+fn socket_smoke_test_ip4() {
+    each_ip(&mut |server_ip, client_ip| {
+        let mut client_pool = Pool::new();
+        client_pool.insert_socket_addr(client_ip, ambient_authority());
+        let mut server_pool = Pool::new();
+        server_pool.insert_socket_addr(server_ip, ambient_authority());
+
+        let (tx1, rx1) = channel();
+        let (tx2, rx2) = channel();
+
+        let p = server_pool.clone();
+        let _t = thread::spawn(move || {
+            let client =
+                UdpSocket::new(AddressFamily::of_socket_addr(client_ip), Blocking::Yes).unwrap();
+            t!(client_pool.bind_existing_udp_socket(&client, &client_ip));
+            rx1.recv().unwrap();
+            t!(p.send_to_udp_socket_addr(&client, &[99], &server_ip));
+            tx2.send(()).unwrap();
+        });
+
+        let server =
+            UdpSocket::new(AddressFamily::of_socket_addr(server_ip), Blocking::Yes).unwrap();
+        t!(server_pool.bind_existing_udp_socket(&server, &server_ip));
+        tx1.send(()).unwrap();
+        let mut buf = [0];
+        let (nread, src) = t!(server.recv_from(&mut buf));
+        assert_eq!(nread, 1);
+        assert_eq!(buf[0], 99);
+        assert_eq!(src, client_ip);
+        rx2.recv().unwrap();
+    })
+}
+
+#[test]
+fn socket_name() {
+    each_ip(&mut |addr, _| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let server = UdpSocket::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_udp_socket(&server, &addr));
+        assert_eq!(addr, t!(server.local_addr()));
+    })
+}
+
+#[test]
+fn socket_peer() {
+    each_ip(&mut |addr1, addr2| {
+        let mut pool1 = Pool::new();
+        pool1.insert_socket_addr(addr1, ambient_authority());
+        let mut pool2 = Pool::new();
+        pool2.insert_socket_addr(addr2, ambient_authority());
+
+        let server = UdpSocket::new(AddressFamily::of_socket_addr(addr1), Blocking::Yes).unwrap();
+        t!(pool1.bind_existing_udp_socket(&server, &addr1));
+        assert_eq!(
+            server.peer_addr().unwrap_err().kind(),
+            ErrorKind::NotConnected
+        );
+        t!(pool2.connect_existing_udp_socket(&server, &addr2));
+        assert_eq!(addr2, t!(server.peer_addr()));
+    })
+}
+
+#[test]
+fn udp_clone_smoke() {
+    each_ip(&mut |addr1, addr2| {
+        let mut pool1 = Pool::new();
+        pool1.insert_socket_addr(addr1, ambient_authority());
+        let mut pool2 = Pool::new();
+        pool2.insert_socket_addr(addr2, ambient_authority());
+
+        let sock1 = UdpSocket::new(AddressFamily::of_socket_addr(addr1), Blocking::Yes).unwrap();
+        t!(pool1.bind_existing_udp_socket(&sock1, &addr1));
+        let sock2 = UdpSocket::new(AddressFamily::of_socket_addr(addr2), Blocking::Yes).unwrap();
+        t!(pool2.bind_existing_udp_socket(&sock2, &addr2));
+
+        let _t = thread::spawn(move || {
+            let mut buf = [0, 0];
+            assert_eq!(sock2.recv_from(&mut buf).unwrap(), (1, addr1));
+            assert_eq!(buf[0], 1);
+            t!(pool1.send_to_udp_socket_addr(&sock2, &[2], &addr1));
+        });
+
+        let sock3 = t!(sock1.try_clone());
+
+        let (tx1, rx1) = channel();
+        let (tx2, rx2) = channel();
+        let p = pool2.clone();
+        let _t = thread::spawn(move || {
+            rx1.recv().unwrap();
+            t!(p.send_to_udp_socket_addr(&sock3, &[1], &addr2));
+            tx2.send(()).unwrap();
+        });
+        tx1.send(()).unwrap();
+        let mut buf = [0, 0];
+        assert_eq!(sock1.recv_from(&mut buf).unwrap(), (1, addr2));
+        rx2.recv().unwrap();
+    })
+}
+
+#[test]
+fn udp_clone_two_read() {
+    each_ip(&mut |addr1, addr2| {
+        let mut pool1 = Pool::new();
+        pool1.insert_socket_addr(addr1, ambient_authority());
+        let mut pool2 = Pool::new();
+        pool2.insert_socket_addr(addr2, ambient_authority());
+
+        let sock1 = UdpSocket::new(AddressFamily::of_socket_addr(addr1), Blocking::Yes).unwrap();
+        t!(pool1.bind_existing_udp_socket(&sock1, &addr1));
+        let sock2 = UdpSocket::new(AddressFamily::of_socket_addr(addr2), Blocking::Yes).unwrap();
+        t!(pool2.bind_existing_udp_socket(&sock2, &addr2));
+        let (tx1, rx) = channel();
+        let tx2 = tx1.clone();
+
+        let _t = thread::spawn(move || {
+            t!(pool1.send_to_udp_socket_addr(&sock2, &[1], &addr1));
+            rx.recv().unwrap();
+            t!(pool1.send_to_udp_socket_addr(&sock2, &[2], &addr1));
+            rx.recv().unwrap();
+        });
+
+        let sock3 = t!(sock1.try_clone());
+
+        let (done, rx) = channel();
+        let _t = thread::spawn(move || {
+            let mut buf = [0, 0];
+            t!(sock3.recv_from(&mut buf));
+            tx2.send(()).unwrap();
+            done.send(()).unwrap();
+        });
+        let mut buf = [0, 0];
+        t!(sock1.recv_from(&mut buf));
+        tx1.send(()).unwrap();
+
+        rx.recv().unwrap();
+    })
+}
+
+#[test]
+fn udp_clone_two_write() {
+    each_ip(&mut |addr1, addr2| {
+        let mut pool1 = Pool::new();
+        pool1.insert_socket_addr(addr1, ambient_authority());
+        let mut pool2 = Pool::new();
+        pool2.insert_socket_addr(addr2, ambient_authority());
+
+        let sock1 = UdpSocket::new(AddressFamily::of_socket_addr(addr1), Blocking::Yes).unwrap();
+        t!(pool1.bind_existing_udp_socket(&sock1, &addr1));
+        let sock2 = UdpSocket::new(AddressFamily::of_socket_addr(addr2), Blocking::Yes).unwrap();
+        t!(pool2.bind_existing_udp_socket(&sock2, &addr2));
+
+        let (tx, rx) = channel();
+        let (serv_tx, serv_rx) = channel();
+
+        let _t = thread::spawn(move || {
+            let mut buf = [0, 1];
+            rx.recv().unwrap();
+            t!(sock2.recv_from(&mut buf));
+            serv_tx.send(()).unwrap();
+        });
+
+        let sock3 = t!(sock1.try_clone());
+
+        let (done, rx) = channel();
+        let tx2 = tx.clone();
+        let p = pool2.clone();
+        let _t = thread::spawn(move || {
+            if p.send_to_udp_socket_addr(&sock3, &[1], &addr2).is_ok() {
+                let _ = tx2.send(());
+            }
+            done.send(()).unwrap();
+        });
+        if pool2.send_to_udp_socket_addr(&sock1, &[2], &addr2).is_ok() {
+            let _ = tx.send(());
+        }
+        drop(tx);
+
+        rx.recv().unwrap();
+        serv_rx.recv().unwrap();
+    })
+}
+
+/* Disable this test, as it depends on Rust-internal details.
+#[test]
+fn debug() {
+    let name = if cfg!(windows) { "socket" } else { "fd" };
+    let socket_addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+
+    let udpsock_inner = udpsock.0.socket().as_inner();
+    let compare = format!("UdpSocket {{ addr: {:?}, {}: {:?} }}", socket_addr, name, udpsock_inner);
+    assert_eq!(format!("{:?}", udpsock), compare);
+}
+*/
+
+// FIXME: re-enabled openbsd/netbsd tests once their socket timeout code
+//        no longer has rounding errors.
+// VxWorks ignores SO_SNDTIMEO.
+#[cfg_attr(
+    any(target_os = "netbsd", target_os = "openbsd", target_os = "vxworks"),
+    ignore
+)]
+#[test]
+fn timeouts() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    pool.insert_socket_addr(addr, ambient_authority());
+
+    let stream = UdpSocket::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+    t!(pool.bind_existing_udp_socket(&stream, &addr));
+    let dur = Duration::new(15410, 0);
+
+    assert_eq!(None, t!(stream.read_timeout()));
+
+    t!(stream.set_read_timeout(Some(dur)));
+    assert_eq!(Some(dur), t!(stream.read_timeout()));
+
+    assert_eq!(None, t!(stream.write_timeout()));
+
+    t!(stream.set_write_timeout(Some(dur)));
+    assert_eq!(Some(dur), t!(stream.write_timeout()));
+
+    t!(stream.set_read_timeout(None));
+    assert_eq!(None, t!(stream.read_timeout()));
+
+    t!(stream.set_write_timeout(None));
+    assert_eq!(None, t!(stream.write_timeout()));
+}
+
+#[test]
+fn test_read_timeout() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    pool.insert_socket_addr(addr, ambient_authority());
+
+    let stream = UdpSocket::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+    t!(pool.bind_existing_udp_socket(&stream, &addr));
+    t!(stream.set_read_timeout(Some(Duration::from_millis(1000))));
+
+    let mut buf = [0; 10];
+
+    let start = Instant::now();
+    loop {
+        let kind = stream
+            .recv_from(&mut buf)
+            .err()
+            .expect("expected error")
+            .kind();
+        if kind != ErrorKind::Interrupted {
+            assert!(
+                kind == ErrorKind::WouldBlock || kind == ErrorKind::TimedOut,
+                "unexpected_error: {:?}",
+                kind
+            );
+            break;
+        }
+    }
+    assert!(start.elapsed() > Duration::from_millis(400));
+}
+
+#[test]
+fn test_read_with_timeout() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    pool.insert_socket_addr(addr, ambient_authority());
+
+    let stream = UdpSocket::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+    t!(pool.bind_existing_udp_socket(&stream, &addr));
+    t!(stream.set_read_timeout(Some(Duration::from_millis(1000))));
+
+    t!(pool.send_to_udp_socket_addr(&stream, b"hello world", &addr));
+
+    let mut buf = [0; 11];
+    t!(stream.recv_from(&mut buf));
+    assert_eq!(b"hello world", &buf[..]);
+
+    let start = Instant::now();
+    loop {
+        let kind = stream
+            .recv_from(&mut buf)
+            .err()
+            .expect("expected error")
+            .kind();
+        if kind != ErrorKind::Interrupted {
+            assert!(
+                kind == ErrorKind::WouldBlock || kind == ErrorKind::TimedOut,
+                "unexpected_error: {:?}",
+                kind
+            );
+            break;
+        }
+    }
+    assert!(start.elapsed() > Duration::from_millis(400));
+}
+
+// Ensure the `set_read_timeout` and `set_write_timeout` calls return errors
+// when passed zero Durations
+#[test]
+fn test_timeout_zero_duration() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    pool.insert_socket_addr(addr, ambient_authority());
+
+    let socket = UdpSocket::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+    t!(pool.bind_existing_udp_socket(&socket, &addr));
+
+    let result = socket.set_write_timeout(Some(Duration::new(0, 0)));
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidInput);
+
+    let result = socket.set_read_timeout(Some(Duration::new(0, 0)));
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidInput);
+}
+
+#[test]
+fn connect_send_recv() {
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    pool.insert_socket_addr(addr, ambient_authority());
+
+    let socket = UdpSocket::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+    t!(pool.bind_existing_udp_socket(&socket, &addr));
+    t!(pool.connect_existing_udp_socket(&socket, addr));
+
+    t!(socket.send(b"hello world"));
+
+    let mut buf = [0; 11];
+    t!(socket.recv(&mut buf));
+    assert_eq!(b"hello world", &buf[..]);
+}
+
+#[test]
+fn connect_send_peek_recv() {
+    each_ip(&mut |addr, _| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let socket = UdpSocket::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_udp_socket(&socket, &addr));
+        t!(pool.connect_existing_udp_socket(&socket, addr));
+
+        t!(socket.send(b"hello world"));
+
+        for _ in 1..3 {
+            let mut buf = [0; 11];
+            let size = t!(socket.peek(&mut buf));
+            assert_eq!(b"hello world", &buf[..]);
+            assert_eq!(size, 11);
+        }
+
+        let mut buf = [0; 11];
+        let size = t!(socket.recv(&mut buf));
+        assert_eq!(b"hello world", &buf[..]);
+        assert_eq!(size, 11);
+    })
+}
+
+#[test]
+fn peek_from() {
+    each_ip(&mut |addr, _| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let socket = UdpSocket::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_udp_socket(&socket, &addr));
+        t!(pool.send_to_udp_socket_addr(&socket, b"hello world", &addr));
+
+        for _ in 1..3 {
+            let mut buf = [0; 11];
+            let (size, _) = t!(socket.peek_from(&mut buf));
+            assert_eq!(b"hello world", &buf[..]);
+            assert_eq!(size, 11);
+        }
+
+        let mut buf = [0; 11];
+        let (size, _) = t!(socket.recv_from(&mut buf));
+        assert_eq!(b"hello world", &buf[..]);
+        assert_eq!(size, 11);
+    })
+}
+
+#[test]
+fn ttl() {
+    let ttl = 100;
+
+    let addr = next_test_ip4();
+
+    let mut pool = Pool::new();
+    pool.insert_socket_addr(addr, ambient_authority());
+
+    let stream = UdpSocket::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+    t!(pool.bind_existing_udp_socket(&stream, &addr));
+
+    t!(stream.set_ttl(ttl));
+    assert_eq!(ttl, t!(stream.ttl()));
+}
+
+#[test]
+fn set_nonblocking() {
+    each_ip(&mut |addr, _| {
+        let mut pool = Pool::new();
+        pool.insert_socket_addr(addr, ambient_authority());
+
+        let socket = UdpSocket::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
+        t!(pool.bind_existing_udp_socket(&socket, &addr));
+
+        t!(socket.set_nonblocking(true));
+        t!(socket.set_nonblocking(false));
+
+        t!(pool.connect_existing_udp_socket(&socket, addr));
+
+        t!(socket.set_nonblocking(false));
+        t!(socket.set_nonblocking(true));
+
+        let mut buf = [0];
+        match socket.recv(&mut buf) {
+            Ok(_) => panic!("expected error"),
+            Err(ref e) if e.kind() == ErrorKind::WouldBlock => {}
+            Err(e) => panic!("unexpected error {}", e),
+        }
+    })
+}


### PR DESCRIPTION
Add a new "cap-net-ext", which has functions that splits out the `socket`, `bind`, and `listen` steps that std normally bundles into a single step (eg. in `TcpListener::bind`).

And, add a function to add addresses to a `Pool` by name, allowing users to write things like `pool.insert("example.com")`.