### PR TITLE
Reenable cap-async-std.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,15 @@ exclude = ["/.*"]
 rust-version = "1.63"
 
 [dev-dependencies]
-#async-std = { version = "1.10.0", features = ["attributes"] }
+async-std = { version = "1.13.0", features = ["attributes", "io_safety"] }
 anyhow = "1.0.37"
-#cap-async-std = { path = "cap-async-std", version = "^0.25.0" }
-cap-fs-ext = { path = "cap-fs-ext", version = "^3.3.0" }
-cap-net-ext = { path = "cap-net-ext", version = "^3.3.0" }
-cap-directories = { path = "cap-directories", version = "^3.3.0" }
-cap-std = { path = "cap-std", version = "^3.3.0" }
-cap-tempfile = { path = "cap-tempfile", version = "^3.3.0" }
-cap-rand = { path = "cap-rand", version = "^3.3.0" }
+cap-async-std = { path = "cap-async-std", version = "3.3.0" }
+cap-fs-ext = { path = "cap-fs-ext", version = "3.3.0" }
+cap-net-ext = { path = "cap-net-ext", version = "3.3.0" }
+cap-directories = { path = "cap-directories", version = "3.3.0" }
+cap-std = { path = "cap-std", version = "3.3.0" }
+cap-tempfile = { path = "cap-tempfile", version = "3.3.0" }
+cap-rand = { path = "cap-rand", version = "3.3.0" }
 rand = "0.8.1"
 tempfile = "3.1.0"
 camino = "1.0.5"
@@ -55,23 +55,23 @@ fs_utf8 = [
     "cap-fs-ext/fs_utf8",
     "cap-tempfile/fs_utf8",
 ]
-#async_std_fs_utf8 = [
-#    "cap-async-std/fs_utf8",
-#    "cap-fs-ext/async_std_fs_utf8"
-#]
+async_std_fs_utf8 = [
+    "cap-async-std/fs_utf8",
+    "cap-fs-ext/async_std_fs_utf8"
+]
 arf_strings = [
     "cap-std/arf_strings",
     "cap-fs-ext/arf_strings",
     "cap-tempfile/arf_strings",
 ]
