### PR TITLE
Update to rustix 1.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ libc = "0.2.100"
 io-lifetimes = "2.0.0"
 
 [target.'cfg(not(windows))'.dev-dependencies]
-rustix = { version = "0.38.0", features = ["fs"] }
+rustix = { version = "1.0.0", features = ["fs"] }
 
 [target.'cfg(windows)'.dev-dependencies]
 # nt_version uses internal Windows APIs, however we're only using it

--- a/cap-async-std/Cargo.toml
+++ b/cap-async-std/Cargo.toml
@@ -21,7 +21,7 @@ io-extras = { version = "0.18.3", features = ["use_async_std"] }
 camino = { version = "1.0.5", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.38.0", features = ["fs"] }
+rustix = { version = "1.0.0", features = ["fs"] }
 
 [features]
 default = []

--- a/cap-directories/Cargo.toml
+++ b/cap-directories/Cargo.toml
@@ -17,7 +17,7 @@ cap-std = { path = "../cap-std", version = "^3.4.3" }
 directories-next = "2.0.0"
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.38.0" }
+rustix = { version = "1.0.0" }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = ">=0.52, <=0.59"

--- a/cap-net-ext/Cargo.toml
+++ b/cap-net-ext/Cargo.toml
@@ -15,5 +15,5 @@ edition = "2021"
 [dependencies]
 cap-std = { path = "../cap-std", version = "^3.4.3" }
 cap-primitives = { path = "../cap-primitives", version = "^3.4.3" }
-rustix = { version = "0.38.0", features = ["net"] }
+rustix = { version = "1.0.0", features = ["net"] }
 smallvec = "1.10"

--- a/cap-net-ext/src/lib.rs
+++ b/cap-net-ext/src/lib.rs
@@ -158,11 +158,7 @@ impl TcpListenerExt for TcpListener {
         set_socket_flags(&stream, blocking)?;
 
         // We know have a TCP socket, so we know we'll get an IP address.
-        let addr = match addr {
-            Some(rustix::net::SocketAddrAny::V4(v4)) => SocketAddr::V4(v4),
-            Some(rustix::net::SocketAddrAny::V6(v6)) => SocketAddr::V6(v6),
-            _ => unreachable!(),
-        };
+        let addr = SocketAddr::try_from(addr.unwrap()).unwrap();
 
         Ok((TcpStream::from(stream), addr))
     }

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -28,7 +28,7 @@ cap-tempfile = { path = "../cap-tempfile" }
 rustix = { version = "1.0.0", features = ["fs", "process", "termios", "time"] }
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
-rustix-linux-procfs = "0.1.0"
+rustix-linux-procfs = "0.1.1"
 
 [target.'cfg(windows)'.dependencies]
 winx = "0.36.0"

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -25,7 +25,10 @@ io-lifetimes = { version = "2.0.0", default-features = false }
 cap-tempfile = { path = "../cap-tempfile" }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.38.38", features = ["fs", "process", "procfs", "termios", "time"] }
+rustix = { version = "1.0.0", features = ["fs", "process", "termios", "time"] }
+
+[target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
+rustix-linux-procfs = "0.1.0"
 
 [target.'cfg(windows)'.dependencies]
 winx = "0.36.0"

--- a/cap-primitives/src/rustix/fs/is_file_read_write_impl.rs
+++ b/cap-primitives/src/rustix/fs/is_file_read_write_impl.rs
@@ -1,7 +1,43 @@
-use rustix::fs::is_file_read_write;
+use rustix::fd::{AsFd, BorrowedFd};
+use rustix::fs::{fcntl_getfl, OFlags};
 use std::{fs, io};
 
 #[inline]
 pub(crate) fn is_file_read_write_impl(file: &fs::File) -> io::Result<(bool, bool)> {
     Ok(is_file_read_write(file)?)
+}
+
+/// `fcntl(fd, F_GETFL) & O_ACCMODE`
+///
+/// Returns a pair of booleans indicating whether the file descriptor is
+/// readable and/or writable, respectively. This is only reliable on files; for
+/// example, it doesn't reflect whether sockets have been shut down; for
+/// general I/O handle support, use [`io::is_read_write`].
+#[inline]
+fn is_file_read_write<Fd: AsFd>(fd: Fd) -> io::Result<(bool, bool)> {
+    _is_file_read_write(fd.as_fd())
+}
+
+fn _is_file_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)> {
+    let mode = fcntl_getfl(fd)?;
+
+    // Check for `O_PATH`.
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "emscripten",
+        target_os = "fuchsia"
+    ))]
+    if mode.contains(OFlags::PATH) {
+        return Ok((false, false));
+    }
+
+    // Use `RWMODE` rather than `ACCMODE` as `ACCMODE` may include `O_PATH`.
+    // We handled `O_PATH` above.
+    match mode & OFlags::RWMODE {
+        OFlags::RDONLY => Ok((true, false)),
+        OFlags::RDWR => Ok((true, true)),
+        OFlags::WRONLY => Ok((false, true)),
+        _ => unreachable!(),
+    }
 }

