### PR TITLE
Fix DirEntryInner::is_same_file at a mountpoint

### DIFF
--- a/cap-primitives/src/rustix/fs/dir_entry_inner.rs
+++ b/cap-primitives/src/rustix/fs/dir_entry_inner.rs
@@ -69,7 +69,8 @@ impl DirEntryInner {
 
     #[inline]
     pub(crate) fn is_same_file(&self, metadata: &Metadata) -> io::Result<bool> {
-        Ok(self.ino() == metadata.ino() && self.metadata()?.dev() == metadata.dev())
+        let self_md = self.metadata()?;
+        Ok(self_md.ino() == metadata.ino() && self_md.dev() == metadata.dev())
     }
 
     fn file_name_bytes(&self) -> &OsStr {


### PR DESCRIPTION
If a direntry comes from a mountpoint's parent, then its ino will be the ino of the underlying directory, not the mounted file system's root directory.  So ignore the direntry's ino, and just look at the ino in its metadata.

Fixes #330