### PR TITLE
Remove the `tell` function from `FileExt` on WASI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -371,6 +371,10 @@ jobs:
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
+
+    - name: Use specific dependency versions for Rust 1.63 compatibility.
+      run: cargo update --package=once_cell --precise=1.20.3
+
     # Don't use --all-features because some of the features have dependencies
     # that don't work on newer Rust versions.
     - run: cargo test --workspace --features=fs_utf8,arf_strings

--- a/cap-primitives/src/fs/file.rs
+++ b/cap-primitives/src/fs/file.rs
@@ -157,9 +157,6 @@ pub trait FileExt {
         Ok(())
     }
 
-    /// Returns the current position within the file.
-    fn tell(&self) -> io::Result<u64>;
-
     /// Adjust the flags associated with this file.
     fn fdstat_set_flags(&self, flags: u16) -> io::Result<()>;
 

--- a/cap-std/src/fs/file.rs
+++ b/cap-std/src/fs/file.rs
@@ -524,11 +524,6 @@ impl crate::fs::FileExt for File {
     }
 
     #[inline]
-    fn tell(&self) -> std::result::Result<u64, io::Error> {
-        std::os::wasi::fs::FileExt::tell(&self.std)
-    }
-
-    #[inline]
     fn fdstat_set_flags(&self, flags: u16) -> std::result::Result<(), io::Error> {
         std::os::wasi::fs::FileExt::fdstat_set_flags(&self.std, flags)
     }

--- a/cap-std/src/fs_utf8/file.rs
+++ b/cap-std/src/fs_utf8/file.rs
@@ -522,11 +522,6 @@ impl crate::fs::FileExt for File {
     }
 
     #[inline]
-    fn tell(&self) -> std::result::Result<u64, io::Error> {
-        self.cap_std.tell()
-    }
-
-    #[inline]
     fn fdstat_set_flags(&self, flags: u16) -> std::result::Result<(), io::Error> {
         self.cap_std.fdstat_set_flags(flags)
     }


### PR DESCRIPTION
Fixes #385.