### PR TITLE
chore: bump to rand v0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ cap-directories = { path = "cap-directories", version = "3.4.5" }
 cap-std = { path = "cap-std", version = "3.4.5" }
 cap-tempfile = { path = "cap-tempfile", version = "3.4.5" }
 cap-rand = { path = "cap-rand", version = "3.4.5" }
-rand = "0.8.1"
+rand = "0.9.2"
 tempfile = "3.1.0"
 camino = "1.0.5"
 libc = "0.2.100"

--- a/cap-rand/Cargo.toml
+++ b/cap-rand/Cargo.toml
@@ -14,7 +14,8 @@ edition = "2021"
 
 [dependencies]
 ambient-authority = "0.0.2"
-rand = "0.8.1"
+rand = "0.9.2"
+rand_distr = "0.5.1"
 
 [features]
 default = []

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -1288,7 +1288,7 @@ fn _assert_send_sync() {
 #[test]
 fn binary_file() {
     let mut bytes = [0; 1024];
-    StdRng::from_entropy().fill_bytes(&mut bytes);
+    StdRng::from_os_rng().fill_bytes(&mut bytes);
 
     let tmpdir = tmpdir();
 
@@ -1301,7 +1301,7 @@ fn binary_file() {
 #[test]
 fn write_then_read() {
     let mut bytes = [0; 1024];
-    StdRng::from_entropy().fill_bytes(&mut bytes);
+    StdRng::from_os_rng().fill_bytes(&mut bytes);
 
     let tmpdir = tmpdir();
 

--- a/tests/fs_utf8.rs
+++ b/tests/fs_utf8.rs
@@ -1285,7 +1285,7 @@ fn _assert_send_sync() {
 #[test]
 fn binary_file() {
     let mut bytes = [0; 1024];
-    StdRng::from_entropy().fill_bytes(&mut bytes);
+    StdRng::from_os_rng().fill_bytes(&mut bytes);
 
     let tmpdir = tmpdir();
 
@@ -1298,7 +1298,7 @@ fn binary_file() {
 #[test]
 fn write_then_read() {
     let mut bytes = [0; 1024];
-    StdRng::from_entropy().fill_bytes(&mut bytes);
+    StdRng::from_os_rng().fill_bytes(&mut bytes);
 
     let tmpdir = tmpdir();
 

--- a/tests/rand.rs
+++ b/tests/rand.rs
@@ -1,5 +1,5 @@
 #[test]
 fn test_std_rng_from_entropy() {
-    let rng = cap_rand::std_rng_from_entropy(cap_rand::ambient_authority());
+    let rng = cap_rand::std_rng_from_os_rng(cap_rand::ambient_authority());
     assert_eq!(rng.clone(), rng);
 }


### PR DESCRIPTION
I've been trying to get rand v0.8 from my dependency tree, so thought I'd contribute a patch upstream. I'm a bit uncertain exactly what we want to re-export here; the `rand` API has changed quite a bit between 0.8 and 0.9 (see the [changelog](https://github.com/rust-random/rand/blob/master/CHANGELOG.md#090---2025-01-27)).

Let me know if you would like any changes making!