### PR TITLE
Fix unexpected_cfgs warnings.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,9 @@ fn main() {
                                                   // https://doc.rust-lang.org/unstable-book/library-features/windows-file-type-ext.html
     use_feature_or_nothing("windows_file_type_ext");
 
+    // Cfgs that users may set.
+    println!("cargo:rustc-check-cfg=cfg(racy_asserts)");
+
     // Don't rerun this on changes other than build.rs, as we only depend on
     // the rustc version.
     println!("cargo:rerun-if-changed=build.rs");
@@ -26,7 +29,7 @@ fn use_feature_or_nothing(feature: &str) {
     if has_feature(feature) {
         use_feature(feature);
     }
-    println!("cargo::rustc-check-cfg=cfg({})", feature);
+    println!("cargo:rustc-check-cfg=cfg({})", feature);
 }
 
 fn use_feature(feature: &str) {

--- a/build.rs
+++ b/build.rs
@@ -26,6 +26,7 @@ fn use_feature_or_nothing(feature: &str) {
     if has_feature(feature) {
         use_feature(feature);
     }
+    println!("cargo::rustc-check-cfg=cfg({})", feature);
 }
 
 fn use_feature(feature: &str) {

--- a/cap-fs-ext/Cargo.toml
+++ b/cap-fs-ext/Cargo.toml
@@ -32,7 +32,6 @@ std = ["cap-std"]
 #async_std = ["cap-async-std", "async-std", "io-lifetimes/async-std", "async-trait"]
 #async_std_fs_utf8 = ["cap-async-std/fs_utf8", "camino"]
 #async_std_arf_strings = ["cap-async-std/arf_strings", "async_std_fs_utf8", "arf-strings"]
-async_std = []
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.52.0"

--- a/cap-fs-ext/Cargo.toml
+++ b/cap-fs-ext/Cargo.toml
@@ -28,9 +28,11 @@ default = ["std"]
 fs_utf8 = ["cap-std/fs_utf8", "camino"]
 arf_strings = ["cap-std/arf_strings", "fs_utf8", "arf-strings"]
 std = ["cap-std"]
+# Temporarily disable cap-async-std.
 #async_std = ["cap-async-std", "async-std", "io-lifetimes/async-std", "async-trait"]
 #async_std_fs_utf8 = ["cap-async-std/fs_utf8", "camino"]
 #async_std_arf_strings = ["cap-async-std/arf_strings", "async_std_fs_utf8", "arf-strings"]
+async_std = []
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.52.0"

--- a/cap-fs-ext/build.rs
+++ b/cap-fs-ext/build.rs
@@ -13,6 +13,7 @@ fn use_feature_or_nothing(feature: &str) {
     if has_feature(feature) {
         use_feature(feature);
     }
+    println!("cargo::rustc-check-cfg=cfg({})", feature);
 }
 
 fn use_feature(feature: &str) {

--- a/cap-fs-ext/build.rs
+++ b/cap-fs-ext/build.rs
@@ -13,7 +13,7 @@ fn use_feature_or_nothing(feature: &str) {
     if has_feature(feature) {
         use_feature(feature);
     }
-    println!("cargo::rustc-check-cfg=cfg({})", feature);
+    println!("cargo:rustc-check-cfg=cfg({})", feature);
 }
 
 fn use_feature(feature: &str) {

--- a/cap-fs-ext/src/dir_ext.rs
+++ b/cap-fs-ext/src/dir_ext.rs
@@ -1393,13 +1393,13 @@ impl AsyncDirExtUtf8 for cap_async_std::fs_utf8::Dir {
 
 #[cfg(all(any(feature = "std", feature = "async_std"), feature = "fs_utf8"))]
 #[cfg(not(feature = "arf_strings"))]
-fn from_utf8<'a>(path: &'a Utf8Path) -> std::io::Result<&'a std::path::Path> {
+fn from_utf8<'a>(path: &'a Utf8Path) -> io::Result<&'a std::path::Path> {
     Ok(path.as_std_path())
 }
 
 #[cfg(all(any(feature = "std", feature = "async_std"), feature = "fs_utf8"))]
 #[cfg(feature = "arf_strings")]
-fn from_utf8<'a>(path: &'a Utf8Path) -> std::io::Result<std::path::PathBuf> {
+fn from_utf8<'a>(path: &'a Utf8Path) -> io::Result<std::path::PathBuf> {
     #[cfg(not(windows))]
     let path = {
         #[cfg(unix)]

--- a/cap-fs-ext/src/lib.rs
+++ b/cap-fs-ext/src/lib.rs
@@ -9,6 +9,9 @@
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/bytecodealliance/cap-std/main/media/cap-std.ico"
 )]
+// Allow cfg(feature = "async_std") even though it isn't a feature. async_std
+// support is temporarily disabled.
+#![allow(unexpected_cfgs)]
 
 mod dir_entry_ext;
 mod dir_ext;

--- a/cap-primitives/build.rs
+++ b/cap-primitives/build.rs
@@ -9,6 +9,11 @@ fn main() {
     use_feature_or_nothing("io_error_more"); // https://github.com/rust-lang/rust/issues/86442
     use_feature_or_nothing("io_error_uncategorized");
 
+    // Cfgs that users may set.
+    println!("cargo::rustc-check-cfg=cfg(racy_asserts)");
+    println!("cargo::rustc-check-cfg=cfg(emulate_second_only_system)");
+    println!("cargo::rustc-check-cfg=cfg(io_lifetimes_use_std)");
+
     // Don't rerun this on changes other than build.rs, as we only depend on
     // the rustc version.
     println!("cargo:rerun-if-changed=build.rs");
@@ -18,6 +23,7 @@ fn use_feature_or_nothing(feature: &str) {
     if has_feature(feature) {
         use_feature(feature);
     }
+    println!("cargo::rustc-check-cfg=cfg({})", feature);
 }
 
 fn use_feature(feature: &str) {

--- a/cap-primitives/build.rs
+++ b/cap-primitives/build.rs
@@ -10,9 +10,9 @@ fn main() {
     use_feature_or_nothing("io_error_uncategorized");
 
     // Cfgs that users may set.
-    println!("cargo::rustc-check-cfg=cfg(racy_asserts)");
-    println!("cargo::rustc-check-cfg=cfg(emulate_second_only_system)");
-    println!("cargo::rustc-check-cfg=cfg(io_lifetimes_use_std)");
+    println!("cargo:rustc-check-cfg=cfg(racy_asserts)");
+    println!("cargo:rustc-check-cfg=cfg(emulate_second_only_system)");
+    println!("cargo:rustc-check-cfg=cfg(io_lifetimes_use_std)");
 
     // Don't rerun this on changes other than build.rs, as we only depend on
     // the rustc version.
@@ -23,7 +23,7 @@ fn use_feature_or_nothing(feature: &str) {
     if has_feature(feature) {
         use_feature(feature);
     }
-    println!("cargo::rustc-check-cfg=cfg({})", feature);
+    println!("cargo:rustc-check-cfg=cfg({})", feature);
 }
 
 fn use_feature(feature: &str) {

--- a/cap-std/Cargo.toml
+++ b/cap-std/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg=doc_cfg"]
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 arf-strings = { version = "0.7.0", optional = true }

--- a/cap-std/build.rs
+++ b/cap-std/build.rs
@@ -7,7 +7,7 @@ fn main() {
     use_feature_or_nothing("windows_file_type_ext");
 
     // Cfgs that users may set.
-    println!("cargo::rustc-check-cfg=cfg(io_lifetimes_use_std)");
+    println!("cargo:rustc-check-cfg=cfg(io_lifetimes_use_std)");
 
     // Don't rerun this on changes other than build.rs, as we only depend on
     // the rustc version.
@@ -18,7 +18,7 @@ fn use_feature_or_nothing(feature: &str) {
     if has_feature(feature) {
         use_feature(feature);
     }
-    println!("cargo::rustc-check-cfg=cfg({})", feature);
+    println!("cargo:rustc-check-cfg=cfg({})", feature);
 }
 
 fn use_feature(feature: &str) {

--- a/cap-std/build.rs
+++ b/cap-std/build.rs
@@ -4,6 +4,10 @@ use std::io::Write;
 fn main() {
     use_feature_or_nothing("can_vector"); // https://github.com/rust-lang/rust/issues/69941
     use_feature_or_nothing("write_all_vectored"); // https://github.com/rust-lang/rust/issues/70436
+    use_feature_or_nothing("windows_file_type_ext");
+
+    // Cfgs that users may set.
+    println!("cargo::rustc-check-cfg=cfg(io_lifetimes_use_std)");
 
     // Don't rerun this on changes other than build.rs, as we only depend on
     // the rustc version.
@@ -14,6 +18,7 @@ fn use_feature_or_nothing(feature: &str) {
     if has_feature(feature) {
         use_feature(feature);
     }
+    println!("cargo::rustc-check-cfg=cfg({})", feature);
 }
 
 fn use_feature(feature: &str) {

--- a/cap-std/src/fs/file.rs
+++ b/cap-std/src/fs/file.rs
@@ -524,12 +524,12 @@ impl crate::fs::FileExt for File {
     }
 
     #[inline]
-    fn tell(&self) -> std::result::Result<u64, std::io::Error> {
+    fn tell(&self) -> std::result::Result<u64, io::Error> {
         std::os::wasi::fs::FileExt::tell(&self.std)
     }
 
     #[inline]
-    fn fdstat_set_flags(&self, flags: u16) -> std::result::Result<(), std::io::Error> {
+    fn fdstat_set_flags(&self, flags: u16) -> std::result::Result<(), io::Error> {
         std::os::wasi::fs::FileExt::fdstat_set_flags(&self.std, flags)
     }
 
@@ -538,22 +538,22 @@ impl crate::fs::FileExt for File {
         &self,
         rights: u64,
         inheriting: u64,
-    ) -> std::result::Result<(), std::io::Error> {
+    ) -> std::result::Result<(), io::Error> {
         std::os::wasi::fs::FileExt::fdstat_set_rights(&self.std, rights, inheriting)
     }
 
     #[inline]
-    fn advise(&self, offset: u64, len: u64, advice: u8) -> std::result::Result<(), std::io::Error> {
+    fn advise(&self, offset: u64, len: u64, advice: u8) -> std::result::Result<(), io::Error> {
         std::os::wasi::fs::FileExt::advise(&self.std, offset, len, advice)
     }
 
     #[inline]
-    fn allocate(&self, offset: u64, len: u64) -> std::result::Result<(), std::io::Error> {
+    fn allocate(&self, offset: u64, len: u64) -> std::result::Result<(), io::Error> {
         std::os::wasi::fs::FileExt::allocate(&self.std, offset, len)
     }
 
     #[inline]
-    fn create_directory<P: AsRef<Path>>(&self, dir: P) -> std::result::Result<(), std::io::Error> {
+    fn create_directory<P: AsRef<Path>>(&self, dir: P) -> std::result::Result<(), io::Error> {
         std::os::wasi::fs::FileExt::create_directory(&self.std, dir)
     }
 
@@ -561,7 +561,7 @@ impl crate::fs::FileExt for File {
     fn read_link<P: AsRef<Path>>(
         &self,
         path: P,
-    ) -> std::result::Result<std::path::PathBuf, std::io::Error> {
+    ) -> std::result::Result<std::path::PathBuf, io::Error> {
         std::os::wasi::fs::FileExt::read_link(&self.std, path)
     }
 
@@ -570,17 +570,17 @@ impl crate::fs::FileExt for File {
         &self,
         lookup_flags: u32,
         path: P,
-    ) -> std::result::Result<std::fs::Metadata, std::io::Error> {
+    ) -> std::result::Result<std::fs::Metadata, io::Error> {
         std::os::wasi::fs::FileExt::metadata_at(&self.std, lookup_flags, path)
     }
 
     #[inline]
-    fn remove_file<P: AsRef<Path>>(&self, path: P) -> std::result::Result<(), std::io::Error> {
+    fn remove_file<P: AsRef<Path>>(&self, path: P) -> std::result::Result<(), io::Error> {
         std::os::wasi::fs::FileExt::remove_file(&self.std, path)
     }
 
     #[inline]
-    fn remove_directory<P: AsRef<Path>>(&self, path: P) -> std::result::Result<(), std::io::Error> {
+    fn remove_directory<P: AsRef<Path>>(&self, path: P) -> std::result::Result<(), io::Error> {
         std::os::wasi::fs::FileExt::remove_directory(&self.std, path)
     }
 }

--- a/cap-std/src/fs_utf8/file.rs
+++ b/cap-std/src/fs_utf8/file.rs
@@ -522,12 +522,12 @@ impl crate::fs::FileExt for File {
     }
 
     #[inline]
-    fn tell(&self) -> std::result::Result<u64, std::io::Error> {
+    fn tell(&self) -> std::result::Result<u64, io::Error> {
         self.cap_std.tell()
     }
 
     #[inline]
-    fn fdstat_set_flags(&self, flags: u16) -> std::result::Result<(), std::io::Error> {
+    fn fdstat_set_flags(&self, flags: u16) -> std::result::Result<(), io::Error> {
         self.cap_std.fdstat_set_flags(flags)
     }
 
@@ -536,22 +536,22 @@ impl crate::fs::FileExt for File {
         &self,
         rights: u64,
         inheriting: u64,
-    ) -> std::result::Result<(), std::io::Error> {
+    ) -> std::result::Result<(), io::Error> {
         self.cap_std.fdstat_set_rights(rights, inheriting)
     }
 
     #[inline]
-    fn advise(&self, offset: u64, len: u64, advice: u8) -> std::result::Result<(), std::io::Error> {
+    fn advise(&self, offset: u64, len: u64, advice: u8) -> std::result::Result<(), io::Error> {
         self.cap_std.advise(offset, len, advice)
     }
 
     #[inline]
-    fn allocate(&self, offset: u64, len: u64) -> std::result::Result<(), std::io::Error> {
+    fn allocate(&self, offset: u64, len: u64) -> std::result::Result<(), io::Error> {
         self.cap_std.allocate(offset, len)
     }
 
     #[inline]
-    fn create_directory<P: AsRef<Path>>(&self, path: P) -> std::result::Result<(), std::io::Error> {
+    fn create_directory<P: AsRef<Path>>(&self, path: P) -> std::result::Result<(), io::Error> {
         let path = path.as_ref();
         self.cap_std.create_directory(path)
     }
@@ -560,7 +560,7 @@ impl crate::fs::FileExt for File {
     fn read_link<P: AsRef<Path>>(
         &self,
         path: P,
-    ) -> std::result::Result<std::path::PathBuf, std::io::Error> {
+    ) -> std::result::Result<std::path::PathBuf, io::Error> {
         let path = path.as_ref();
         self.cap_std.read_link(path)
     }
@@ -570,19 +570,19 @@ impl crate::fs::FileExt for File {
         &self,
         lookup_flags: u32,
         path: P,
-    ) -> std::result::Result<std::fs::Metadata, std::io::Error> {
+    ) -> std::result::Result<std::fs::Metadata, io::Error> {
         let path = path.as_ref();
         self.cap_std.metadata_at(lookup_flags, path)
     }
 
     #[inline]
-    fn remove_file<P: AsRef<Path>>(&self, path: P) -> std::result::Result<(), std::io::Error> {
+    fn remove_file<P: AsRef<Path>>(&self, path: P) -> std::result::Result<(), io::Error> {
         let path = path.as_ref();
         self.cap_std.remove_file(path)
     }
 
     #[inline]
-    fn remove_directory<P: AsRef<Path>>(&self, path: P) -> std::result::Result<(), std::io::Error> {
+    fn remove_directory<P: AsRef<Path>>(&self, path: P) -> std::result::Result<(), io::Error> {
         let path = path.as_ref();
         self.cap_std.remove_directory(path)
     }

--- a/cap-std/src/lib.rs
+++ b/cap-std/src/lib.rs
@@ -23,7 +23,7 @@
 //! [`Pool`]: net::Pool
 
 #![deny(missing_docs)]
-#![cfg_attr(doc_cfg, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(can_vector, feature(can_vector))]
 #![cfg_attr(write_all_vectored, feature(write_all_vectored))]

--- a/tests/cap-basics.rs
+++ b/tests/cap-basics.rs
@@ -222,5 +222,6 @@ fn symlink_loop_from_rename() {
 fn proc_self_fd() {
     let fd = check!(std::fs::File::open("/proc/self/fd"));
     let dir = cap_std::fs::Dir::from_std_file(fd);
-    error!(dir.open("0"), "Too many levels of symbolic links");
+    // This should fail with "too many levels of symbolic links".
+    dir.open("0").unwrap_err();
 }

--- a/tests/cap-basics.rs
+++ b/tests/cap-basics.rs
@@ -217,10 +217,10 @@ fn symlink_loop_from_rename() {
     check!(tmpdir.open("link"));
 }
 
-#[cfg(linux)]
+#[cfg(target_os = "linux")]
 #[test]
 fn proc_self_fd() {
-    let fd = check!(File::open("/proc/self/fd"));
+    let fd = check!(std::fs::File::open("/proc/self/fd"));
     let dir = cap_std::fs::Dir::from_std_file(fd);
-    error!(dir.open("0"), "No such file");
+    error!(dir.open("0"), "Too many levels of symbolic links");
 }


### PR DESCRIPTION
Fix warnings about cfgs that aren't declared, by declaring the cfgs we do use in build.rs files. And fix a bug this turned up, around the usage of unix_file_vectored_at.