--- a/cap-primitives/src/rustix/fs/metadata_ext.rs
+++ b/cap-primitives/src/rustix/fs/metadata_ext.rs
@@ -102,9 +102,6 @@ impl ImplMetadataExt {
     #[inline]
     #[allow(unused_comparisons)] // NB: rust-lang/rust#115823 requires this here instead of on `st_dev` processing below
     pub(crate) fn from_rustix(stat: Stat) -> Metadata {
-        #[cfg(not(target_os = "wasi"))]
-        use rustix::fs::StatExt;
-
         Metadata {
             file_type: ImplFileTypeExt::from_raw_mode(stat.st_mode as RawMode),
             len: u64::try_from(stat.st_size).unwrap(),
@@ -115,12 +112,12 @@ impl ImplMetadataExt {
 
             #[cfg(not(any(target_os = "netbsd", target_os = "wasi")))]
             modified: system_time_from_rustix(
-                stat.mtime().try_into().unwrap(),
+                stat.st_mtime.try_into().unwrap(),
                 stat.st_mtime_nsec as _,
             ),
             #[cfg(not(any(target_os = "netbsd", target_os = "wasi")))]
             accessed: system_time_from_rustix(
-                stat.atime().try_into().unwrap(),
+                stat.st_atime.try_into().unwrap(),
                 stat.st_atime_nsec as _,
             ),
 
@@ -200,19 +197,19 @@ impl ImplMetadataExt {
                 rdev: u64::try_from(stat.st_rdev).unwrap(),
                 size: u64::try_from(stat.st_size).unwrap(),
                 #[cfg(not(target_os = "wasi"))]
-                atime: i64::try_from(stat.atime()).unwrap(),
+                atime: i64::try_from(stat.st_atime).unwrap(),
                 #[cfg(not(any(target_os = "netbsd", target_os = "wasi")))]
                 atime_nsec: stat.st_atime_nsec as _,
                 #[cfg(target_os = "netbsd")]
                 atime_nsec: stat.st_atimensec as _,
                 #[cfg(not(target_os = "wasi"))]
-                mtime: i64::try_from(stat.mtime()).unwrap(),
+                mtime: i64::try_from(stat.st_mtime).unwrap(),
                 #[cfg(not(any(target_os = "netbsd", target_os = "wasi")))]
                 mtime_nsec: stat.st_mtime_nsec as _,
                 #[cfg(target_os = "netbsd")]
                 mtime_nsec: stat.st_mtimensec as _,
                 #[cfg(not(target_os = "wasi"))]
-                ctime: i64::try_from(stat.ctime()).unwrap(),
+                ctime: i64::try_from(stat.st_ctime).unwrap(),
                 #[cfg(not(any(target_os = "netbsd", target_os = "wasi")))]
                 ctime_nsec: stat.st_ctime_nsec as _,
                 #[cfg(target_os = "netbsd")]

--- a/cap-primitives/src/rustix/fs/metadata_ext.rs
+++ b/cap-primitives/src/rustix/fs/metadata_ext.rs
@@ -110,26 +110,15 @@ impl ImplMetadataExt {
             #[cfg(target_os = "wasi")]
             permissions: ImplPermissionsExt::default(),
 
-            #[cfg(not(any(target_os = "netbsd", target_os = "wasi")))]
+            #[cfg(not(target_os = "wasi"))]
             modified: system_time_from_rustix(
                 stat.st_mtime.try_into().unwrap(),
                 stat.st_mtime_nsec as _,
             ),
-            #[cfg(not(any(target_os = "netbsd", target_os = "wasi")))]
+            #[cfg(not(target_os = "wasi"))]
             accessed: system_time_from_rustix(
                 stat.st_atime.try_into().unwrap(),
                 stat.st_atime_nsec as _,
-            ),
-
-            #[cfg(target_os = "netbsd")]
-            modified: system_time_from_rustix(
-                stat.st_mtime.try_into().unwrap(),
-                stat.st_mtimensec as _,
-            ),
-            #[cfg(target_os = "netbsd")]
-            accessed: system_time_from_rustix(
-                stat.st_atime.try_into().unwrap(),
-                stat.st_atimensec as _,
             ),
 
             #[cfg(target_os = "wasi")]
@@ -140,6 +129,7 @@ impl ImplMetadataExt {
             #[cfg(any(
                 target_os = "freebsd",
                 target_os = "openbsd",
+                target_os = "netbsd",
                 target_os = "macos",
                 target_os = "ios",
                 target_os = "tvos",
@@ -149,12 +139,6 @@ impl ImplMetadataExt {
             created: system_time_from_rustix(
                 stat.st_birthtime.try_into().unwrap(),
                 stat.st_birthtime_nsec as _,
-            ),
-
-            #[cfg(target_os = "netbsd")]
-            created: system_time_from_rustix(
-                stat.st_birthtime.try_into().unwrap(),
-                stat.st_birthtimensec as _,
             ),
 
             // `stat.st_ctime` is the latest status change; we want the creation.
@@ -198,22 +182,16 @@ impl ImplMetadataExt {
                 size: u64::try_from(stat.st_size).unwrap(),
                 #[cfg(not(target_os = "wasi"))]
                 atime: i64::try_from(stat.st_atime).unwrap(),
-                #[cfg(not(any(target_os = "netbsd", target_os = "wasi")))]
+                #[cfg(not(target_os = "wasi"))]
                 atime_nsec: stat.st_atime_nsec as _,
-                #[cfg(target_os = "netbsd")]
-                atime_nsec: stat.st_atimensec as _,
                 #[cfg(not(target_os = "wasi"))]
                 mtime: i64::try_from(stat.st_mtime).unwrap(),
-                #[cfg(not(any(target_os = "netbsd", target_os = "wasi")))]
+                #[cfg(not(target_os = "wasi"))]
                 mtime_nsec: stat.st_mtime_nsec as _,
-                #[cfg(target_os = "netbsd")]
-                mtime_nsec: stat.st_mtimensec as _,
                 #[cfg(not(target_os = "wasi"))]
                 ctime: i64::try_from(stat.st_ctime).unwrap(),
-                #[cfg(not(any(target_os = "netbsd", target_os = "wasi")))]
+                #[cfg(not(target_os = "wasi"))]
                 ctime_nsec: stat.st_ctime_nsec as _,
-                #[cfg(target_os = "netbsd")]
-                ctime_nsec: stat.st_ctimensec as _,
                 #[cfg(not(target_os = "wasi"))]
                 blksize: u64::try_from(stat.st_blksize).unwrap(),
                 #[cfg(not(target_os = "wasi"))]

--- a/cap-primitives/src/rustix/linux/fs/procfs.rs
+++ b/cap-primitives/src/rustix/linux/fs/procfs.rs
@@ -13,7 +13,7 @@ use crate::fs::{
 use io_lifetimes::{AsFd, AsFilelike};
 use rustix::fs::{chmodat, AtFlags, Mode, OFlags, RawMode};
 use rustix::path::DecInt;
-use rustix::procfs::proc_self_fd;
+use rustix_linux_procfs::proc_self_fd;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::{fs, io};

--- a/cap-std/Cargo.toml
+++ b/cap-std/Cargo.toml
@@ -24,7 +24,7 @@ io-lifetimes = { version = "2.0.0", default-features = false }
 camino = { version = "1.0.5", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.38.0", features = ["fs"] }
+rustix = { version = "1.0.0", features = ["fs"] }
 
 [features]
 default = []

--- a/cap-tempfile/Cargo.toml
+++ b/cap-tempfile/Cargo.toml
@@ -21,7 +21,10 @@ camino = { version = "1.0.5", optional = true }
 rand = "0.8.1"
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.38.0", features = ["procfs"] }
+rustix = { version = "1.0.0" }
+
+[target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
+rustix-linux-procfs = "0.1.0"
 
 [target.'cfg(windows)'.dev-dependencies.windows-sys]
 version = ">=0.52, <=0.59"

--- a/cap-tempfile/Cargo.toml
+++ b/cap-tempfile/Cargo.toml
@@ -24,7 +24,7 @@ rand = "0.8.1"
 rustix = { version = "1.0.0" }
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
-rustix-linux-procfs = "0.1.0"
+rustix-linux-procfs = "0.1.1"
 
 [target.'cfg(windows)'.dev-dependencies.windows-sys]
 version = ">=0.52, <=0.59"

--- a/cap-tempfile/src/tempfile.rs
+++ b/cap-tempfile/src/tempfile.rs
@@ -87,7 +87,7 @@ fn new_tempfile_linux(d: &Dir, anonymous: bool) -> io::Result<Option<File>> {
 fn generate_name_in(subdir: &Dir, f: &File) -> io::Result<String> {
     use rustix::fd::AsFd;
     use rustix::fs::AtFlags;
-    let procself_fd = rustix::procfs::proc_self_fd()?;
+    let procself_fd = rustix_linux_procfs::proc_self_fd()?;
     let fdnum = rustix::path::DecInt::from_fd(f.as_fd());
     let fdnum = fdnum.as_c_str();
     super::retry_with_name_ignoring(io::ErrorKind::AlreadyExists, |name| {

--- a/cap-time-ext/Cargo.toml
+++ b/cap-time-ext/Cargo.toml
@@ -19,7 +19,7 @@ cap-std = { path = "../cap-std", optional = true, version = "^3.4.3" }
 iana-time-zone = "0.1.57"
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.38.0", features = ["time"] }
+rustix = { version = "1.0.0", features = ["time"] }
 
 [target.'cfg(windows)'.dependencies]
 once_cell = "1.5.2"


### PR DESCRIPTION
rustix's procfs module has moved to a separate crate, rustix-linux-procfs.