### PR TITLE
Backport build.rs fixes to 1.x.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,11 +2,10 @@
 # at revision 7f4774e76bd5cb9ccb7140d71ef9be9c16009cdf.
 
 task:
-  name: stable x86_64-unknown-freebsd-13
+  name: stable x86_64-unknown-freebsd-15-snap
   freebsd_instance:
-    image_family: freebsd-13-0-snap
+    image_family: freebsd-15-0-snap
   setup_script:
-    - pkg install -y curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh --default-toolchain stable -y --profile=minimal
     - . $HOME/.cargo/env
@@ -16,11 +15,23 @@ task:
     - cargo test --features=fs_utf8 --workspace
 
 task:
-  name: stable x86_64-unknown-freebsd-12
+  name: stable x86_64-unknown-freebsd-14
   freebsd_instance:
-    image_family: freebsd-12-1
+    image_family: freebsd-14-0
   setup_script:
-    - pkg install -y curl
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh --default-toolchain stable -y --profile=minimal
+    - . $HOME/.cargo/env
+    - rustup default stable
+  test_script:
+    - . $HOME/.cargo/env
+    - cargo test --features=fs_utf8 --workspace
+
+task:
+  name: stable x86_64-unknown-freebsd-13
+  freebsd_instance:
+    image_family: freebsd-13-3
+  setup_script:
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh --default-toolchain stable -y --profile=minimal
     - . $HOME/.cargo/env

--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -8,5 +8,5 @@ inputs:
     default: 'stable'
 
 runs:
-  using: node16
+  using: node20
   main: 'main.js'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -34,7 +34,7 @@ jobs:
             rust: beta
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -88,7 +88,7 @@ jobs:
             rust: beta
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -116,7 +116,7 @@ jobs:
             rust: nightly
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -150,7 +150,7 @@ jobs:
         riscv64gc-unknown-linux-gnu
         arm-unknown-linux-gnueabihf
         aarch64-linux-android
-        wasm32-wasi
+        wasm32-wasip1
     - run: cargo check --workspace --all-targets --all-features --release -vv
     - run: cargo check --workspace --all-targets --all-features --release -vv --target=x86_64-unknown-linux-musl
     - run: cargo check --workspace --all-targets --all-features --release -vv --target=x86_64-unknown-linux-gnux32
@@ -164,7 +164,7 @@ jobs:
     - run: cargo check --workspace --all-targets --all-features --release -vv --target=riscv64gc-unknown-linux-gnu
     - run: cargo check --workspace --all-targets --all-features --release -vv --target=arm-unknown-linux-gnueabihf
     - run: cargo check --workspace --all-targets --all-features --release -vv --target=aarch64-linux-android
-    - run: cd cap-std && cargo check --features=fs_utf8 --release -vv --target=wasm32-wasi
+    - run: cd cap-std && cargo check --features=fs_utf8 --release -vv --target=wasm32-wasip1
 
   check_cross_nightly_windows:
     name: Check Cross-Compilation on Rust nightly on Windows
@@ -178,7 +178,7 @@ jobs:
             rust: nightly
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -201,7 +201,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, windows-latest, windows-2019, macos-latest, macos-10.15, beta, ubuntu-20.04, aarch64-ubuntu]
+        build: [stable, windows-latest, windows-2019, macos-latest, macos-12, beta, ubuntu-20.04, aarch64-ubuntu]
         include:
           - build: stable
             os: ubuntu-latest
@@ -215,8 +215,8 @@ jobs:
           - build: macos-latest
             os: macos-latest
             rust: stable
-          - build: macos-10.15
-            os: macos-10.15
+          - build: macos-12
+            os: macos-12
             rust: stable
           - build: beta
             os: ubuntu-latest
@@ -234,7 +234,7 @@ jobs:
             qemu_target: aarch64-linux-user
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -291,7 +291,7 @@ jobs:
             rust: nightly
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -311,7 +311,7 @@ jobs:
             rust: stable
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -345,7 +345,7 @@ jobs:
       RUSTFLAGS: --cfg linux_raw
       RUSTDOCFLAGS: --cfg linux_raw
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -365,7 +365,7 @@ jobs:
             rust: 1.58
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -381,7 +381,7 @@ jobs:
     name: Fuzz Targets
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust

