### PR TITLE
[cap-primitives] add support for illumos

### DIFF
--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 [dependencies]
 ambient-authority = "0.0.2"
 arbitrary = { version = "1.0.0", optional = true, features = ["derive"] }
-ipnet = "2.3.0"
+ipnet = "2.5.0"
 maybe-owned = "0.3.4"
 fs-set-times = "0.20.0"
 io-extras = "0.18.0"
@@ -25,7 +25,7 @@ io-lifetimes = { version = "2.0.0", default-features = false }
 cap-tempfile = { path = "../cap-tempfile" }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.38.32", features = ["fs", "process", "procfs", "termios", "time"] }
+rustix = { version = "0.38.38", features = ["fs", "process", "procfs", "termios", "time"] }
 
 [target.'cfg(windows)'.dependencies]
 winx = "0.36.0"

--- a/cap-primitives/src/fs/dir_entry.rs
+++ b/cap-primitives/src/fs/dir_entry.rs
@@ -82,6 +82,12 @@ impl DirEntry {
     /// Returns the file type for the file that this entry points at.
     ///
     /// This corresponds to [`std::fs::DirEntry::file_type`].
+    ///
+    /// # Platform-specific behavior
+    ///
+    /// On Windows and most Unix platforms this function is free (no extra system calls needed), but
+    /// some Unix platforms may require the equivalent call to `metadata` to learn about the target
+    /// file type.
     #[inline]
     pub fn file_type(&self) -> io::Result<FileType> {
         self.inner.file_type()

--- a/cap-primitives/src/rustix/fs/dir_utils.rs
+++ b/cap-primitives/src/rustix/fs/dir_utils.rs
@@ -143,6 +143,8 @@ pub(crate) const fn target_o_path() -> OFlags {
         target_os = "netbsd",
         target_os = "openbsd",
         target_os = "wasi",
+        target_os = "illumos",
+        target_os = "solaris",
     ))]
     {
         OFlags::empty()

--- a/cap-primitives/src/rustix/fs/mod.rs
+++ b/cap-primitives/src/rustix/fs/mod.rs
@@ -142,10 +142,13 @@ fn tty_path() {
     #[cfg(unix)]
     use std::os::unix::fs::FileTypeExt;
 
-    // On FreeBSD, /dev/{tty,stdin,stdout,stderr} are aliases to different real
-    // devices.
     let paths: &[&str] = if cfg!(target_os = "freebsd") {
+        // On FreeBSD, /dev/{tty,stdin,stdout,stderr} are aliases to different
+        // real devices.
         &["/dev/ttyv0", "/dev/pts/0"]
+    } else if cfg!(target_os = "illumos") {
+        // On illumos, /dev/std{in,out,err} only exist if they're open.
+        &["/dev/tty", "/dev/pts/0"]
     } else {
         &["/dev/tty", "/dev/stdin", "/dev/stdout", "/dev/stderr"]
     };
@@ -162,7 +165,8 @@ fn tty_path() {
                             .as_ref()
                             .map(std::fs::canonicalize)
                             .map(Result::unwrap),
-                        Some(canonical)
+                        Some(canonical),
+                        "for path {path}, file_path matches canonicalized path"
                     );
                 }
             }


### PR DESCRIPTION
Get the cap-primitives library building and passing all tests on illumos. There were just a couple of minor tweaks required.

I also ran into an issue where the minimum version of `ipnet` required was too old, so I took the liberty to bump it to 2.5.0 which has `IpNet::new`.

The note in `dir_entry.rs` is copied over from Rust's std: https://doc.rust-lang.org/std/fs/struct.DirEntry.html#method.file_type