### PR TITLE
Make `Pool` implement `Default`.

### DIFF
--- a/cap-async-std/src/net/pool.rs
+++ b/cap-async-std/src/net/pool.rs
@@ -7,7 +7,7 @@ use cap_primitives::{ipnet, AmbientAuthority};
 ///
 /// This does not directly correspond to anything in `async_std`, however its
 /// methods correspond to the several functions in [`async_std::net`].
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Pool {
     cap: cap_primitives::net::Pool,
 }

--- a/cap-primitives/src/net/pool.rs
+++ b/cap-primitives/src/net/pool.rs
@@ -54,7 +54,7 @@ impl IpGrant {
 ///
 /// This is presently a very simple concept, though it could grow in
 /// sophistication in the future.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Pool {
     // TODO: when compiling for WASI, use WASI-specific handle instead
     grants: Vec<IpGrant>,

--- a/cap-std/src/net/pool.rs
+++ b/cap-std/src/net/pool.rs
@@ -8,7 +8,7 @@ use std::{io, net};
 ///
 /// This does not directly correspond to anything in `std`, however its methods
 /// correspond to the several functions in [`std::net`].
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Pool {
     cap: cap_primitives::net::Pool,
 }


### PR DESCRIPTION
A `Pool` can reasonably default to an empty set.