### PR TITLE
Avoid calling `openat2` on Android in more places.

### DIFF
--- a/cap-primitives/src/rustix/linux/fs/mod.rs
+++ b/cap-primitives/src/rustix/linux/fs/mod.rs
@@ -1,23 +1,36 @@
+#[cfg(target_os = "linux")]
 mod canonicalize_impl;
+#[cfg(target_os = "linux")]
 mod file_metadata;
 mod file_path;
+#[cfg(target_os = "linux")]
 mod open_entry_impl;
 mod open_impl;
 mod procfs;
 mod set_permissions_impl;
 mod set_times_impl;
+#[cfg(target_os = "linux")]
 mod stat_impl;
 
+#[cfg(target_os = "android")]
+pub(crate) use crate::fs::manually::canonicalize as canonicalize_impl;
+#[cfg(target_os = "android")]
+pub(crate) use crate::fs::manually::open_entry as open_entry_impl;
+#[cfg(target_os = "android")]
+pub(crate) use crate::fs::manually::stat as stat_impl;
 pub(crate) use crate::fs::via_parent::set_times_nofollow as set_times_nofollow_impl;
+#[cfg(target_os = "linux")]
 pub(crate) use canonicalize_impl::canonicalize_impl;
 pub(crate) use file_path::file_path;
+#[cfg(target_os = "linux")]
 pub(crate) use open_entry_impl::open_entry_impl;
-pub(crate) use open_impl::{open_beneath, open_impl};
+#[cfg(target_os = "linux")]
+pub(crate) use open_impl::open_beneath;
+pub(crate) use open_impl::open_impl;
 pub(crate) use set_permissions_impl::set_permissions_impl;
 pub(crate) use set_times_impl::set_times_impl;
+#[cfg(target_os = "linux")]
 pub(crate) use stat_impl::stat_impl;
-
-use file_metadata::file_metadata;
 
 // In theory we could optimize `link` using `openat2` with `O_PATH` and
 // `linkat` with `AT_EMPTY_PATH`, however that requires `CAP_DAC_READ_SEARCH`,

--- a/cap-primitives/src/rustix/linux/fs/open_impl.rs
+++ b/cap-primitives/src/rustix/linux/fs/open_impl.rs
@@ -7,17 +7,21 @@
 //!
 //! On older Linux, fall back to `manually::open`.
 
-use super::super::super::fs::compute_oflags;
 #[cfg(racy_asserts)]
 use crate::fs::is_same_file;
-use crate::fs::{errors, manually, OpenOptions};
-use io_lifetimes::FromFd;
-use rustix::fs::{openat2, Mode, OFlags, RawMode, ResolveFlags};
-use rustix::path::Arg;
+use crate::fs::{manually, OpenOptions};
 use std::path::Path;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering::Relaxed;
 use std::{fs, io};
+#[cfg(target_os = "linux")]
+use {
+    super::super::super::fs::compute_oflags,
+    crate::fs::errors,
+    io_lifetimes::FromFd,
+    rustix::fs::{openat2, Mode, OFlags, RawMode, ResolveFlags},
+    rustix::path::Arg,
+    std::sync::atomic::AtomicBool,
+    std::sync::atomic::Ordering::Relaxed,
+};
 
 /// Call the `openat2` system call, or use a fallback if that's unavailable.
 pub(crate) fn open_impl(
@@ -48,6 +52,7 @@ pub(crate) fn open_impl(
 /// Call the `openat2` system call with `RESOLVE_BENEATH`. If the syscall is
 /// unavailable, mark it so for future calls. If `openat2` is unavailable
 /// either permanently or temporarily, return `ENOSYS`.
+#[cfg(target_os = "linux")]
 pub(crate) fn open_beneath(
     start: &fs::File,
     path: &Path,

--- a/cap-primitives/src/rustix/linux/fs/stat_impl.rs
+++ b/cap-primitives/src/rustix/linux/fs/stat_impl.rs
@@ -2,7 +2,7 @@
 //! having read or write access to it; we can use that with `openat2` and
 //! `fstat` to perform a fast sandboxed `stat`.
 
-use super::file_metadata;
+use super::file_metadata::file_metadata;
 use crate::fs::{manually, open_beneath, FollowSymlinks, Metadata, OpenOptions};
 use rustix::fs::OFlags;
 use std::path::Path;


### PR DESCRIPTION
Disable the `openat2` code entirely on Android with a `cfg`, and adjust other code to avoid calling it.

This fixes some `openat2` calls that remained after #312.