-#async_std_arf_strings = [
-#    "cap-async-std/arf_strings",
-#    "cap-fs-ext/async_std_arf_strings"
-#]
+async_std_arf_strings = [
+    "cap-async-std/arf_strings",
+    "cap-fs-ext/async_std_arf_strings"
+]
 
 [workspace]
 members = [
-  #"cap-async-std",
+  "cap-async-std",
   "cap-fs-ext",
   "cap-net-ext",
   "cap-directories",

--- a/cap-async-std/Cargo.toml
+++ b/cap-async-std/Cargo.toml
@@ -17,7 +17,7 @@ arf-strings = { version = "0.7.0", optional = true }
 async-std = { version = "1.13.0", features = ["attributes", "io_safety"] }
 cap-primitives = { path = "../cap-primitives", version = "^3.3.0" }
 io-lifetimes = { version = "2.0.0", default-features = false, features = ["async-std"] }
-io-extras = { version = "0.18.0", features = ["use_async_std"] }
+io-extras = { version = "0.18.3", features = ["use_async_std"] }
 camino = { version = "1.0.5", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]

--- a/cap-async-std/Cargo.toml
+++ b/cap-async-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cap-async-std"
-version = "0.25.2"
+version = "3.3.0"
 description = "Capability-based version of async-std"
 authors = [
     "Dan Gohman <dev@sunfishcode.online>",
@@ -11,15 +11,13 @@ keywords = ["network", "file", "async", "future", "await"]
 categories = ["filesystem", "network-programming", "asynchronous", "concurrency"]
 repository = "https://github.com/bytecodealliance/cap-std"
 edition = "2021"
-publish = false # temporary, until async-rs/async-std#1036 is available
 
 [dependencies]
 arf-strings = { version = "0.7.0", optional = true }
-# Enable "unstable" for `spawn_blocking`.
-async-std = { version = "1.10.0", features = ["attributes", "unstable"] }
-cap-primitives = { path = "../cap-primitives", version = "^0.25.0" }
+async-std = { version = "1.13.0", features = ["attributes", "io_safety"] }
+cap-primitives = { path = "../cap-primitives", version = "^3.3.0" }
 io-lifetimes = { version = "2.0.0", default-features = false, features = ["async-std"] }
-io-extras = { version = "0.17.0", features = ["use_async_std"] }
+io-extras = { version = "0.18.0", features = ["use_async_std"] }
 camino = { version = "1.0.5", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]

--- a/cap-async-std/build.rs
+++ b/cap-async-std/build.rs
@@ -1,0 +1,84 @@
+use std::env::var;
+use std::io::Write;
+
+fn main() {
+    use_feature_or_nothing("windows_file_type_ext");
+
+    // Cfgs that users may set.
+    println!("cargo:rustc-check-cfg=cfg(io_lifetimes_use_std)");
+
+    // Don't rerun this on changes other than build.rs, as we only depend on
+    // the rustc version.
+    println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn use_feature_or_nothing(feature: &str) {
+    if has_feature(feature) {
+        use_feature(feature);
+    }
+    println!("cargo:rustc-check-cfg=cfg({})", feature);
+}
+
+fn use_feature(feature: &str) {
+    println!("cargo:rustc-cfg={}", feature);
+}
+
+/// Test whether the rustc at `var("RUSTC")` supports the given feature.
+fn has_feature(feature: &str) -> bool {
+    can_compile(&format!(
+        "#![allow(stable_features)]\n#![feature({})]",
+        feature
+    ))
+}
+
+/// Test whether the rustc at `var("RUSTC")` can compile the given code.
+fn can_compile<T: AsRef<str>>(test: T) -> bool {
+    use std::process::Stdio;
+
+    let out_dir = var("OUT_DIR").unwrap();
+    let rustc = var("RUSTC").unwrap();
+    let target = var("TARGET").unwrap();
+
+    // Use `RUSTC_WRAPPER` if it's set, unless it's set to an empty string,
+    // as documented [here].
+    // [here]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-reads
+    let wrapper = var("RUSTC_WRAPPER")
+        .ok()
+        .and_then(|w| if w.is_empty() { None } else { Some(w) });
+
+    let mut cmd = if let Some(wrapper) = wrapper {
+        let mut cmd = std::process::Command::new(wrapper);
+        // The wrapper's first argument is supposed to be the path to rustc.
+        cmd.arg(rustc);
+        cmd
+    } else {
+        std::process::Command::new(rustc)
+    };
+
+    cmd.arg("--crate-type=rlib") // Don't require `main`.
+        .arg("--emit=metadata") // Do as little as possible but still parse.
+        .arg("--target")
+        .arg(target)
+        .arg("--out-dir")
+        .arg(out_dir); // Put the output somewhere inconsequential.
+
+    // If Cargo wants to set RUSTFLAGS, use that.
+    if let Ok(rustflags) = var("CARGO_ENCODED_RUSTFLAGS") {
+        if !rustflags.is_empty() {
+            for arg in rustflags.split('\x1f') {
+                cmd.arg(arg);
+            }
+        }
+    }
+
+    let mut child = cmd
+        .arg("-") // Read from stdin.
+        .stdin(Stdio::piped()) // Stdin is a pipe.
+        .stderr(Stdio::null()) // Errors from feature detection aren't interesting and can be confusing.
+        .spawn()
+        .unwrap();
+
+    writeln!(child.stdin.take().unwrap(), "{}", test.as_ref()).unwrap();
+
+    child.wait().unwrap().success()
+}

--- a/cap-async-std/src/fs/file.rs
+++ b/cap-async-std/src/fs/file.rs
@@ -90,8 +90,7 @@ impl File {
     #[inline]
     pub async fn metadata(&self) -> io::Result<Metadata> {
         let clone = self.clone();
-        let sync = clone.std.as_filelike_view::<std::fs::File>();
-        spawn_blocking(move || metadata_from(&*sync)).await
+        spawn_blocking(move || metadata_from(&*clone.std.as_filelike_view::<std::fs::File>())).await
     }
 
     // async_std doesn't have `try_clone`.

--- a/cap-async-std/src/fs/mod.rs
+++ b/cap-async-std/src/fs/mod.rs
@@ -40,9 +40,9 @@ pub use cap_primitives::fs::{DirBuilder, FileType, Metadata, OpenOptions, Permis
 // Re-export conditional types from `cap_primitives`.
 #[cfg(any(unix, target_os = "vxworks", all(windows, windows_file_type_ext)))]
 pub use cap_primitives::fs::FileTypeExt;
-pub use cap_primitives::fs::{FileExt, OpenOptionsExt, MetadataExt};
 #[cfg(unix)]
 pub use cap_primitives::fs::{DirBuilderExt, PermissionsExt};
+pub use cap_primitives::fs::{FileExt, MetadataExt, OpenOptionsExt};
 
 // Re-export things from `async_std` that we can use as-is.
 #[cfg(target_os = "wasi")]

--- a/cap-async-std/src/fs_utf8/mod.rs
+++ b/cap-async-std/src/fs_utf8/mod.rs
@@ -25,9 +25,9 @@ pub use crate::fs::{DirBuilder, FileType, Metadata, OpenOptions, Permissions};
 // Re-export conditional types from `cap_primitives`.
 #[cfg(any(unix, target_os = "vxworks", all(windows, windows_file_type_ext)))]
 pub use cap_primitives::fs::FileTypeExt;
-pub use cap_primitives::fs::{FileExt, OpenOptionsExt, MetadataExt};
 #[cfg(unix)]
 pub use cap_primitives::fs::{DirBuilderExt, PermissionsExt};
+pub use cap_primitives::fs::{FileExt, MetadataExt, OpenOptionsExt};
 
 // Re-export `camino` to make it easy for users to depend on the same
 // version we do, because we use its types in our public API.
@@ -37,7 +37,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 
 #[cfg(not(feature = "arf_strings"))]
 fn from_utf8<'a>(path: &'a Utf8Path) -> std::io::Result<&'a async_std::path::Path> {
-    Ok(path.as_std_path())
+    Ok(path.as_std_path().into())
 }
 
 #[cfg(feature = "arf_strings")]

--- a/cap-async-std/src/lib.rs
+++ b/cap-async-std/src/lib.rs
@@ -49,5 +49,5 @@ pub use cap_primitives::{ambient_authority, AmbientAuthority};
 // version we do, because we use its types in our public API.
 pub use async_std;
 // And these are also part of our public API
-pub use io_lifetimes;
 pub use cap_primitives::ipnet;
+pub use io_lifetimes;

--- a/cap-async-std/src/net/pool.rs
+++ b/cap-async-std/src/net/pool.rs
@@ -36,12 +36,15 @@ impl Pool {
     /// # Ambient Authority
     ///
     /// This function allows ambient access to any IP address.
-    pub fn insert<A: ToSocketAddrs>(
+    pub async fn insert<A: ToSocketAddrs>(
         &mut self,
         addrs: A,
         ambient_authority: AmbientAuthority,
     ) -> io::Result<()> {
-        self.cap.insert(addrs, ambient_authority)
+        for addr in addrs.to_socket_addrs().await? {
+            self.cap.insert(addr, ambient_authority)?;
+        }
+        Ok(())
     }
 
     /// Add a specific [`net::SocketAddr`] to the pool.
@@ -65,11 +68,16 @@ impl Pool {
     /// # Ambient Authority
     ///
     /// This function allows ambient access to any IP address.
-    pub fn insert_ip_net_port_any(&mut self, ip_net: ipnet::IpNet, ambient_authority: AmbientAuthority) {
+    pub fn insert_ip_net_port_any(
+        &mut self,
+        ip_net: ipnet::IpNet,
+        ambient_authority: AmbientAuthority,
+    ) {
         self.cap.insert_ip_net_port_any(ip_net, ambient_authority)
     }
 
-    /// Add a range of network addresses, accepting a range of ports, to the pool.
+    /// Add a range of network addresses, accepting a range of ports, to the
+    /// pool.
     ///
     /// This grants access to the port range starting at `ports_start` and,
     /// if `ports_end` is provided, ending before `ports_end`.
@@ -84,7 +92,8 @@ impl Pool {
         ports_end: Option<u16>,
         ambient_authority: AmbientAuthority,
     ) {
-        self.cap.insert_ip_net_port_range(ip_net, ports_start, ports_end, ambient_authority)
+        self.cap
+            .insert_ip_net_port_range(ip_net, ports_start, ports_end, ambient_authority)
     }
 
     /// Add a range of network addresses with a specific port to the pool.

--- a/cap-async-std/src/net/udp_socket.rs
+++ b/cap-async-std/src/net/udp_socket.rs
@@ -337,7 +337,7 @@ impl IntoRawSocket for UdpSocket {
 impl From<UdpSocket> for OwnedSocket {
     #[inline]
     fn from(socket: UdpSocket) -> OwnedSocket {
-        self.std.into()
+        socket.std.into()
     }
 }
 

--- a/cap-fs-ext/Cargo.toml
+++ b/cap-fs-ext/Cargo.toml
@@ -14,13 +14,12 @@ edition = "2021"
 
 [dependencies]
 arf-strings = { version = "0.7.0", optional = true }
-#cap-async-std = { path = "../cap-async-std", optional = true, version = "^0.25.0" }
-cap-std = { path = "../cap-std", optional = true, version = "^3.3.0" }
-cap-primitives = { path = "../cap-primitives", version = "^3.3.0" }
+cap-async-std = { path = "../cap-async-std", optional = true, version = "3.3.0" }
+cap-std = { path = "../cap-std", optional = true, version = "3.3.0" }
+cap-primitives = { path = "../cap-primitives", version = "3.3.0" }
 io-lifetimes = { version = "2.0.0", default-features = false }
-# Enable "unstable" for `spawn_blocking`.
-#async-std = { version = "1.10.0", features = ["attributes", "unstable"], optional = true }
-#async-trait = { version = "0.1.42", optional = true }
+async-std = { version = "1.13.0", features = ["io_safety", "attributes"], optional = true }
+async-trait = { version = "0.1.42", optional = true }
 camino = { version = "1.0.5", optional = true }
 
 [features]
@@ -28,10 +27,9 @@ default = ["std"]
 fs_utf8 = ["cap-std/fs_utf8", "camino"]
 arf_strings = ["cap-std/arf_strings", "fs_utf8", "arf-strings"]
 std = ["cap-std"]
-# Temporarily disable cap-async-std.
-#async_std = ["cap-async-std", "async-std", "io-lifetimes/async-std", "async-trait"]
-#async_std_fs_utf8 = ["cap-async-std/fs_utf8", "camino"]
-#async_std_arf_strings = ["cap-async-std/arf_strings", "async_std_fs_utf8", "arf-strings"]
+async_std = ["cap-async-std", "async-std", "io-lifetimes/async-std", "async-trait"]
+async_std_fs_utf8 = ["cap-async-std/fs_utf8", "camino"]
+async_std_arf_strings = ["cap-async-std/arf_strings", "async_std_fs_utf8", "arf-strings"]
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.52.0"

--- a/cap-fs-ext/src/lib.rs
+++ b/cap-fs-ext/src/lib.rs
@@ -9,9 +9,6 @@
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/bytecodealliance/cap-std/main/media/cap-std.ico"
 )]
-// Allow cfg(feature = "async_std") even though it isn't a feature. async_std
-// support is temporarily disabled.
-#![allow(unexpected_cfgs)]
 
 mod dir_entry_ext;
 mod dir_ext;
@@ -24,6 +21,10 @@ mod open_options_sync_ext;
 mod reopen;
 
 pub use dir_entry_ext::DirEntryExt;
+#[cfg(feature = "async_std")]
+pub use dir_ext::AsyncDirExt;
+#[cfg(all(feature = "async_std", feature = "fs_utf8"))]
+pub use dir_ext::AsyncDirExtUtf8;
 #[cfg(all(any(feature = "std", feature = "async_std"), feature = "fs_utf8"))]
 pub use dir_ext::DirExtUtf8;
 pub use dir_ext::{AccessType, DirExt, SystemTimeSpec};

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -18,7 +18,7 @@ arbitrary = { version = "1.0.0", optional = true, features = ["derive"] }
 ipnet = "2.5.0"
 maybe-owned = "0.3.4"
 fs-set-times = "0.20.0"
-io-extras = "0.18.0"
+io-extras = "0.18.3"
 io-lifetimes = { version = "2.0.0", default-features = false }
 
 [dev-dependencies]

--- a/cap-std/Cargo.toml
+++ b/cap-std/Cargo.toml
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg=docsrs"]
 [dependencies]
 arf-strings = { version = "0.7.0", optional = true }
 cap-primitives = { path = "../cap-primitives", version = "^3.3.0" }
-io-extras = "0.18.0"
+io-extras = "0.18.3"
 io-lifetimes = { version = "2.0.0", default-features = false }
 camino = { version = "1.0.5", optional = true }
 

--- a/examples/async_std_fs_misc.rs
+++ b/examples/async_std_fs_misc.rs
@@ -1,7 +1,6 @@
 // Copied from https://doc.rust-lang.org/rust-by-example/std_misc/fs.html and
 // adapted to use this crate instead.
 
-/*
 use async_std::io;
 use async_std::io::prelude::*;
 use cap_async_std::ambient_authority;
@@ -111,8 +110,4 @@ async fn main() {
     cwd.remove_dir("a/c/d").await.unwrap_or_else(|why| {
         println!("! {:?}", why.kind());
     });
-}
-*/
-fn main() {
-    eprintln!("async-std doesn't have io_safety traits implemented yet");
 }


### PR DESCRIPTION
async-std 1.13.0 is now released with the "io_safety" feature, which means we can now reenable cap-async-std.