### PR TITLE
Add `set_symlink_permissions` and `access` functions to `DirExt`

### DIFF
--- a/cap-fs-ext/src/lib.rs
+++ b/cap-fs-ext/src/lib.rs
@@ -23,7 +23,7 @@ mod reopen;
 pub use dir_entry_ext::DirEntryExt;
 #[cfg(all(any(feature = "std", feature = "async_std"), feature = "fs_utf8"))]
 pub use dir_ext::DirExtUtf8;
-pub use dir_ext::{DirExt, SystemTimeSpec};
+pub use dir_ext::{AccessType, DirExt, SystemTimeSpec};
 pub use file_type_ext::FileTypeExt;
 pub use is_file_read_write::IsFileReadWrite;
 pub use metadata_ext::MetadataExt;

--- a/cap-net-ext/src/lib.rs
+++ b/cap-net-ext/src/lib.rs
@@ -244,7 +244,7 @@ pub trait PoolExt: private::Sealed {
     /// Initiate a TCP connection, converting a [`TcpListener`] to a
     /// [`TcpStream`].
     ///
-    /// This is simlar to to [`Pool::connect_tcp_stream`] in that it performs a
+    /// This is simlar to [`Pool::connect_tcp_stream`] in that it performs a
     /// TCP connection, but instead of creating a new socket itself it takes a
     /// [`TcpListener`], such as one created with [`TcpListenerExt::new`].
     ///
@@ -263,8 +263,8 @@ pub trait PoolExt: private::Sealed {
 
     /// Initiate a TCP connection on a socket.
     ///
-    /// This is simlar to to [`Self::connect_into_tcp_stream`], however instead
-    /// of converting a `TcpListener` to a `TcpStream`, it leaves fd in the
+    /// This is simlar to [`Self::connect_into_tcp_stream`], however instead of
+    /// converting a `TcpListener` to a `TcpStream`, it leaves fd in the
     /// existing `TcpListener`.
     ///
     /// This function ensures that the address to connect to is permitted by
@@ -279,7 +279,7 @@ pub trait PoolExt: private::Sealed {
 
     /// Initiate a UDP connection.
     ///
-    /// This is simlar to to [`Pool::connect_udp_socket`] in that it performs a
+    /// This is simlar to [`Pool::connect_udp_socket`] in that it performs a
     /// UDP connection, but instead of creating a new socket itself it takes a
     /// [`UdpSocket`], such as one created with [`UdpSocketExt::new`].
     ///
@@ -537,7 +537,7 @@ impl TcpConnecter {
     /// Initiate a TCP connection, converting a [`TcpListener`] to a
     /// [`TcpStream`].
     ///
-    /// This is simlar to to [`Pool::connect_tcp_stream`] in that it performs a
+    /// This is simlar to [`Pool::connect_tcp_stream`] in that it performs a
     /// TCP connection, but instead of creating a new socket itself it takes a
     /// [`TcpListener`], such as one created with [`TcpListenerExt::new`].
     ///
@@ -554,8 +554,8 @@ impl TcpConnecter {
 
     /// Initiate a TCP connection on a socket.
     ///
-    /// This is simlar to to [`Pool::connect_into_tcp_stream`], however instead
-    /// of converting a `TcpListener` to a `TcpStream`, it leaves fd in the
+    /// This is simlar to [`Pool::connect_into_tcp_stream`], however instead of
+    /// converting a `TcpListener` to a `TcpStream`, it leaves fd in the
     /// existing `TcpListener`.
     ///
     /// This is similar to [`PoolExt::connect_existing_tcp_listener`] except
@@ -584,7 +584,7 @@ pub struct UdpConnecter(smallvec::SmallVec<[SocketAddr; 1]>);
 impl UdpConnecter {
     /// Initiate a UDP connection.
     ///
-    /// This is simlar to to [`Pool::connect_udp_socket`] in that it performs a
+    /// This is simlar to [`Pool::connect_udp_socket`] in that it performs a
     /// UDP connection, but instead of creating a new socket itself it takes a
     /// [`UdpSocket`], such as one created with [`UdpSocketExt::new`].
     ///

--- a/cap-primitives/src/fs/access.rs
+++ b/cap-primitives/src/fs/access.rs
@@ -1,0 +1,89 @@
+//! Access test functions.
+
+use crate::fs::{access_impl, FollowSymlinks};
+#[cfg(racy_asserts)]
+use crate::fs::{access_unchecked, file_path};
+use std::path::Path;
+use std::{fs, io};
+
+/// Access modes for use with [`DirExt::access`].
+#[derive(Clone, Copy, Debug)]
+pub struct AccessModes {
+    /// Is the object readable?
+    pub readable: bool,
+    /// Is the object writable?
+    pub writable: bool,
+    /// Is the object executable?
+    pub executable: bool,
+}
+
+/// Access modes for use with [`DirExt::access`].
+#[derive(Clone, Copy, Debug)]
+pub enum AccessType {
+    /// Test whether the named object is accessible in the given modes.
+    Access(AccessModes),
+
+    /// Test whether the named object exists.
+    Exists,
+}
+
+/// Canonicalize the given path, ensuring that the resolution of the path never
+/// escapes the directory tree rooted at `start`.
+#[cfg_attr(not(racy_asserts), allow(clippy::let_and_return))]
+pub fn access(
+    start: &fs::File,
+    path: &Path,
+    type_: AccessType,
+    follow: FollowSymlinks,
+) -> io::Result<()> {
+    // Call the underlying implementation.
+    let result = access_impl(start, path, type_, follow);
+
+    #[cfg(racy_asserts)]
+    let unchecked = access_unchecked(start, path, type_, follow);
+
+    #[cfg(racy_asserts)]
+    check_access(start, path, type_, follow, &result, &unchecked);
+
+    result
+}
+
+#[cfg(racy_asserts)]
+#[allow(clippy::enum_glob_use)]
+fn check_access(
+    start: &fs::File,
+    path: &Path,
+    _type_: AccessType,
+    _follow: FollowSymlinks,
+    result: &io::Result<()>,
+    unchecked: &io::Result<()>,
+) {
+    use io::ErrorKind::*;
+
+    match (map_result(result), map_result(stat)) {
+        (Ok(()), Ok(())) => {}
+
+        (Err((PermissionDenied, message)), _) => {
+            // TODO: Check that access in the no-follow case got the right
+            // error.
+        }
+
+        (Err((kind, message)), Err((unchecked_kind, unchecked_message))) => {
+            assert_eq!(kind, unchecked_kind);
+            assert_eq!(
+                message,
+                unchecked_message,
+                "start='{:?}', path='{:?}'",
+                start,
+                path.display()
+            );
+        }
+
+        other => panic!(
+            "unexpected result from access start='{:?}', path='{}':\n{:#?}",
+            start,
+            path.display(),
+            other,
+        ),
+    }
+}

--- a/cap-primitives/src/fs/mod.rs
+++ b/cap-primitives/src/fs/mod.rs
@@ -4,6 +4,7 @@
 #[macro_use]
 pub(crate) mod assert_same_file;
 
+mod access;
 mod canonicalize;
 mod copy;
 mod create_dir;
@@ -57,6 +58,7 @@ pub(crate) use super::windows::fs::*;
 #[cfg(not(windows))]
 pub(crate) use read_dir::{read_dir_nofollow, read_dir_unchecked};
 
+pub use access::{access, AccessModes, AccessType};
 pub use canonicalize::canonicalize;
 pub use copy::copy;
 pub use create_dir::create_dir;
@@ -90,7 +92,7 @@ pub use remove_open_dir::{remove_open_dir, remove_open_dir_all};
 pub use rename::rename;
 pub use reopen::reopen;
 #[cfg(not(target_os = "wasi"))]
-pub use set_permissions::set_permissions;
+pub use set_permissions::{set_permissions, set_symlink_permissions};
 pub use set_times::{set_times, set_times_nofollow};
 pub use stat::stat;
 #[cfg(not(windows))]

--- a/cap-primitives/src/fs/via_parent/access.rs
+++ b/cap-primitives/src/fs/via_parent/access.rs
@@ -1,0 +1,19 @@
+use super::open_parent;
+use crate::fs::{access_unchecked, AccessType, FollowSymlinks, MaybeOwnedFile};
+use std::path::Path;
+use std::{fs, io};
+
+/// Implement `access` by `open`ing up the parent component of the path and
+/// then calling `access_unchecked` on the last component.
+pub(crate) fn access(
+    start: &fs::File,
+    path: &Path,
+    type_: AccessType,
+    follow: FollowSymlinks,
+) -> io::Result<()> {
+    let start = MaybeOwnedFile::borrowed(start);
+
+    let (dir, basename) = open_parent(start, path)?;
+
+    access_unchecked(&dir, basename.as_ref(), type_, follow)
+}

--- a/cap-primitives/src/fs/via_parent/mod.rs
+++ b/cap-primitives/src/fs/via_parent/mod.rs
@@ -2,6 +2,7 @@
 //! in `create_dir`, the last component names the path to be created, while the
 //! rest of the components just name the place to create it in.
 
+mod access;
 mod create_dir;
 mod hard_link;
 mod open_parent;
@@ -12,12 +13,15 @@ mod remove_file;
 mod rename;
 #[cfg(windows)]
 mod set_permissions;
+#[cfg(not(target_os = "wasi"))]
+mod set_symlink_permissions;
 #[cfg(not(windows))]
 mod set_times_nofollow;
 mod symlink;
 
 use open_parent::open_parent;
 
+pub(crate) use access::access;
 pub(crate) use create_dir::create_dir;
 pub(crate) use hard_link::hard_link;
 #[cfg(not(windows))] // doesn't work on windows; use a windows-specific impl
@@ -27,6 +31,8 @@ pub(crate) use remove_file::remove_file;
 pub(crate) use rename::rename;
 #[cfg(windows)]
 pub(crate) use set_permissions::set_permissions;
+#[cfg(not(target_os = "wasi"))]
+pub(crate) use set_symlink_permissions::set_symlink_permissions;
 #[cfg(not(windows))]
 pub(crate) use set_times_nofollow::set_times_nofollow;
 #[cfg(not(windows))]

--- a/cap-primitives/src/fs/via_parent/set_symlink_permissions.rs
+++ b/cap-primitives/src/fs/via_parent/set_symlink_permissions.rs
@@ -1,0 +1,17 @@
+use super::open_parent;
+use crate::fs::{set_symlink_permissions_unchecked, MaybeOwnedFile, Permissions};
+use std::path::Path;
+use std::{fs, io};
+
+#[inline]
+pub(crate) fn set_symlink_permissions(
+    start: &fs::File,
+    path: &Path,
+    perm: Permissions,
+) -> io::Result<()> {
+    let start = MaybeOwnedFile::borrowed(start);
+
+    let (dir, basename) = open_parent(start, path)?;
+
+    set_symlink_permissions_unchecked(&dir, basename.as_ref(), perm)
+}

--- a/cap-primitives/src/rustix/fs/access_unchecked.rs
+++ b/cap-primitives/src/rustix/fs/access_unchecked.rs
@@ -1,0 +1,38 @@
+use crate::fs::{AccessType, FollowSymlinks};
+use rustix::fs::{Access, AtFlags};
+use std::path::Path;
+use std::{fs, io};
+
+/// *Unsandboxed* function similar to `access`, but which does not perform
+/// sandboxing.
+pub(crate) fn access_unchecked(
+    start: &fs::File,
+    path: &Path,
+    type_: AccessType,
+    follow: FollowSymlinks,
+) -> io::Result<()> {
+    let mut access_type = Access::empty();
+    match type_ {
+        AccessType::Exists => access_type |= Access::EXISTS,
+        AccessType::Access(modes) => {
+            if modes.readable {
+                access_type |= Access::READ_OK;
+            }
+            if modes.writable {
+                access_type |= Access::WRITE_OK;
+            }
+            if modes.executable {
+                access_type |= Access::EXEC_OK;
+            }
+        }
+    }
+
+    let atflags = match follow {
+        FollowSymlinks::Yes => AtFlags::empty(),
+        FollowSymlinks::No => AtFlags::SYMLINK_NOFOLLOW,
+    };
+
+    rustix::fs::accessat(start, path, access_type, atflags)?;
+
+    Ok(())
+}

--- a/cap-primitives/src/rustix/fs/mod.rs
+++ b/cap-primitives/src/rustix/fs/mod.rs
@@ -1,3 +1,4 @@
+mod access_unchecked;
 mod copy_impl;
 mod create_dir_unchecked;
 mod dir_entry_inner;
@@ -26,6 +27,8 @@ mod rename_unchecked;
 mod reopen_impl;
 #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "wasi")))]
 mod set_permissions_impl;
+#[cfg(not(target_os = "wasi"))]
+mod set_symlink_permissions_unchecked;
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
 mod set_times_impl;
 mod stat_unchecked;
@@ -65,11 +68,14 @@ pub(super) use file_path::file_path_by_ttyname_or_seaching;
 pub(crate) use file_path::file_path_by_ttyname_or_seaching as file_path;
 #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "wasi")))]
 pub(crate) use set_permissions_impl::set_permissions_impl;
+#[cfg(not(target_os = "wasi"))]
+pub(crate) use set_symlink_permissions_unchecked::set_symlink_permissions_unchecked;
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
 pub(crate) use set_times_impl::set_times_impl;
 
 #[rustfmt::skip]
 pub(crate) use crate::fs::{
+    via_parent::access as access_impl,
     via_parent::hard_link as hard_link_impl,
     via_parent::create_dir as create_dir_impl,
     via_parent::read_link as read_link_impl,
@@ -79,7 +85,10 @@ pub(crate) use crate::fs::{
     via_parent::remove_file as remove_file_impl,
     remove_open_dir_by_searching as remove_open_dir_impl,
 };
+#[cfg(not(target_os = "wasi"))]
+pub(crate) use crate::fs::via_parent::set_symlink_permissions as set_symlink_permissions_impl;
 
+pub(crate) use access_unchecked::access_unchecked;
 pub(crate) use copy_impl::copy_impl;
 pub(crate) use create_dir_unchecked::create_dir_unchecked;
 pub(crate) use dir_entry_inner::DirEntryInner;

--- a/cap-primitives/src/rustix/fs/set_symlink_permissions_unchecked.rs
+++ b/cap-primitives/src/rustix/fs/set_symlink_permissions_unchecked.rs
@@ -1,0 +1,17 @@
+use crate::fs::Permissions;
+use rustix::fs::{chmodat, AtFlags, Mode};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::{fs, io};
+
+/// This can just use `AT_SYMLINK_NOFOLLOW`.
+pub(crate) fn set_symlink_permissions_unchecked(
+    start: &fs::File,
+    path: &Path,
+    perm: Permissions,
+) -> io::Result<()> {
+    let mode = Mode::from_bits_truncate(perm.mode().try_into().unwrap());
+
+    Ok(chmodat(start, path, mode, AtFlags::SYMLINK_NOFOLLOW)?)
+}

--- a/cap-primitives/src/windows/fs/access_unchecked.rs
+++ b/cap-primitives/src/windows/fs/access_unchecked.rs
@@ -1,0 +1,32 @@
+use crate::fs::{open, AccessType, FollowSymlinks, OpenOptions};
+use std::path::Path;
+use std::{fs, io};
+
+/// *Unsandboxed* function similar to `access`, but which does not perform
+/// sandboxing.
+pub(crate) fn access_unchecked(
+    start: &fs::File,
+    path: &Path,
+    type_: AccessType,
+    follow: FollowSymlinks,
+) -> io::Result<()> {
+    let mut options = OpenOptions::new();
+    options.follow(follow);
+    match type_ {
+        AccessType::Exists => {
+            options.read(true);
+        }
+        AccessType::Access(modes) => {
+            if modes.readable {
+                options.read(true);
+            }
+            if modes.writable {
+                options.write(true);
+            }
+            if modes.executable {
+                options.read(true);
+            }
+        }
+    }
+    open(start, path, &options).map(|_| ())
+}

--- a/cap-primitives/src/windows/fs/mod.rs
+++ b/cap-primitives/src/windows/fs/mod.rs
@@ -1,3 +1,4 @@
+mod access_unchecked;
 mod copy;
 mod create_dir_unchecked;
 mod create_file_at_w;
@@ -24,6 +25,7 @@ mod remove_open_dir_impl;
 mod rename_unchecked;
 mod reopen_impl;
 mod set_permissions_unchecked;
+mod set_symlink_permissions_unchecked;
 mod set_times_impl;
 mod stat_unchecked;
 mod symlink_unchecked;
@@ -33,17 +35,20 @@ pub(crate) mod errors;
 #[rustfmt::skip]
 pub(crate) use crate::fs::{
     manually::canonicalize as canonicalize_impl,
+    via_parent::access as access_impl,
     via_parent::hard_link as hard_link_impl,
     via_parent::create_dir as create_dir_impl,
     via_parent::rename as rename_impl,
     via_parent::remove_dir as remove_dir_impl,
     via_parent::set_permissions as set_permissions_impl,
+    via_parent::set_symlink_permissions as set_symlink_permissions_impl,
     manually::stat as stat_impl,
     via_parent::symlink_dir as symlink_dir_impl,
     via_parent::symlink_file as symlink_file_impl,
     via_parent::remove_file as remove_file_impl,
 };
 
+pub(crate) use access_unchecked::*;
 pub(crate) use copy::*;
 pub(crate) use create_dir_unchecked::*;
 pub(crate) use dir_entry_inner::*;
@@ -67,6 +72,7 @@ pub(crate) use remove_open_dir_impl::*;
 pub(crate) use rename_unchecked::*;
 pub(crate) use reopen_impl::reopen_impl;
 pub(crate) use set_permissions_unchecked::*;
+pub(crate) use set_symlink_permissions_unchecked::*;
 pub(crate) use set_times_impl::*;
 pub(crate) use stat_unchecked::*;
 pub(crate) use symlink_unchecked::*;

--- a/cap-primitives/src/windows/fs/set_symlink_permissions_unchecked.rs
+++ b/cap-primitives/src/windows/fs/set_symlink_permissions_unchecked.rs
@@ -1,0 +1,20 @@
+use super::get_path::concatenate;
+use crate::fs::Permissions;
+use std::path::Path;
+use std::{fs, io};
+
+/// This can just use `AT_SYMLINK_NOFOLLOW`.
+pub(crate) fn set_symlink_permissions_unchecked(
+    start: &fs::File,
+    path: &Path,
+    perm: Permissions,
+) -> io::Result<()> {
+    // According to [Rust's documentation], `fs::set_permissions` uses
+    // `SetFileAttributes`, and according to [Windows' documentation]
+    // `SetFileAttributes` does not follow symbolic links.
+    //
+    // [Windows' documentation]: https://docs.microsoft.com/en-us/windows/win32/fileio/symbolic-link-effects-on-file-systems-functions#setfileattributes
+    // [Rust's documentation]: https://doc.rust-lang.org/std/fs/fn.set_permissions.html#platform-specific-behavior
+    let out_path = concatenate(start, path)?;
+    fs::set_permissions(out_path, perm.into_std(start)?)
+}

--- a/cap-rand/src/lib.rs
+++ b/cap-rand/src/lib.rs
@@ -57,8 +57,8 @@ pub mod rngs {
     #[cfg(feature = "small_rng")]
     pub use rand::rngs::SmallRng;
 
-    /// A random number generator that retrieves randomness from from the
-    /// operating system.
+    /// A random number generator that retrieves randomness from the operating
+    /// system.
     ///
     /// This corresponds to [`rand::rngs::OsRng`], except instead of
     /// implementing `Default` it has an ambient-authority `default` function


### PR DESCRIPTION
`set_symlink_permissions` is to `set_permissions` as `symlink_metadata` is to `metadata`; it doesn't follow symlinks.

`access` follows the POSIX `faccessat` behavior.