--- a/build.rs
+++ b/build.rs
@@ -19,6 +19,9 @@ fn main() {
                                                   // https://doc.rust-lang.org/unstable-book/library-features/windows-file-type-ext.html
     use_feature_or_nothing("windows_file_type_ext");
 
+    // Cfgs that users may set.
+    println!("cargo:rustc-check-cfg=cfg(racy_asserts)");
+
     // Don't rerun this on changes other than build.rs, as we only depend on
     // the rustc version.
     println!("cargo:rerun-if-changed=build.rs");
@@ -28,6 +31,7 @@ fn use_feature_or_nothing(feature: &str) {
     if has_feature(feature) {
         use_feature(feature);
     }
+    println!("cargo:rustc-check-cfg=cfg({})", feature);
 }
 
 fn use_feature(feature: &str) {
@@ -36,7 +40,7 @@ fn use_feature(feature: &str) {
 
 /// Test whether the rustc at `var("RUSTC")` supports the given feature.
 fn has_feature(feature: &str) -> bool {
-    can_compile(&format!(
+    can_compile(format!(
         "#![allow(stable_features)]\n#![feature({})]",
         feature
     ))
@@ -46,12 +50,11 @@ fn has_feature(feature: &str) -> bool {
 fn can_compile<T: AsRef<str>>(test: T) -> bool {
     use std::process::Stdio;
 
-    let out_dir = var("OUT_DIR").unwrap();
     let rustc = var("RUSTC").unwrap();
     let target = var("TARGET").unwrap();
 
-    // Use `RUSTC_WRAPPER` if it's set, unless it's set to an empty string,
-    // as documented [here].
+    // Use `RUSTC_WRAPPER` if it's set, unless it's set to an empty string, as
+    // documented [here].
     // [here]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-reads
     let wrapper = var("RUSTC_WRAPPER")
         .ok()
@@ -70,8 +73,9 @@ fn can_compile<T: AsRef<str>>(test: T) -> bool {
         .arg("--emit=metadata") // Do as little as possible but still parse.
         .arg("--target")
         .arg(target)
-        .arg("--out-dir")
-        .arg(out_dir); // Put the output somewhere inconsequential.
+        .arg("-o")
+        .arg("-")
+        .stdout(Stdio::null()); // We don't care about the output (only whether it builds or not)
 
     // If Cargo wants to set RUSTFLAGS, use that.
     if let Ok(rustflags) = var("CARGO_ENCODED_RUSTFLAGS") {

--- a/cap-fs-ext/Cargo.toml
+++ b/cap-fs-ext/Cargo.toml
@@ -40,3 +40,9 @@ features = [
 
 [dev-dependencies]
 cap-tempfile = { path = "../cap-tempfile" }
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(feature, values("async_std"))'
+]

--- a/cap-fs-ext/build.rs
+++ b/cap-fs-ext/build.rs
@@ -13,6 +13,7 @@ fn use_feature_or_nothing(feature: &str) {
     if has_feature(feature) {
         use_feature(feature);
     }
+    println!("cargo:rustc-check-cfg=cfg({})", feature);
 }
 
 fn use_feature(feature: &str) {
@@ -21,20 +22,60 @@ fn use_feature(feature: &str) {
 
 /// Test whether the rustc at `var("RUSTC")` supports the given feature.
 fn has_feature(feature: &str) -> bool {
-    let out_dir = var("OUT_DIR").unwrap();
-    let rustc = var("RUSTC").unwrap();
+    can_compile(&format!(
+        "#![allow(stable_features)]\n#![feature({})]",
+        feature
+    ))
+}
 
-    let mut child = std::process::Command::new(rustc)
-        .arg("--crate-type=rlib") // Don't require `main`.
+/// Test whether the rustc at `var("RUSTC")` can compile the given code.
+fn can_compile<T: AsRef<str>>(test: T) -> bool {
+    use std::process::Stdio;
+
+    let rustc = var("RUSTC").unwrap();
+    let target = var("TARGET").unwrap();
+
+    // Use `RUSTC_WRAPPER` if it's set, unless it's set to an empty string,
+    // as documented [here].
+    // [here]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-reads
+    let wrapper = var("RUSTC_WRAPPER")
+        .ok()
+        .and_then(|w| if w.is_empty() { None } else { Some(w) });
+
+    let mut cmd = if let Some(wrapper) = wrapper {
+        let mut cmd = std::process::Command::new(wrapper);
+        // The wrapper's first argument is supposed to be the path to rustc.
+        cmd.arg(rustc);
+        cmd
+    } else {
+        std::process::Command::new(rustc)
+    };
+
+    cmd.arg("--crate-type=rlib") // Don't require `main`.
         .arg("--emit=metadata") // Do as little as possible but still parse.
-        .arg("--out-dir")
-        .arg(out_dir) // Put the output somewhere inconsequential.
+        .arg("--target")
+        .arg(target)
+        .arg("-o")
+        .arg("-")
+        .stdout(Stdio::null()); // We don't care about the output (only whether it builds or not)
+
+    // If Cargo wants to set RUSTFLAGS, use that.
+    if let Ok(rustflags) = var("CARGO_ENCODED_RUSTFLAGS") {
+        if !rustflags.is_empty() {
+            for arg in rustflags.split('\x1f') {
+                cmd.arg(arg);
+            }
+        }
+    }
+
+    let mut child = cmd
         .arg("-") // Read from stdin.
-        .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
+        .stdin(Stdio::piped()) // Stdin is a pipe.
+        .stderr(Stdio::null()) // Errors from feature detection aren't interesting and can be confusing.
         .spawn()
         .unwrap();
 
-    writeln!(child.stdin.take().unwrap(), "#![feature({})]", feature).unwrap();
+    writeln!(child.stdin.take().unwrap(), "{}", test.as_ref()).unwrap();
 
     child.wait().unwrap().success()
 }

--- a/cap-primitives/build.rs
+++ b/cap-primitives/build.rs
@@ -5,8 +5,14 @@ fn main() {
     use_feature_or_nothing("windows_by_handle"); // https://github.com/rust-lang/rust/issues/63010
                                                  // https://doc.rust-lang.org/unstable-book/library-features/windows-file-type-ext.html
     use_feature_or_nothing("windows_file_type_ext");
+    use_feature_or_nothing("windows_change_time");
     use_feature_or_nothing("io_error_more"); // https://github.com/rust-lang/rust/issues/86442
     use_feature_or_nothing("io_error_uncategorized");
+
+    // Cfgs that users may set.
+    println!("cargo:rustc-check-cfg=cfg(racy_asserts)");
+    println!("cargo:rustc-check-cfg=cfg(emulate_second_only_system)");
+    println!("cargo:rustc-check-cfg=cfg(io_lifetimes_use_std)");
 
     // Don't rerun this on changes other than build.rs, as we only depend on
     // the rustc version.
@@ -17,6 +23,7 @@ fn use_feature_or_nothing(feature: &str) {
     if has_feature(feature) {
         use_feature(feature);
     }
+    println!("cargo:rustc-check-cfg=cfg({})", feature);
 }
 
 fn use_feature(feature: &str) {
@@ -25,20 +32,60 @@ fn use_feature(feature: &str) {
 
 /// Test whether the rustc at `var("RUSTC")` supports the given feature.
 fn has_feature(feature: &str) -> bool {
-    let out_dir = var("OUT_DIR").unwrap();
-    let rustc = var("RUSTC").unwrap();
+    can_compile(&format!(
+        "#![allow(stable_features)]\n#![feature({})]",
+        feature
+    ))
+}
 
-    let mut child = std::process::Command::new(rustc)
-        .arg("--crate-type=rlib") // Don't require `main`.
+/// Test whether the rustc at `var("RUSTC")` can compile the given code.
+fn can_compile<T: AsRef<str>>(test: T) -> bool {
+    use std::process::Stdio;
+
+    let rustc = var("RUSTC").unwrap();
+    let target = var("TARGET").unwrap();
+
+    // Use `RUSTC_WRAPPER` if it's set, unless it's set to an empty string,
+    // as documented [here].
+    // [here]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-reads
+    let wrapper = var("RUSTC_WRAPPER")
+        .ok()
+        .and_then(|w| if w.is_empty() { None } else { Some(w) });
+
+    let mut cmd = if let Some(wrapper) = wrapper {
+        let mut cmd = std::process::Command::new(wrapper);
+        // The wrapper's first argument is supposed to be the path to rustc.
+        cmd.arg(rustc);
+        cmd
+    } else {
+        std::process::Command::new(rustc)
+    };
+
+    cmd.arg("--crate-type=rlib") // Don't require `main`.
         .arg("--emit=metadata") // Do as little as possible but still parse.
-        .arg("--out-dir")
-        .arg(out_dir) // Put the output somewhere inconsequential.
+        .arg("--target")
+        .arg(target)
+        .arg("-o")
+        .arg("-")
+        .stdout(Stdio::null()); // We don't care about the output (only whether it builds or not)
+
+    // If Cargo wants to set RUSTFLAGS, use that.
+    if let Ok(rustflags) = var("CARGO_ENCODED_RUSTFLAGS") {
+        if !rustflags.is_empty() {
+            for arg in rustflags.split('\x1f') {
+                cmd.arg(arg);
+            }
+        }
+    }
+
+    let mut child = cmd
         .arg("-") // Read from stdin.
-        .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
+        .stdin(Stdio::piped()) // Stdin is a pipe.
+        .stderr(Stdio::null()) // Errors from feature detection aren't interesting and can be confusing.
         .spawn()
         .unwrap();
 
-    writeln!(child.stdin.take().unwrap(), "#![feature({})]", feature).unwrap();
+    writeln!(child.stdin.take().unwrap(), "{}", test.as_ref()).unwrap();
 
     child.wait().unwrap().success()
 }

--- a/cap-primitives/src/fs/metadata.rs
+++ b/cap-primitives/src/fs/metadata.rs
@@ -443,6 +443,11 @@ impl std::os::windows::fs::MetadataExt for Metadata {
     fn file_index(&self) -> Option<u64> {
         self.ext.file_index()
     }
+
+    #[inline]
+    fn change_time(&self) -> Option<u64> {
+        self.ext.change_time()
+    }
 }
 
 /// Extension trait to allow `volume_serial_number` etc. to be exposed by

--- a/cap-primitives/src/lib.rs
+++ b/cap-primitives/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(stable_features)]
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(all(windows, windows_by_handle), feature(windows_by_handle))]
+#![cfg_attr(all(windows, windows_change_time), feature(windows_change_time))]
 #![cfg_attr(all(windows, windows_file_type_ext), feature(windows_file_type_ext))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/bytecodealliance/cap-std/main/media/cap-std.svg"

--- a/cap-primitives/src/windows/fs/metadata_ext.rs
+++ b/cap-primitives/src/windows/fs/metadata_ext.rs
@@ -18,6 +18,8 @@ pub(crate) struct MetadataExt {
     volume_serial_number: Option<u32>,
     number_of_links: Option<u32>,
     file_index: Option<u64>,
+    #[cfg(windows_change_time)]
+    change_time: Option<u64>,
 }
 
 impl MetadataExt {
@@ -26,7 +28,8 @@ impl MetadataExt {
     #[inline]
     #[allow(unused_variables)]
     pub(crate) fn from(file: &fs::File, std: &fs::Metadata) -> io::Result<Self> {
-        let (mut volume_serial_number, mut number_of_links, mut file_index) = (None, None, None);
+        let (mut volume_serial_number, mut number_of_links, mut file_index, mut change_time) =
+            (None, None, None, None);
 
         #[cfg(windows_by_handle)]
         {
@@ -40,10 +43,17 @@ impl MetadataExt {
             if let Some(some) = std.file_index() {
                 file_index = Some(some);
             }
+            if let Some(some) = std.change_time() {
+                change_time = Some(some);
+            }
         }
 
         #[cfg(not(windows_by_handle))]
-        if volume_serial_number.is_none() || number_of_links.is_none() || file_index.is_none() {
+        if volume_serial_number.is_none()
+            || number_of_links.is_none()
+            || file_index.is_none()
+            || change_time.is_none()
+        {
             let fileinfo = winx::winapi_util::file::information(file)?;
             if volume_serial_number.is_none() {
                 let t64: u64 = fileinfo.volume_serial_number();
@@ -58,6 +68,7 @@ impl MetadataExt {
             if file_index.is_none() {
                 file_index = Some(fileinfo.file_index());
             }
+            change_time = None;
         }
 
         Ok(Self::from_parts(
@@ -65,6 +76,7 @@ impl MetadataExt {
             volume_serial_number,
             number_of_links,
             file_index,
+            change_time,
         ))
     }
 
@@ -78,7 +90,8 @@ impl MetadataExt {
     #[inline]
     #[allow(unused_mut)]
     pub(crate) fn from_just_metadata(std: &fs::Metadata) -> Self {
-        let (mut volume_serial_number, mut number_of_links, mut file_index) = (None, None, None);
+        let (mut volume_serial_number, mut number_of_links, mut file_index, mut change_time) =
+            (None, None, None, None);
 
         #[cfg(windows_by_handle)]
         {
@@ -92,9 +105,18 @@ impl MetadataExt {
             if let Some(some) = std.file_index() {
                 file_index = Some(some);
             }
+            if let Some(some) = std.change_time() {
+                change_time = Some(some);
+            }
         }
 
-        Self::from_parts(std, volume_serial_number, number_of_links, file_index)
+        Self::from_parts(
+            std,
+            volume_serial_number,
+            number_of_links,
+            file_index,
+            change_time,
+        )
     }
 
     #[inline]
@@ -103,8 +125,13 @@ impl MetadataExt {
         volume_serial_number: Option<u32>,
         number_of_links: Option<u32>,
         file_index: Option<u64>,
+        change_time: Option<u64>,
     ) -> Self {
         use std::os::windows::fs::MetadataExt;
+
+        #[cfg(not(windows_change_time))]
+        let _ = change_time;
+
         Self {
             file_attributes: std.file_attributes(),
             #[cfg(windows_by_handle)]
@@ -118,6 +145,8 @@ impl MetadataExt {
             volume_serial_number,
             number_of_links,
             file_index,
+            #[cfg(windows_change_time)]
+            change_time,
         }
     }
 
@@ -189,6 +218,11 @@ impl std::os::windows::fs::MetadataExt for MetadataExt {
     #[inline]
     fn file_index(&self) -> Option<u64> {
         self.file_index
+    }
+
+    #[inline]
+    fn change_time(&self) -> Option<u64> {
+        self.change_time
     }
 }
 

--- a/cap-std/Cargo.toml
+++ b/cap-std/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg=doc_cfg"]
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 arf-strings = { version = "0.7.0", optional = true }

--- a/cap-std/build.rs
+++ b/cap-std/build.rs
@@ -6,6 +6,10 @@ fn main() {
     use_feature_or_nothing("seek_convenience"); // https://github.com/rust-lang/rust/issues/59359
     use_feature_or_nothing("with_options"); // https://github.com/rust-lang/rust/issues/65439
     use_feature_or_nothing("write_all_vectored"); // https://github.com/rust-lang/rust/issues/70436
+    use_feature_or_nothing("windows_file_type_ext");
+
+    // Cfgs that users may set.
+    println!("cargo:rustc-check-cfg=cfg(io_lifetimes_use_std)");
 
     // Don't rerun this on changes other than build.rs, as we only depend on
     // the rustc version.
@@ -16,6 +20,7 @@ fn use_feature_or_nothing(feature: &str) {
     if has_feature(feature) {
         use_feature(feature);
     }
+    println!("cargo:rustc-check-cfg=cfg({})", feature);
 }
 
 fn use_feature(feature: &str) {
@@ -24,20 +29,60 @@ fn use_feature(feature: &str) {
 
 /// Test whether the rustc at `var("RUSTC")` supports the given feature.
 fn has_feature(feature: &str) -> bool {
-    let out_dir = var("OUT_DIR").unwrap();
-    let rustc = var("RUSTC").unwrap();
+    can_compile(&format!(
+        "#![allow(stable_features)]\n#![feature({})]",
+        feature
+    ))
+}
 
-    let mut child = std::process::Command::new(rustc)
-        .arg("--crate-type=rlib") // Don't require `main`.
+/// Test whether the rustc at `var("RUSTC")` can compile the given code.
+fn can_compile<T: AsRef<str>>(test: T) -> bool {
+    use std::process::Stdio;
+
+    let rustc = var("RUSTC").unwrap();
+    let target = var("TARGET").unwrap();
+
+    // Use `RUSTC_WRAPPER` if it's set, unless it's set to an empty string,
+    // as documented [here].
+    // [here]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-reads
+    let wrapper = var("RUSTC_WRAPPER")
+        .ok()
+        .and_then(|w| if w.is_empty() { None } else { Some(w) });
+
+    let mut cmd = if let Some(wrapper) = wrapper {
+        let mut cmd = std::process::Command::new(wrapper);
+        // The wrapper's first argument is supposed to be the path to rustc.
+        cmd.arg(rustc);
+        cmd
+    } else {
+        std::process::Command::new(rustc)
+    };
+
+    cmd.arg("--crate-type=rlib") // Don't require `main`.
         .arg("--emit=metadata") // Do as little as possible but still parse.
-        .arg("--out-dir")
-        .arg(out_dir) // Put the output somewhere inconsequential.
+        .arg("--target")
+        .arg(target)
+        .arg("-o")
+        .arg("-")
+        .stdout(Stdio::null()); // We don't care about the output (only whether it builds or not)
+
+    // If Cargo wants to set RUSTFLAGS, use that.
+    if let Ok(rustflags) = var("CARGO_ENCODED_RUSTFLAGS") {
+        if !rustflags.is_empty() {
+            for arg in rustflags.split('\x1f') {
+                cmd.arg(arg);
+            }
+        }
+    }
+
+    let mut child = cmd
         .arg("-") // Read from stdin.
-        .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
+        .stdin(Stdio::piped()) // Stdin is a pipe.
+        .stderr(Stdio::null()) // Errors from feature detection aren't interesting and can be confusing.
         .spawn()
         .unwrap();
 
-    writeln!(child.stdin.take().unwrap(), "#![feature({})]", feature).unwrap();
+    writeln!(child.stdin.take().unwrap(), "{}", test.as_ref()).unwrap();
 
     child.wait().unwrap().success()
 }

--- a/cap-std/src/lib.rs
+++ b/cap-std/src/lib.rs
@@ -23,7 +23,7 @@
 //! [`Pool`]: net::Pool
 
 #![deny(missing_docs)]
-#![cfg_attr(doc_cfg, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(can_vector, feature(can_vector))]
 #![cfg_attr(seek_convenience, feature(seek_convenience))]

--- a/tests/cap-basics.rs
+++ b/tests/cap-basics.rs
@@ -217,10 +217,11 @@ fn symlink_loop_from_rename() {
     check!(tmpdir.open("link"));
 }
 
-#[cfg(linux)]
+#[cfg(target_os = "linux")]
 #[test]
 fn proc_self_fd() {
-    let fd = check!(File::open("/proc/self/fd"));
+    let fd = check!(std::fs::File::open("/proc/self/fd"));
     let dir = cap_std::fs::Dir::from_std_file(fd);
-    error!(dir.open("0"), "No such file");
+    // This should fail with "too many levels of symbolic links".
+    dir.open("0").unwrap_err();
 }


### PR DESCRIPTION
* Backport build.rs fixes to 1.x.

* Fix warnings on recent Rust compilers.

* Fix the build of timezone.rs on recent Rust versions.

* Use docsrs instead of doc_cfg.

* Update CI for 1.x.

* Implement `change_time` for windows' `MetadataExt`.