### PR TITLE
Fix handling of `..` paths in symlinks.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -201,7 +201,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, windows-latest, windows-2019, macos-latest, macos-11, beta, ubuntu-20.04, aarch64-ubuntu]
+        build: [stable, windows-latest, windows-2019, macos-latest, macos-12, beta, ubuntu-20.04, aarch64-ubuntu]
         include:
           - build: stable
             os: ubuntu-latest

--- a/cap-primitives/src/fs/manually/open.rs
+++ b/cap-primitives/src/fs/manually/open.rs
@@ -314,6 +314,7 @@ impl<'start> Context<'start> {
 
     /// Push the components of `destination` onto the worklist stack.
     fn push_symlink_destination(&mut self, destination: PathBuf) -> io::Result<()> {
+        let at_end = self.components.is_empty();
         let trailing_slash = path_has_trailing_slash(&destination);
         let trailing_dot = path_has_trailing_dot(&destination);
         let trailing_dotdot = destination.ends_with(Component::ParentDir);
@@ -362,9 +363,11 @@ impl<'start> Context<'start> {
 
         // Record whether the new components ended with a path that implies
         // an open of `.` at the end of path resolution.
-        self.follow_with_dot |= trailing_dot | trailing_dotdot;
-        self.trailing_slash |= trailing_slash;
-        self.dir_required |= trailing_slash;
+        if at_end {
+            self.follow_with_dot |= trailing_dot | trailing_dotdot;
+            self.trailing_slash |= trailing_slash;
+            self.dir_required |= trailing_slash;
+        }
 
         // As an optimization, hold onto the `PathBuf` buffer for later reuse.
         self.reuse = destination;

--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -1062,6 +1062,7 @@ fn dotdot_in_middle_of_symlink() {
 ///
 /// Windows doesn't appear to like symlinks that end with `/.`.
 #[test]
+#[cfg_attr(windows, ignore)]
 fn dotdot_slashdot_in_middle_of_symlink() {
     let tmpdir = tmpdir();
 

--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -1060,7 +1060,7 @@ fn dotdot_in_middle_of_symlink() {
 
 /// Like `dotdot_in_middle_of_symlink` but with a `/.` at the end.
 ///
-/// This fails on Windows for unknown reasons. Patches welcome.
+/// Windows doesn't appear to like symlinks that end with `/.`.
 #[test]
 fn dotdot_slashdot_in_middle_of_symlink() {
     let tmpdir = tmpdir();
@@ -1080,9 +1080,9 @@ fn dotdot_slashdot_in_middle_of_symlink() {
 
 /// Same as `dotdot_in_middle_of_symlink`, but use two levels of `..`.
 ///
-/// This fails on Windows for unknown reasons. Patches welcome.
+/// Windows doesn't appear to like symlinks that end with `/..`.
 #[test]
-//#[cfg_attr(windows, ignore)]
+#[cfg_attr(windows, ignore)]
 fn dotdot_more_in_middle_of_symlink() {
     let tmpdir = tmpdir();
 
@@ -1101,9 +1101,9 @@ fn dotdot_more_in_middle_of_symlink() {
 
 /// Like `dotdot_more_in_middle_of_symlink`, but with a `/.` at the end.
 ///
-/// This fails on Windows for unknown reasons. Patches welcome.
+/// Windows doesn't appear to like symlinks that end with `/.`.
 #[test]
-//#[cfg_attr(windows, ignore)]
+#[cfg_attr(windows, ignore)]
 fn dotdot_slashdot_more_in_middle_of_symlink() {
     let tmpdir = tmpdir();
 
@@ -1123,9 +1123,9 @@ fn dotdot_slashdot_more_in_middle_of_symlink() {
 /// Same as `dotdot_more_in_middle_of_symlink`, but the symlink doesn't
 /// include `c`.
 ///
-/// This fails on Windows for unknown reasons. Patches welcome.
+/// Windows doesn't appear to like symlinks that end with `/..`.
 #[test]
-//#[cfg_attr(windows, ignore)]
+#[cfg_attr(windows, ignore)]
 fn dotdot_other_in_middle_of_symlink() {
     let tmpdir = tmpdir();
 
@@ -1144,9 +1144,9 @@ fn dotdot_other_in_middle_of_symlink() {
 
 /// Like `dotdot_other_in_middle_of_symlink`, but with `/.` at the end.
 ///
-/// This fails on Windows for unknown reasons. Patches welcome.
+/// Windows doesn't appear to like symlinks that end with `/.`.
 #[test]
-//#[cfg_attr(windows, ignore)]
+#[cfg_attr(windows, ignore)]
 fn dotdot_slashdot_other_in_middle_of_symlink() {
     let tmpdir = tmpdir();
 
@@ -1184,9 +1184,9 @@ fn dotdot_even_more_in_middle_of_symlink() {
 
 /// Like `dotdot_even_more_in_middle_of_symlink`, but with a `/.` at the end.
 ///
-/// This fails on Windows for unknown reasons. Patches welcome.
+/// Windows doesn't appear to like symlinks that end with `/.`.
 #[test]
-//#[cfg_attr(windows, ignore)]
+#[cfg_attr(windows, ignore)]
 fn dotdot_slashdot_even_more_in_middle_of_symlink() {
     let tmpdir = tmpdir();
 
@@ -1224,9 +1224,9 @@ fn dotdot_even_other_in_middle_of_symlink() {
 
 /// Like `dotdot_even_other_in_middle_of_symlink`, but with a `/.` at the end.
 ///
-/// This fails on Windows for unknown reasons. Patches welcome.
+/// Windows doesn't appear to like symlinks that end with `/.`.
 #[test]
-//#[cfg_attr(windows, ignore)]
+#[cfg_attr(windows, ignore)]
 fn dotdot_slashdot_even_other_in_middle_of_symlink() {
     let tmpdir = tmpdir();
 
@@ -1273,9 +1273,9 @@ fn dotdot_at_end_of_symlink() {
 
 /// Like `dotdot_at_end_of_symlink`, but with a `/.` at the end.
 ///
-/// This fails on Windows for unknown reasons. Patches welcome.
+/// Windows doesn't appear to like symlinks that end with `/.`.
 #[test]
-//#[cfg_attr(windows, ignore)]
+#[cfg_attr(windows, ignore)]
 fn dotdot_slashdot_at_end_of_symlink() {
     let tmpdir = tmpdir();
 
@@ -1329,9 +1329,9 @@ fn dotdot_at_end_of_symlink_all_inside_dir() {
 
 /// `dotdot_at_end_of_symlink_all_inside_dir`, but with a `/.` at the end.
 ///
-/// This fails on Windows for unknown reasons. Patches welcome.
+/// Windows doesn't appear to like symlinks that end with `/.`.
 #[test]
-//#[cfg_attr(windows, ignore)]
+#[cfg_attr(windows, ignore)]
 fn dotdot_slashdot_at_end_of_symlink_all_inside_dir() {
     let tmpdir = tmpdir();
 

--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -1059,6 +1059,8 @@ fn dotdot_in_middle_of_symlink() {
 }
 
 /// Like `dotdot_in_middle_of_symlink` but with a `/.` at the end.
+///
+/// This fails on Windows for unknown reasons. Patches welcome.
 #[test]
 fn dotdot_slashdot_in_middle_of_symlink() {
     let tmpdir = tmpdir();
@@ -1080,7 +1082,7 @@ fn dotdot_slashdot_in_middle_of_symlink() {
 ///
 /// This fails on Windows for unknown reasons. Patches welcome.
 #[test]
-//#[cfg(not(windows))]
+//#[cfg_attr(windows, ignore)]
 fn dotdot_more_in_middle_of_symlink() {
     let tmpdir = tmpdir();
 
@@ -1098,8 +1100,10 @@ fn dotdot_more_in_middle_of_symlink() {
 }
 
 /// Like `dotdot_more_in_middle_of_symlink`, but with a `/.` at the end.
+///
+/// This fails on Windows for unknown reasons. Patches welcome.
 #[test]
-//#[cfg(not(windows))]
+//#[cfg_attr(windows, ignore)]
 fn dotdot_slashdot_more_in_middle_of_symlink() {
     let tmpdir = tmpdir();
 
@@ -1121,7 +1125,7 @@ fn dotdot_slashdot_more_in_middle_of_symlink() {
 ///
 /// This fails on Windows for unknown reasons. Patches welcome.
 #[test]
-//#[cfg(not(windows))]
+//#[cfg_attr(windows, ignore)]
 fn dotdot_other_in_middle_of_symlink() {
     let tmpdir = tmpdir();
 
@@ -1139,8 +1143,10 @@ fn dotdot_other_in_middle_of_symlink() {
 }
 
 /// Like `dotdot_other_in_middle_of_symlink`, but with `/.` at the end.
+///
+/// This fails on Windows for unknown reasons. Patches welcome.
 #[test]
-//#[cfg(not(windows))]
+//#[cfg_attr(windows, ignore)]
 fn dotdot_slashdot_other_in_middle_of_symlink() {
     let tmpdir = tmpdir();
 
@@ -1177,7 +1183,10 @@ fn dotdot_even_more_in_middle_of_symlink() {
 }
 
 /// Like `dotdot_even_more_in_middle_of_symlink`, but with a `/.` at the end.
+///
+/// This fails on Windows for unknown reasons. Patches welcome.
 #[test]
+//#[cfg_attr(windows, ignore)]
 fn dotdot_slashdot_even_more_in_middle_of_symlink() {
     let tmpdir = tmpdir();
 
@@ -1214,7 +1223,10 @@ fn dotdot_even_other_in_middle_of_symlink() {
 }
 
 /// Like `dotdot_even_other_in_middle_of_symlink`, but with a `/.` at the end.
+///
+/// This fails on Windows for unknown reasons. Patches welcome.
 #[test]
+//#[cfg_attr(windows, ignore)]
 fn dotdot_slashdot_even_other_in_middle_of_symlink() {
     let tmpdir = tmpdir();
 
@@ -1260,7 +1272,10 @@ fn dotdot_at_end_of_symlink() {
 }
 
 /// Like `dotdot_at_end_of_symlink`, but with a `/.` at the end.
+///
+/// This fails on Windows for unknown reasons. Patches welcome.
 #[test]
+//#[cfg_attr(windows, ignore)]
 fn dotdot_slashdot_at_end_of_symlink() {
     let tmpdir = tmpdir();
 
@@ -1313,7 +1328,10 @@ fn dotdot_at_end_of_symlink_all_inside_dir() {
 }
 
 /// `dotdot_at_end_of_symlink_all_inside_dir`, but with a `/.` at the end.
+///
+/// This fails on Windows for unknown reasons. Patches welcome.
 #[test]
+//#[cfg_attr(windows, ignore)]
 fn dotdot_slashdot_at_end_of_symlink_all_inside_dir() {
     let tmpdir = tmpdir();
 

--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -1058,11 +1058,29 @@ fn dotdot_in_middle_of_symlink() {
     assert_eq!(data, foo);
 }
 
+/// Like `dotdot_in_middle_of_symlink` but with a `/.` at the end.
+#[test]
+fn dotdot_slashdot_in_middle_of_symlink() {
+    let tmpdir = tmpdir();
+
+    let foo = b"foo";
+    check!(tmpdir.write("target", foo));
+    check!(tmpdir.create_dir("b"));
+    let b = check!(tmpdir.open_dir("b"));
+    check!(symlink_dir("../.", &b, "up"));
+
+    let path = "b/up/target";
+    let mut file = check!(tmpdir.open(path));
+    let mut data = Vec::new();
+    check!(file.read_to_end(&mut data));
+    assert_eq!(data, foo);
+}
+
 /// Same as `dotdot_in_middle_of_symlink`, but use two levels of `..`.
 ///
 /// This fails on Windows for unknown reasons. Patches welcome.
 #[test]
-#[cfg(not(windows))]
+//#[cfg(not(windows))]
 fn dotdot_more_in_middle_of_symlink() {
     let tmpdir = tmpdir();
 
@@ -1079,12 +1097,31 @@ fn dotdot_more_in_middle_of_symlink() {
     assert_eq!(data, foo);
 }
 
+/// Like `dotdot_more_in_middle_of_symlink`, but with a `/.` at the end.
+#[test]
+//#[cfg(not(windows))]
+fn dotdot_slashdot_more_in_middle_of_symlink() {
+    let tmpdir = tmpdir();
+
+    let foo = b"foo";
+    check!(tmpdir.write("target", foo));
+    check!(tmpdir.create_dir_all("b/c"));
+    let b = check!(tmpdir.open_dir("b"));
+    check!(symlink_dir("c/../../.", &b, "up"));
+
+    let path = "b/up/target";
+    let mut file = check!(tmpdir.open(path));
+    let mut data = Vec::new();
+    check!(file.read_to_end(&mut data));
+    assert_eq!(data, foo);
+}
+
 /// Same as `dotdot_more_in_middle_of_symlink`, but the symlink doesn't
 /// include `c`.
 ///
 /// This fails on Windows for unknown reasons. Patches welcome.
 #[test]
-#[cfg(not(windows))]
+//#[cfg(not(windows))]
 fn dotdot_other_in_middle_of_symlink() {
     let tmpdir = tmpdir();
 
@@ -1093,6 +1130,25 @@ fn dotdot_other_in_middle_of_symlink() {
     check!(tmpdir.create_dir_all("b/c"));
     let c = check!(tmpdir.open_dir("b/c"));
     check!(symlink_dir("../..", &c, "up"));
+
+    let path = "b/c/up/target";
+    let mut file = check!(tmpdir.open(path));
+    let mut data = Vec::new();
+    check!(file.read_to_end(&mut data));
+    assert_eq!(data, foo);
+}
+
+/// Like `dotdot_other_in_middle_of_symlink`, but with `/.` at the end.
+#[test]
+//#[cfg(not(windows))]
+fn dotdot_slashdot_other_in_middle_of_symlink() {
+    let tmpdir = tmpdir();
+
+    let foo = b"foo";
+    check!(tmpdir.write("target", foo));
+    check!(tmpdir.create_dir_all("b/c"));
+    let c = check!(tmpdir.open_dir("b/c"));
+    check!(symlink_dir("../../.", &c, "up"));
 
     let path = "b/c/up/target";
     let mut file = check!(tmpdir.open(path));
@@ -1120,6 +1176,24 @@ fn dotdot_even_more_in_middle_of_symlink() {
     assert_eq!(data, foo);
 }
 
+/// Like `dotdot_even_more_in_middle_of_symlink`, but with a `/.` at the end.
+#[test]
+fn dotdot_slashdot_even_more_in_middle_of_symlink() {
+    let tmpdir = tmpdir();
+
+    let foo = b"foo";
+    check!(tmpdir.create_dir_all("b/c"));
+    check!(tmpdir.write("b/target", foo));
+    let b = check!(tmpdir.open_dir("b"));
+    check!(symlink_dir("c/../../b/.", &b, "up"));
+
+    let path = "b/up/target";
+    let mut file = check!(tmpdir.open(path));
+    let mut data = Vec::new();
+    check!(file.read_to_end(&mut data));
+    assert_eq!(data, foo);
+}
+
 /// Same as `dotdot_even_more_in_middle_of_symlink`, but the symlink doesn't
 /// include `c`.
 #[test]
@@ -1131,6 +1205,24 @@ fn dotdot_even_other_in_middle_of_symlink() {
     check!(tmpdir.write("b/target", foo));
     let c = check!(tmpdir.open_dir("b/c"));
     check!(symlink_dir("../../b", &c, "up"));
+
+    let path = "b/c/up/target";
+    let mut file = check!(tmpdir.open(path));
+    let mut data = Vec::new();
+    check!(file.read_to_end(&mut data));
+    assert_eq!(data, foo);
+}
+
+/// Like `dotdot_even_other_in_middle_of_symlink`, but with a `/.` at the end.
+#[test]
+fn dotdot_slashdot_even_other_in_middle_of_symlink() {
+    let tmpdir = tmpdir();
+
+    let foo = b"foo";
+    check!(tmpdir.create_dir_all("b/c"));
+    check!(tmpdir.write("b/target", foo));
+    let c = check!(tmpdir.open_dir("b/c"));
+    check!(symlink_dir("../../b/.", &c, "up"));
 
     let path = "b/c/up/target";
     let mut file = check!(tmpdir.open(path));
@@ -1167,6 +1259,31 @@ fn dotdot_at_end_of_symlink() {
     }
 }
 
+/// Like `dotdot_at_end_of_symlink`, but with a `/.` at the end.
+#[test]
+fn dotdot_slashdot_at_end_of_symlink() {
+    let tmpdir = tmpdir();
+
+    let foo = b"foo";
+    check!(tmpdir.write("target", foo));
+    check!(tmpdir.create_dir("b"));
+    let b = check!(tmpdir.open_dir("b"));
+    check!(symlink_dir("../.", &b, "up"));
+
+    // Do some things with `path` that might break with an `O_PATH` fd.
+    // On Linux, the `permissions` part doesn't because cap-std uses
+    // /proc/self/fd. But the `read_dir` part does.
+    let path = "b/up";
+
+    let perms = check!(tmpdir.metadata(path)).permissions();
+    check!(tmpdir.set_permissions(path, perms));
+
+    let contents = check!(tmpdir.read_dir(path));
+    for entry in contents {
+        let _entry = check!(entry);
+    }
+}
+
 /// Like `dotdot_at_end_of_symlink`, but do everything inside a new directory,
 /// so that `MaybeOwnedFile` doesn't reopen `.` which would artificially give
 /// us a non-`O_PATH` fd.
@@ -1180,6 +1297,32 @@ fn dotdot_at_end_of_symlink_all_inside_dir() {
     check!(tmpdir.create_dir("dir/b"));
     let b = check!(tmpdir.open_dir("dir/b"));
     check!(symlink_dir("..", &b, "up"));
+
+    // Do some things with `path` that might break with an `O_PATH` fd.
+    // On Linux, the `permissions` part doesn't because cap-std uses
+    // /proc/self/fd. But the `read_dir` part does.
+    let path = "dir/b/up";
+
+    let perms = check!(tmpdir.metadata(path)).permissions();
+    check!(tmpdir.set_permissions(path, perms));
+
+    let contents = check!(tmpdir.read_dir(path));
+    for entry in contents {
+        let _entry = check!(entry);
+    }
+}
+
+/// `dotdot_at_end_of_symlink_all_inside_dir`, but with a `/.` at the end.
+#[test]
+fn dotdot_slashdot_at_end_of_symlink_all_inside_dir() {
+    let tmpdir = tmpdir();
+
+    let foo = b"foo";
+    check!(tmpdir.create_dir("dir"));
+    check!(tmpdir.write("dir/target", foo));
+    check!(tmpdir.create_dir("dir/b"));
+    let b = check!(tmpdir.open_dir("dir/b"));
+    check!(symlink_dir("../.", &b, "up"));
 
     // Do some things with `path` that might break with an `O_PATH` fd.
     // On Linux, the `permissions` part doesn't because cap-std uses


### PR DESCRIPTION
When `..` appears at the end of a symlink target, but is not at the end of the full path target, don't mark the path as being expected to open a directory.

This fixes the reduced testcase in bytecodealliance/wasmtime#9272.