### PR TITLE
Add doc aliases for bind, connect, and send_to functions.

### DIFF
--- a/cap-async-std/src/fs/dir.rs
+++ b/cap-async-std/src/fs/dir.rs
@@ -662,6 +662,7 @@ impl Dir {
     /// XXX: This function is not yet implemented.
     ///
     /// [`async_std::os::unix::net::UnixListener::bind`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixListener.html#method.bind
+    #[doc(alias = "bind")]
     #[cfg(unix)]
     #[inline]
     pub async fn bind_unix_listener<P: AsRef<Path>>(&self, path: P) -> io::Result<UnixListener> {
@@ -680,6 +681,7 @@ impl Dir {
     /// XXX: This function is not yet implemented.
     ///
     /// [`async_std::os::unix::net::UnixStream::connect`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixStream.html#method.connect
+    #[doc(alias = "connect")]
     #[cfg(unix)]
     #[inline]
     pub async fn connect_unix_stream<P: AsRef<Path>>(&self, path: P) -> io::Result<UnixStream> {
@@ -698,6 +700,7 @@ impl Dir {
     /// XXX: This function is not yet implemented.
     ///
     /// [`async_std::os::unix::net::UnixDatagram::bind`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.bind
+    #[doc(alias = "bind")]
     #[cfg(unix)]
     #[inline]
     pub async fn bind_unix_datagram<P: AsRef<Path>>(&self, path: P) -> io::Result<UnixDatagram> {
@@ -717,6 +720,7 @@ impl Dir {
     /// XXX: This function is not yet implemented.
     ///
     /// [`async_std::os::unix::net::UnixDatagram::connect`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.connect
+    #[doc(alias = "connect")]
     #[cfg(unix)]
     #[inline]
     pub async fn connect_unix_datagram<P: AsRef<Path>>(
@@ -740,6 +744,7 @@ impl Dir {
     /// XXX: This function is not yet implemented.
     ///
     /// [`async_std::os::unix::net::UnixDatagram::send_to`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.send_to
+    #[doc(alias = "send_to")]
     #[cfg(unix)]
     #[inline]
     pub async fn send_to_unix_datagram_addr<P: AsRef<Path>>(

--- a/cap-async-std/src/fs_utf8/dir.rs
+++ b/cap-async-std/src/fs_utf8/dir.rs
@@ -457,6 +457,7 @@ impl Dir {
     /// XXX: This function is not yet implemented.
     ///
     /// [`async_std::os::unix::net::UnixListener::bind`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixListener.html#method.bind
+    #[doc(alias = "bind")]
     #[cfg(unix)]
     #[inline]
     pub async fn bind_unix_listener<P: AsRef<Utf8Path>>(
@@ -475,6 +476,7 @@ impl Dir {
     /// XXX: This function is not yet implemented.
     ///
     /// [`async_std::os::unix::net::UnixStream::connect`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixStream.html#method.connect
+    #[doc(alias = "connect")]
     #[cfg(unix)]
     #[inline]
     pub async fn connect_unix_stream<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<UnixStream> {
@@ -490,6 +492,7 @@ impl Dir {
     /// XXX: This function is not yet implemented.
     ///
     /// [`async_std::os::unix::net::UnixDatagram::bind`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.bind
+    #[doc(alias = "bind")]
     #[cfg(unix)]
     #[inline]
     pub async fn bind_unix_datagram<P: AsRef<Utf8Path>>(
@@ -509,6 +512,7 @@ impl Dir {
     /// XXX: This function is not yet implemented.
     ///
     /// [`async_std::os::unix::net::UnixDatagram::connect`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.connect
+    #[doc(alias = "connect")]
     #[cfg(unix)]
     #[inline]
     pub async fn connect_unix_datagram<P: AsRef<Utf8Path>>(
@@ -531,6 +535,7 @@ impl Dir {
     /// XXX: This function is not yet implemented.
     ///
     /// [`async_std::os::unix::net::UnixDatagram::send_to`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.send_to
+    #[doc(alias = "send_to")]
     #[cfg(unix)]
     #[inline]
     pub async fn send_to_unix_datagram_addr<P: AsRef<Utf8Path>>(

--- a/cap-async-std/src/net/pool.rs
+++ b/cap-async-std/src/net/pool.rs
@@ -105,6 +105,7 @@ impl Pool {
     /// address.
     ///
     /// This corresponds to [`async_std::net::TcpListener::bind`].
+    #[doc(alias = "bind")]
     #[inline]
     pub async fn bind_tcp_listener<A: ToSocketAddrs>(&self, addr: A) -> io::Result<TcpListener> {
         let addrs = addr.to_socket_addrs().await?;
@@ -127,6 +128,7 @@ impl Pool {
     /// Creates a new TCP stream connected to the specified address.
     ///
     /// This corresponds to [`async_std::net::TcpStream::connect`].
+    #[doc(alias = "connect")]
     #[inline]
     pub async fn connect_tcp_stream<A: ToSocketAddrs>(&self, addr: A) -> io::Result<TcpStream> {
         let addrs = addr.to_socket_addrs().await?;
@@ -151,6 +153,7 @@ impl Pool {
     /// Creates a UDP socket from the given address.
     ///
     /// This corresponds to [`async_std::net::UdpSocket::bind`].
+    #[doc(alias = "bind")]
     #[inline]
     pub async fn bind_udp_socket<A: ToSocketAddrs>(&self, addr: A) -> io::Result<UdpSocket> {
         let addrs = addr.to_socket_addrs().await?;
@@ -172,6 +175,7 @@ impl Pool {
     /// Sends data on the socket to the given address.
     ///
     /// This corresponds to [`async_std::net::UdpSocket::send_to`].
+    #[doc(alias = "send_to")]
     #[inline]
     pub async fn send_to_udp_socket_addr<A: ToSocketAddrs>(
         &self,
@@ -193,6 +197,7 @@ impl Pool {
     /// Connects the UDP socket to a remote address.
     ///
     /// This corresponds to [`async_std::net::UdpSocket::connect`].
+    #[doc(alias = "connect")]
     #[inline]
     pub async fn connect_udp_socket<A: ToSocketAddrs>(
         &self,

--- a/cap-std/src/fs/dir.rs
+++ b/cap-std/src/fs/dir.rs
@@ -478,6 +478,7 @@ impl Dir {
     /// XXX: This function is not yet implemented.
     ///
     /// [`std::os::unix::net::UnixListener::bind`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixListener.html#method.bind
+    #[doc(alias = "bind")]
     #[cfg(unix)]
     #[inline]
     pub fn bind_unix_listener<P: AsRef<Path>>(&self, path: P) -> io::Result<UnixListener> {
@@ -496,6 +497,7 @@ impl Dir {
     /// XXX: This function is not yet implemented.
     ///
     /// [`std::os::unix::net::UnixStream::connect`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixStream.html#method.connect
+    #[doc(alias = "connect")]
     #[cfg(unix)]
     #[inline]
     pub fn connect_unix_stream<P: AsRef<Path>>(&self, path: P) -> io::Result<UnixStream> {
@@ -514,6 +516,7 @@ impl Dir {
     /// XXX: This function is not yet implemented.
     ///
     /// [`std::os::unix::net::UnixDatagram::bind`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.bind
+    #[doc(alias = "bind")]
     #[cfg(unix)]
     #[inline]
     pub fn bind_unix_datagram<P: AsRef<Path>>(&self, path: P) -> io::Result<UnixDatagram> {
@@ -532,6 +535,7 @@ impl Dir {
     /// XXX: This function is not yet implemented.
     ///
     /// [`std::os::unix::net::UnixDatagram::connect`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.connect
+    #[doc(alias = "connect")]
     #[cfg(unix)]
     #[inline]
     pub fn connect_unix_datagram<P: AsRef<Path>>(
@@ -554,6 +558,7 @@ impl Dir {
     /// XXX: This function is not yet implemented.
     ///
     /// [`std::os::unix::net::UnixDatagram::send_to`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.send_to
+    #[doc(alias = "send_to")]
     #[cfg(unix)]
     #[inline]
     pub fn send_to_unix_datagram_addr<P: AsRef<Path>>(

--- a/cap-std/src/fs_utf8/dir.rs
+++ b/cap-std/src/fs_utf8/dir.rs
@@ -448,6 +448,7 @@ impl Dir {
     /// XXX: This function is not yet implemented.
     ///
     /// [`std::os::unix::net::UnixListener::bind`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixListener.html#method.bind
+    #[doc(alias = "bind")]
     #[cfg(unix)]
     #[inline]
     pub fn bind_unix_listener<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<UnixListener> {
@@ -463,6 +464,7 @@ impl Dir {
     /// XXX: This function is not yet implemented.
     ///
     /// [`std::os::unix::net::UnixStream::connect`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixStream.html#method.connect
+    #[doc(alias = "connect")]
     #[cfg(unix)]
     #[inline]
     pub fn connect_unix_stream<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<UnixStream> {
@@ -478,6 +480,7 @@ impl Dir {
     /// XXX: This function is not yet implemented.
     ///
     /// [`std::os::unix::net::UnixDatagram::bind`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.bind
+    #[doc(alias = "bind")]
     #[cfg(unix)]
     #[inline]
     pub fn bind_unix_datagram<P: AsRef<Utf8Path>>(&self, path: P) -> io::Result<UnixDatagram> {
@@ -493,6 +496,7 @@ impl Dir {
     /// XXX: This function is not yet implemented.
     ///
     /// [`std::os::unix::net::UnixDatagram::connect`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.connect
+    #[doc(alias = "connect")]
     #[cfg(unix)]
     #[inline]
     pub fn connect_unix_datagram<P: AsRef<Utf8Path>>(
@@ -512,6 +516,7 @@ impl Dir {
     /// XXX: This function is not yet implemented.
     ///
     /// [`std::os::unix::net::UnixDatagram::send_to`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.send_to
+    #[doc(alias = "send_to")]
     #[cfg(unix)]
     #[inline]
     pub fn send_to_unix_datagram_addr<P: AsRef<Utf8Path>>(

--- a/cap-std/src/net/pool.rs
+++ b/cap-std/src/net/pool.rs
@@ -47,7 +47,7 @@ impl Pool {
 
     /// Add a specific [`net::SocketAddr`] to the pool.
     ///
-    /// # AmbientAuthority
+    /// # Ambient Authority
     ///
     /// This function allows ambient access to any IP address.
     pub fn insert_socket_addr(
@@ -96,7 +96,7 @@ impl Pool {
 
     /// Add a range of network addresses with a specific port to the pool.
     ///
-    /// # AmbientAuthority
+    /// # Ambient Authority
     ///
     /// This function allows ambient access to any IP address.
     pub fn insert_ip_net(
@@ -112,6 +112,7 @@ impl Pool {
     /// address.
     ///
     /// This corresponds to [`std::net::TcpListener::bind`].
+    #[doc(alias = "bind")]
     #[inline]
     pub fn bind_tcp_listener<A: ToSocketAddrs>(&self, addr: A) -> io::Result<TcpListener> {
         let addrs = addr.to_socket_addrs()?;
@@ -134,6 +135,7 @@ impl Pool {
     /// Opens a TCP connection to a remote host.
     ///
     /// This corresponds to [`std::net::TcpStream::connect`].
+    #[doc(alias = "connect")]
     #[inline]
     pub fn connect_tcp_stream<A: ToSocketAddrs>(&self, addr: A) -> io::Result<TcpStream> {
         let addrs = addr.to_socket_addrs()?;
@@ -156,6 +158,7 @@ impl Pool {
     /// Opens a TCP connection to a remote host with a timeout.
     ///
     /// This corresponds to [`std::net::TcpStream::connect_timeout`].
+    #[doc(alias = "connect")]
     #[inline]
     pub fn connect_timeout_tcp_stream(
         &self,
@@ -170,6 +173,7 @@ impl Pool {
     /// Creates a UDP socket from the given address.
     ///
     /// This corresponds to [`std::net::UdpSocket::bind`].
+    #[doc(alias = "bind")]
     #[inline]
     pub fn bind_udp_socket<A: ToSocketAddrs>(&self, addr: A) -> io::Result<UdpSocket> {
         let addrs = addr.to_socket_addrs()?;
@@ -192,6 +196,7 @@ impl Pool {
     /// number of bytes written.
     ///
     /// This corresponds to [`std::net::UdpSocket::send_to`].
+    #[doc(alias = "send_to")]
     #[inline]
     pub fn send_to_udp_socket_addr<A: ToSocketAddrs>(
         &self,
@@ -212,6 +217,7 @@ impl Pool {
     /// only receive data from the specified address.
     ///
     /// This corresponds to [`std::net::UdpSocket::connect`].
+    #[doc(alias = "connect")]
     #[inline]
     pub fn connect_udp_socket<A: ToSocketAddrs>(
         &self,


### PR DESCRIPTION
Functions corresponding to bind, connect, and send_to have different names in cap-std, so give them doc aliases to make them easier to find and make the correspondence more clear.