### PR TITLE
Fix the tty_path test on FreeBSD

### DIFF
--- a/cap-primitives/src/rustix/fs/mod.rs
+++ b/cap-primitives/src/rustix/fs/mod.rs
@@ -121,9 +121,10 @@ fn tty_path() {
     #[cfg(unix)]
     use std::os::unix::fs::FileTypeExt;
 
-    // On FreeBSD, `ttyname` doesn't seem to work on /dev/std{in,out,err}.
+    // On FreeBSD, /dev/{tty,stdin,stdout,stderr} are aliases to different real
+    // devices.
     let paths: &[&str] = if cfg!(target_os = "freebsd") {
-        &["/dev/tty"]
+        &["/dev/ttyv0", "/dev/pts/0"]
     } else {
         &["/dev/tty", "/dev/stdin", "/dev/stdout", "/dev/stderr"]
     };


### PR DESCRIPTION
On FreeBSD, ttyname(3) may not return exactly the same name as was used to open the file descriptor.  For example, "/dev/tty" is an alias for whatever the real tty device is.  But paths like "/dev/pts/0" aren't aliases.  If the user can open them, ttyname() will always return their own name.

Note that the test will still fail on non-Linux, non-Darwin due to an unrelated Rustix bug.  See
https://github.com/bytecodealliance/rustix/pull/832