### PR TITLE
Use RESOLVE_NO_SYMLINKS on Linux when following symlinks is disabled

### DIFF
--- a/tests/symlinks.rs
+++ b/tests/symlinks.rs
@@ -258,19 +258,19 @@ fn open_dir_nofollow() {
             let name = format!("{}{}", symlink_dir, suffix);
             check!(tmpdir.open_dir(&name));
             // On Windows, a trailing dot is stripped early.
-            if cfg!(not(windows)) || suffix != &"/." {
-                check!(tmpdir.open_dir_nofollow(&name));
-            } else {
+            if cfg!(windows) || suffix == &"/." || cfg!(target_os = "linux") {
                 assert!(tmpdir.open_dir_nofollow(&name).is_err());
+            } else {
+                check!(tmpdir.open_dir_nofollow(&name));
             }
             for dir_name in &["dir", "symlink_dir"] {
                 let name = format!("{}/../{}", dir_name, name);
                 check!(tmpdir.open_dir(&name));
                 // On Windows, a trailing dot is stripped early.
-                if cfg!(not(windows)) || suffix != &"/." {
-                    check!(tmpdir.open_dir_nofollow(&name));
-                } else {
+                if cfg!(windows) || suffix == &"/." || cfg!(target_os = "linux") {
                     assert!(tmpdir.open_dir_nofollow(&name).is_err());
+                } else {
+                    check!(tmpdir.open_dir_nofollow(&name));
                 }
             }
         }
@@ -296,7 +296,11 @@ fn open_dir_nofollow() {
             #[cfg(not(windows))]
             {
                 check!(tmpdir.open_dir(&name));
-                check!(tmpdir.open_dir_nofollow(&name));
+                if cfg!(target_os = "linux") {
+                    assert!(tmpdir.open_dir_nofollow(&name).is_err());
+                } else {
+                    check!(tmpdir.open_dir_nofollow(&name));
+                }
             }
             for dir_name in &["dir", "symlink_dir"] {
                 let name = format!("{}/../{}", dir_name, name);
@@ -308,7 +312,11 @@ fn open_dir_nofollow() {
                 #[cfg(not(windows))]
                 {
                     check!(tmpdir.open_dir(&name));
-                    check!(tmpdir.open_dir_nofollow(&name));
+                    if cfg!(target_os = "linux") {
+                        assert!(tmpdir.open_dir_nofollow(&name).is_err());
+                    } else {
+                        check!(tmpdir.open_dir_nofollow(&name));
+                    }
                 }
             }
         }


### PR DESCRIPTION
This addresses a bug where a forward slash is the last element of a symlink directory path and `open_dir_nofollow` is used.

If a symlink is created to a directory without specifying an absolute path, then the path behind the symlink does not error when opened with `open_dir_nofollow`.

Take these two symlinks:

```
> ls -l /home/ylk/test-dir-symlink*
lrwxrwxrwx 1 ylk ylk 24 Feb 19 21:15 /home/ylk/test-dir-symlink ->
/local/home/ylk/test-dir/
lrwxrwxrwx 1 ylk ylk 8 Feb 19 21:27 /home/ylk/test-dir-symlink2 ->
test-dir/
```

Without this patch, the following behavior is observed when using open_dir_nofollow:

test-dir-symlink/ -> error
test-dir-symlink -> error
test-dir-symlink2 -> error
test-dir-symlink2/ -> **no error**