### PR TITLE
Have `cap-fs-ext` re-export `OpenOptionsExt` and `MetadataExt`.

### DIFF
--- a/cap-fs-ext/src/lib.rs
+++ b/cap-fs-ext/src/lib.rs
@@ -36,7 +36,9 @@ pub use open_options_sync_ext::OpenOptionsSyncExt;
 pub use reopen::Reopen;
 
 /// Re-export these to allow them to be used with `Reuse`.
-pub use cap_primitives::fs::{FollowSymlinks, Metadata, MetadataExt, OpenOptions, OpenOptionsExt};
+pub use cap_primitives::fs::{
+    FollowSymlinks, Metadata, MetadataExt as OsMetadataExt, OpenOptions, OpenOptionsExt,
+};
 
 #[doc(hidden)]
 pub use cap_primitives::ambient_authority_known_at_compile_time;

--- a/cap-fs-ext/src/lib.rs
+++ b/cap-fs-ext/src/lib.rs
@@ -36,7 +36,7 @@ pub use open_options_sync_ext::OpenOptionsSyncExt;
 pub use reopen::Reopen;
 
 /// Re-export these to allow them to be used with `Reuse`.
-pub use cap_primitives::fs::{FollowSymlinks, Metadata, OpenOptions};
+pub use cap_primitives::fs::{FollowSymlinks, Metadata, MetadataExt, OpenOptions, OpenOptionsExt};
 
 #[doc(hidden)]
 pub use cap_primitives::ambient_authority_known_at_compile_time;

--- a/cap-primitives/src/fs/metadata.rs
+++ b/cap-primitives/src/fs/metadata.rs
@@ -261,6 +261,8 @@ pub trait MetadataExt {
 }
 
 /// Windows-specific extensions to [`Metadata`].
+///
+/// This corresponds to [`std::os::windows::fs::MetadataExt`].
 #[cfg(windows)]
 pub trait MetadataExt {
     /// Returns the value of the `dwFileAttributes` field of this metadata.


### PR DESCRIPTION
Since cap-fs-ext is already re-exporting `OpenOptions` and `Metadata`, now that `OpenOptionsExt` and `MetadataExt` are custom traits instead of std traits, re-export them so users can use them with `OpenOptions` and `Metadata`.