### PR TITLE
Allow read_link to read absolute paths

### DIFF
--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -12,8 +12,7 @@ use std::io::prelude::*;
 
 #[cfg(target_os = "macos")]
 use crate::sys::weak::weak;
-use cap_std::ambient_authority;
-use cap_std::fs::{self, Dir, OpenOptions};
+use cap_std::fs::{self, OpenOptions};
 #[cfg(target_os = "macos")]
 use libc::{c_char, c_int};
 use std::io::{self, ErrorKind, SeekFrom};
@@ -935,24 +934,6 @@ fn symlink_noexist() {
 
 #[test]
 fn read_link() {
-    if cfg!(windows) {
-        // directory symlink
-        let root = Dir::open_ambient_dir(r"C:\", ambient_authority()).unwrap();
-        error_contains!(
-            root.read_link(r"Users\All Users"),
-            "a path led outside of the filesystem"
-        );
-        // junction
-        error_contains!(
-            root.read_link(r"Users\Default User"),
-            "a path led outside of the filesystem"
-        );
-        // junction with special permissions
-        error_contains!(
-            root.read_link(r"Documents and Settings\"),
-            "a path led outside of the filesystem"
-        );
-    }
     let tmpdir = tmpdir();
     let link = "link";
     if !got_symlink_permission(&tmpdir) {

--- a/tests/fs_utf8.rs
+++ b/tests/fs_utf8.rs
@@ -14,8 +14,7 @@ use std::io::prelude::*;
 #[cfg(target_os = "macos")]
 use crate::sys::weak::weak;
 use camino::{Utf8Path as Path, Utf8PathBuf as PathBuf};
-use cap_std::ambient_authority;
-use cap_std::fs_utf8::{self as fs, Dir, OpenOptions};
+use cap_std::fs_utf8::{self as fs, OpenOptions};
 #[cfg(target_os = "macos")]
 use libc::{c_char, c_int};
 use std::io::{self, ErrorKind, SeekFrom};
@@ -938,24 +937,6 @@ fn symlink_noexist() {
 
 #[test]
 fn read_link() {
-    if cfg!(windows) {
-        // directory symlink
-        let root = Dir::open_ambient_dir(r"C:\", ambient_authority()).unwrap();
-        error_contains!(
-            root.read_link(r"Users\All Users"),
-            "a path led outside of the filesystem"
-        );
-        // junction
-        error_contains!(
-            root.read_link(r"Users\Default User"),
-            "a path led outside of the filesystem"
-        );
-        // junction with special permissions
-        error_contains!(
-            root.read_link(r"Documents and Settings\"),
-            "a path led outside of the filesystem"
-        );
-    }
     let tmpdir = tmpdir();
     let link = "link";
     if !got_symlink_permission(&tmpdir) {

--- a/tests/symlinks.rs
+++ b/tests/symlinks.rs
@@ -4,6 +4,7 @@ mod sys_common;
 use cap_fs_ext::DirExt;
 use cap_std::ambient_authority;
 use cap_std::fs::Dir;
+use std::path::Path;
 use sys_common::io::tmpdir;
 use sys_common::symlink_supported;
 
@@ -116,19 +117,19 @@ fn readlink_absolute() {
     let tmpdir = check!(Dir::open_ambient_dir(dir.path(), ambient_authority()));
 
     #[cfg(not(windows))]
-    error_contains!(
-        tmpdir.read_link("thing_symlink"),
-        "a path led outside of the filesystem"
+    assert_eq!(
+        tmpdir.read_link("thing_symlink").unwrap(),
+        Path::new("/thing")
     );
     #[cfg(windows)]
-    error_contains!(
-        tmpdir.read_link("file_symlink_file"),
-        "a path led outside of the filesystem"
+    assert_eq!(
+        tmpdir.read_link("file_symlink_file").unwrap(),
+        Path::new("/file")
     );
     #[cfg(windows)]
-    error_contains!(
-        tmpdir.read_link("dir_symlink_dir"),
-        "a path led outside of the filesystem"
+    assert_eq!(
+        tmpdir.read_link("dir_symlink_dir").unwrap(),
+        Path::new("/dir")
     );
 }
 


### PR DESCRIPTION
Previously it would return an error if the link's destination were absolute.  But there were three problems with this:

* It wouldn't return an error if the link's destination were a relative path that uses ../ to point outside of the sandbox. That's inconsistent.
* Sometimes a symlink with an absolute path doesn't escape the sandbox. For example /sandbox/link -> /sandbox/target.  But read_link wouldn't allow that.
* More importantly, sometimes it's important to read a link that points outside of the sandbox. For example, a backup application could copy all of the files from the root directory of one computer to a subdirectory of another. Symlinks would be broken, but would work again after a restore operation. The application that performs the restore would need to be able to read link targets, even if they point outside of the root. Or, a jail file system could contain absolute symlinks that resolve correctly for a jailed process, but not for an unjailed one. But it would still sometimes be useful for an unjailed process to read the links.

Fixes #353