### PR TITLE
chore: fix clippy lints and cargo check warnings

### DIFF
--- a/cap-async-std/src/net/tcp_listener.rs
+++ b/cap-async-std/src/net/tcp_listener.rs
@@ -67,7 +67,7 @@ impl TcpListener {
     ///
     /// This corresponds to [`async_std::net::TcpListener::incoming`].
     #[inline]
-    pub fn incoming(&self) -> Incoming {
+    pub fn incoming(&self) -> Incoming<'_> {
         let incoming = self.std.incoming();
         Incoming::from_std(incoming)
     }

--- a/cap-async-std/src/os/unix/net/unix_listener.rs
+++ b/cap-async-std/src/os/unix/net/unix_listener.rs
@@ -69,7 +69,7 @@ impl UnixListener {
     ///
     /// [`async_std::os::unix::net::UnixListener::incoming`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixListener.html#method.incoming
     #[inline]
-    pub fn incoming(&self) -> Incoming {
+    pub fn incoming(&self) -> Incoming<'_> {
         let incoming = self.std.incoming();
         Incoming::from_std(incoming)
     }

--- a/cap-primitives/src/fs/via_parent/open_parent.rs
+++ b/cap-primitives/src/fs/via_parent/open_parent.rs
@@ -37,7 +37,7 @@ pub(super) fn open_parent<'path, 'borrow>(
 ///  - Append a `.` to a path with a trailing `..` to avoid requiring our
 ///    callers to special-case `..`.
 ///  - Bare absolute paths are ok.
-fn split_parent(path: &Path) -> Option<(&Path, Component)> {
+fn split_parent(path: &Path) -> Option<(&Path, Component<'_>)> {
     if path.as_os_str().is_empty() {
         return None;
     }

--- a/cap-std/src/net/tcp_listener.rs
+++ b/cap-std/src/net/tcp_listener.rs
@@ -72,7 +72,7 @@ impl TcpListener {
     ///
     /// This corresponds to [`std::net::TcpListener::incoming`].
     #[inline]
-    pub fn incoming(&self) -> Incoming {
+    pub fn incoming(&self) -> Incoming<'_> {
         let incoming = self.std.incoming();
         Incoming::from_std(incoming)
     }

--- a/cap-std/src/os/unix/net/unix_listener.rs
+++ b/cap-std/src/os/unix/net/unix_listener.rs
@@ -90,7 +90,7 @@ impl UnixListener {
     ///
     /// [`std::os::unix::net::UnixListener::incoming`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixListener.html#method.incoming
     #[inline]
-    pub fn incoming(&self) -> Incoming {
+    pub fn incoming(&self) -> Incoming<'_> {
         let incoming = self.std.incoming();
         Incoming::from_std(incoming)
     }

--- a/examples/async_std_fs_misc.rs
+++ b/examples/async_std_fs_misc.rs
@@ -45,14 +45,11 @@ async fn main() {
     println!("`mkdir a`");
 
     // Create a directory, returns `io::Result<()>`
-    match cwd.create_dir("a") {
-        Err(why) => println!("! {:?}", why.kind()),
-        Ok(_) => {}
-    }
+    if let Err(why) = cwd.create_dir("a") { println!("! {:?}", why.kind()) }
 
     println!("`echo hello > a/b.txt`");
     // The previous match can be simplified using the `unwrap_or_else` method
-    echo("hello", &mut cwd, &Path::new("a/b.txt"))
+    echo("hello", &mut cwd, Path::new("a/b.txt"))
         .await
         .unwrap_or_else(|why| {
             println!("! {:?}", why.kind());
@@ -65,7 +62,7 @@ async fn main() {
     });
 
     println!("`touch a/c/e.txt`");
-    touch(&mut cwd, &Path::new("a/c/e.txt"))
+    touch(&mut cwd, Path::new("a/c/e.txt"))
         .await
         .unwrap_or_else(|why| {
             println!("! {:?}", why.kind());
@@ -83,7 +80,7 @@ async fn main() {
     }
 
     println!("`cat a/c/b.txt`");
-    match cat(&mut cwd, &Path::new("a/c/b.txt")).await {
+    match cat(&mut cwd, Path::new("a/c/b.txt")).await {
         Err(why) => println!("! {:?}", why.kind()),
         Ok(s) => println!("> {}", s),
     }

--- a/examples/std_fs_misc.rs
+++ b/examples/std_fs_misc.rs
@@ -39,14 +39,11 @@ fn main() {
     println!("`mkdir a`");
 
     // Create a directory, returns `io::Result<()>`
-    match cwd.create_dir("a") {
-        Err(why) => println!("! {:?}", why.kind()),
-        Ok(_) => {}
-    }
+    if let Err(why) = cwd.create_dir("a") { println!("! {:?}", why.kind()) }
 
     println!("`echo hello > a/b.txt`");
     // The previous match can be simplified using the `unwrap_or_else` method
-    echo("hello", &mut cwd, &Path::new("a/b.txt")).unwrap_or_else(|why| {
+    echo("hello", &mut cwd, Path::new("a/b.txt")).unwrap_or_else(|why| {
         println!("! {:?}", why.kind());
     });
 
@@ -57,7 +54,7 @@ fn main() {
     });
 
     println!("`touch a/c/e.txt`");
-    touch(&mut cwd, &Path::new("a/c/e.txt")).unwrap_or_else(|why| {
+    touch(&mut cwd, Path::new("a/c/e.txt")).unwrap_or_else(|why| {
         println!("! {:?}", why.kind());
     });
 
@@ -71,7 +68,7 @@ fn main() {
     }
 
     println!("`cat a/c/b.txt`");
-    match cat(&mut cwd, &Path::new("a/c/b.txt")) {
+    match cat(&mut cwd, Path::new("a/c/b.txt")) {
         Err(why) => println!("! {:?}", why.kind()),
         Ok(s) => println!("> {}", s),
     }

--- a/tests/cap-net-ext-udp-split.rs
+++ b/tests/cap-net-ext-udp-split.rs
@@ -62,18 +62,18 @@ fn socket_smoke_test_ip4() {
             let client =
                 UdpSocket::new(AddressFamily::of_socket_addr(client_ip), Blocking::Yes).unwrap();
             t!(client_pool
-                .udp_binder(&client_ip)
+                .udp_binder(client_ip)
                 .unwrap()
                 .bind_existing_udp_socket(&client));
             rx1.recv().unwrap();
-            t!(p.send_to_udp_socket_addr(&client, &[99], &server_ip));
+            t!(p.send_to_udp_socket_addr(&client, &[99], server_ip));
             tx2.send(()).unwrap();
         });
 
         let server =
             UdpSocket::new(AddressFamily::of_socket_addr(server_ip), Blocking::Yes).unwrap();
         t!(server_pool
-            .udp_binder(&server_ip)
+            .udp_binder(server_ip)
             .unwrap()
             .bind_existing_udp_socket(&server));
         tx1.send(()).unwrap();
@@ -94,7 +94,7 @@ fn socket_name() {
 
         let server = UdpSocket::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
         t!(pool
-            .udp_binder(&addr)
+            .udp_binder(addr)
             .unwrap()
             .bind_existing_udp_socket(&server));
         assert_eq!(addr, t!(server.local_addr()));
@@ -111,7 +111,7 @@ fn socket_peer() {
 
         let server = UdpSocket::new(AddressFamily::of_socket_addr(addr1), Blocking::Yes).unwrap();
         t!(pool1
-            .udp_binder(&addr1)
+            .udp_binder(addr1)
             .unwrap()
             .bind_existing_udp_socket(&server));
         assert_eq!(
@@ -119,7 +119,7 @@ fn socket_peer() {
             ErrorKind::NotConnected
         );
         t!(pool2
-            .udp_connecter(&addr2)
+            .udp_connecter(addr2)
             .unwrap()
             .connect_existing_udp_socket(&server));
         assert_eq!(addr2, t!(server.peer_addr()));
@@ -136,12 +136,12 @@ fn udp_clone_smoke() {
 
         let sock1 = UdpSocket::new(AddressFamily::of_socket_addr(addr1), Blocking::Yes).unwrap();
         t!(pool1
-            .udp_binder(&addr1)
+            .udp_binder(addr1)
             .unwrap()
             .bind_existing_udp_socket(&sock1));
         let sock2 = UdpSocket::new(AddressFamily::of_socket_addr(addr2), Blocking::Yes).unwrap();
         t!(pool2
-            .udp_binder(&addr2)
+            .udp_binder(addr2)
             .unwrap()
             .bind_existing_udp_socket(&sock2));
 
@@ -149,7 +149,7 @@ fn udp_clone_smoke() {
             let mut buf = [0, 0];
             assert_eq!(sock2.recv_from(&mut buf).unwrap(), (1, addr1));
             assert_eq!(buf[0], 1);
-            t!(pool1.send_to_udp_socket_addr(&sock2, &[2], &addr1));
+            t!(pool1.send_to_udp_socket_addr(&sock2, &[2], addr1));
         });
 
         let sock3 = t!(sock1.try_clone());
@@ -159,7 +159,7 @@ fn udp_clone_smoke() {
         let p = pool2.clone();
         let _t = thread::spawn(move || {
             rx1.recv().unwrap();
-            t!(p.send_to_udp_socket_addr(&sock3, &[1], &addr2));
+            t!(p.send_to_udp_socket_addr(&sock3, &[1], addr2));
             tx2.send(()).unwrap();
         });
         tx1.send(()).unwrap();
@@ -179,21 +179,21 @@ fn udp_clone_two_read() {
 
         let sock1 = UdpSocket::new(AddressFamily::of_socket_addr(addr1), Blocking::Yes).unwrap();
         t!(pool1
-            .udp_binder(&addr1)
+            .udp_binder(addr1)
             .unwrap()
             .bind_existing_udp_socket(&sock1));
         let sock2 = UdpSocket::new(AddressFamily::of_socket_addr(addr2), Blocking::Yes).unwrap();
         t!(pool2
-            .udp_binder(&addr2)
+            .udp_binder(addr2)
             .unwrap()
             .bind_existing_udp_socket(&sock2));
         let (tx1, rx) = channel();
         let tx2 = tx1.clone();
 
         let _t = thread::spawn(move || {
-            t!(pool1.send_to_udp_socket_addr(&sock2, &[1], &addr1));
+            t!(pool1.send_to_udp_socket_addr(&sock2, &[1], addr1));
             rx.recv().unwrap();
-            t!(pool1.send_to_udp_socket_addr(&sock2, &[2], &addr1));
+            t!(pool1.send_to_udp_socket_addr(&sock2, &[2], addr1));
             rx.recv().unwrap();
         });
 
@@ -224,12 +224,12 @@ fn udp_clone_two_write() {
 
         let sock1 = UdpSocket::new(AddressFamily::of_socket_addr(addr1), Blocking::Yes).unwrap();
         t!(pool1
-            .udp_binder(&addr1)
+            .udp_binder(addr1)
             .unwrap()
             .bind_existing_udp_socket(&sock1));
         let sock2 = UdpSocket::new(AddressFamily::of_socket_addr(addr2), Blocking::Yes).unwrap();
         t!(pool2
-            .udp_binder(&addr2)
+            .udp_binder(addr2)
             .unwrap()
             .bind_existing_udp_socket(&sock2));
 
@@ -249,12 +249,12 @@ fn udp_clone_two_write() {
         let tx2 = tx.clone();
         let p = pool2.clone();
         let _t = thread::spawn(move || {
-            if p.send_to_udp_socket_addr(&sock3, &[1], &addr2).is_ok() {
+            if p.send_to_udp_socket_addr(&sock3, &[1], addr2).is_ok() {
                 let _ = tx2.send(());
             }
             done.send(()).unwrap();
         });
-        if pool2.send_to_udp_socket_addr(&sock1, &[2], &addr2).is_ok() {
+        if pool2.send_to_udp_socket_addr(&sock1, &[2], addr2).is_ok() {
             let _ = tx.send(());
         }
         drop(tx);
@@ -294,7 +294,7 @@ fn timeouts() {
 
     let stream = UdpSocket::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
     t!(pool
-        .udp_binder(&addr)
+        .udp_binder(addr)
         .unwrap()
         .bind_existing_udp_socket(&stream));
     let dur = Duration::new(15410, 0);
@@ -325,7 +325,7 @@ fn test_read_timeout() {
 
     let stream = UdpSocket::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
     t!(pool
-        .udp_binder(&addr)
+        .udp_binder(addr)
         .unwrap()
         .bind_existing_udp_socket(&stream));
     t!(stream.set_read_timeout(Some(Duration::from_millis(1000))));
@@ -336,8 +336,7 @@ fn test_read_timeout() {
     loop {
         let kind = stream
             .recv_from(&mut buf)
-            .err()
-            .expect("expected error")
+            .expect_err("expected error")
             .kind();
         if kind != ErrorKind::Interrupted {
             assert!(
@@ -360,12 +359,12 @@ fn test_read_with_timeout() {
 
     let stream = UdpSocket::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
     t!(pool
-        .udp_binder(&addr)
+        .udp_binder(addr)
         .unwrap()
         .bind_existing_udp_socket(&stream));
     t!(stream.set_read_timeout(Some(Duration::from_millis(1000))));
 
-    t!(pool.send_to_udp_socket_addr(&stream, b"hello world", &addr));
+    t!(pool.send_to_udp_socket_addr(&stream, b"hello world", addr));
 
     let mut buf = [0; 11];
     t!(stream.recv_from(&mut buf));
@@ -375,8 +374,7 @@ fn test_read_with_timeout() {
     loop {
         let kind = stream
             .recv_from(&mut buf)
-            .err()
-            .expect("expected error")
+            .expect_err("expected error")
             .kind();
         if kind != ErrorKind::Interrupted {
             assert!(
@@ -401,7 +399,7 @@ fn test_timeout_zero_duration() {
 
     let socket = UdpSocket::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
     t!(pool
-        .udp_binder(&addr)
+        .udp_binder(addr)
         .unwrap()
         .bind_existing_udp_socket(&socket));
 
@@ -423,7 +421,7 @@ fn connect_send_recv() {
 
     let socket = UdpSocket::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
     t!(pool
-        .udp_binder(&addr)
+        .udp_binder(addr)
         .unwrap()
         .bind_existing_udp_socket(&socket));
     t!(pool
@@ -446,7 +444,7 @@ fn connect_send_peek_recv() {
 
         let socket = UdpSocket::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
         t!(pool
-            .udp_binder(&addr)
+            .udp_binder(addr)
             .unwrap()
             .bind_existing_udp_socket(&socket));
         t!(pool
@@ -478,10 +476,10 @@ fn peek_from() {
 
         let socket = UdpSocket::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
         t!(pool
-            .udp_binder(&addr)
+            .udp_binder(addr)
             .unwrap()
             .bind_existing_udp_socket(&socket));
-        t!(pool.send_to_udp_socket_addr(&socket, b"hello world", &addr));
+        t!(pool.send_to_udp_socket_addr(&socket, b"hello world", addr));
 
         for _ in 1..3 {
             let mut buf = [0; 11];
@@ -508,7 +506,7 @@ fn ttl() {
 
     let stream = UdpSocket::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
     t!(pool
-        .udp_binder(&addr)
+        .udp_binder(addr)
         .unwrap()
         .bind_existing_udp_socket(&stream));
 
@@ -524,7 +522,7 @@ fn set_nonblocking() {
 
         let socket = UdpSocket::new(AddressFamily::of_socket_addr(addr), Blocking::Yes).unwrap();
         t!(pool
-            .udp_binder(&addr)
+            .udp_binder(addr)
             .unwrap()
             .bind_existing_udp_socket(&socket));
 

--- a/tests/dir-ext.rs
+++ b/tests/dir-ext.rs
@@ -41,7 +41,7 @@ fn remove_symlink_to_dir() {
 
     let tempdir = TempDir::new(ambient_authority()).expect("create tempdir");
     {
-        let _target = tempdir.create_dir("target").expect("create target dir");
+        tempdir.create_dir("target").expect("create target dir");
     }
     tempdir.symlink("target", "link").expect("create symlink");
     assert!(tempdir.exists("link"), "link exists");
@@ -56,7 +56,7 @@ fn remove_symlink_to_dir() {
 fn do_not_remove_dir() {
     let tempdir = TempDir::new(ambient_authority()).expect("create tempdir");
     {
-        let _subdir = tempdir.create_dir("subdir").expect("create dir");
+        tempdir.create_dir("subdir").expect("create dir");
     }
     assert!(tempdir.exists("subdir"), "subdir created");
     tempdir
@@ -86,7 +86,7 @@ fn test_set_symlink_permissions() {
     match tmpdir.set_symlink_permissions("symlink", permissions.clone()) {
         Ok(()) => {}
         Err(err) if err.raw_os_error() == Some(libc::EOPNOTSUPP) => return,
-        Err(err) => Err(err).unwrap(),
+        Err(err) => panic!("{:?}", err),
     }
     tmpdir
         .set_symlink_permissions("other", permissions.clone())

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -89,7 +89,7 @@ fn able_to_not_follow_symlinks_while_hard_linking() -> bool {
 
 #[cfg(not(target_os = "macos"))]
 fn able_to_not_follow_symlinks_while_hard_linking() -> bool {
-    return true;
+    true
 }
 
 #[test]
@@ -172,7 +172,7 @@ fn file_test_io_non_positional_read() {
 fn file_test_io_seek_and_tell_smoke_test() {
     let message = "ten-four";
     let mut read_mem = [0; 4];
-    let set_cursor = 4 as u64;
+    let set_cursor = 4_u64;
     let tell_pos_pre_read;
     let tell_pos_post_read;
     let tmpdir = tmpdir();
@@ -184,9 +184,9 @@ fn file_test_io_seek_and_tell_smoke_test() {
     {
         let mut read_stream = check!(tmpdir.open(filename));
         check!(read_stream.seek(SeekFrom::Start(set_cursor)));
-        tell_pos_pre_read = check!(read_stream.seek(SeekFrom::Current(0)));
+        tell_pos_pre_read = check!(read_stream.stream_position());
         check!(read_stream.read(&mut read_mem));
-        tell_pos_post_read = check!(read_stream.seek(SeekFrom::Current(0)));
+        tell_pos_post_read = check!(read_stream.stream_position());
     }
     check!(tmpdir.remove_file(filename));
     let read_str = str::from_utf8(&read_mem).unwrap();
@@ -289,48 +289,48 @@ fn file_test_io_read_write_at() {
             .clone();
         let mut rw = check!(tmpdir.open_with(filename, &oo));
         assert_eq!(check!(rw.write_at(write1.as_bytes(), 5)), write1.len());
-        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 0);
+        assert_eq!(check!(rw.stream_position()), 0);
         assert_eq!(check!(rw.read_at(&mut buf, 5)), write1.len());
         assert_eq!(str::from_utf8(&buf[..write1.len()]), Ok(write1));
-        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 0);
+        assert_eq!(check!(rw.stream_position()), 0);
         assert_eq!(
             check!(rw.read_at(&mut buf[..write2.len()], 0)),
             write2.len()
         );
         assert_eq!(str::from_utf8(&buf[..write2.len()]), Ok("\0\0\0\0\0"));
-        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 0);
+        assert_eq!(check!(rw.stream_position()), 0);
         assert_eq!(check!(rw.write(write2.as_bytes())), write2.len());
-        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 5);
+        assert_eq!(check!(rw.stream_position()), 5);
         assert_eq!(check!(rw.read(&mut buf)), write1.len());
         assert_eq!(str::from_utf8(&buf[..write1.len()]), Ok(write1));
-        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 9);
+        assert_eq!(check!(rw.stream_position()), 9);
         assert_eq!(
             check!(rw.read_at(&mut buf[..write2.len()], 0)),
             write2.len()
         );
         assert_eq!(str::from_utf8(&buf[..write2.len()]), Ok(write2));
-        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 9);
+        assert_eq!(check!(rw.stream_position()), 9);
         assert_eq!(check!(rw.write_at(write3.as_bytes(), 9)), write3.len());
-        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 9);
+        assert_eq!(check!(rw.stream_position()), 9);
     }
     {
         let mut read = check!(tmpdir.open(filename));
         assert_eq!(check!(read.read_at(&mut buf, 0)), content.len());
         assert_eq!(str::from_utf8(&buf[..content.len()]), Ok(content));
-        assert_eq!(check!(read.seek(SeekFrom::Current(0))), 0);
+        assert_eq!(check!(read.stream_position()), 0);
         assert_eq!(check!(read.seek(SeekFrom::End(-5))), 9);
         assert_eq!(check!(read.read_at(&mut buf, 0)), content.len());
         assert_eq!(str::from_utf8(&buf[..content.len()]), Ok(content));
-        assert_eq!(check!(read.seek(SeekFrom::Current(0))), 9);
+        assert_eq!(check!(read.stream_position()), 9);
         assert_eq!(check!(read.read(&mut buf)), write3.len());
         assert_eq!(str::from_utf8(&buf[..write3.len()]), Ok(write3));
-        assert_eq!(check!(read.seek(SeekFrom::Current(0))), 14);
+        assert_eq!(check!(read.stream_position()), 14);
         assert_eq!(check!(read.read_at(&mut buf, 0)), content.len());
         assert_eq!(str::from_utf8(&buf[..content.len()]), Ok(content));
-        assert_eq!(check!(read.seek(SeekFrom::Current(0))), 14);
+        assert_eq!(check!(read.stream_position()), 14);
         assert_eq!(check!(read.read_at(&mut buf, 14)), 0);
         assert_eq!(check!(read.read_at(&mut buf, 15)), 0);
-        assert_eq!(check!(read.seek(SeekFrom::Current(0))), 14);
+        assert_eq!(check!(read.stream_position()), 14);
     }
     check!(tmpdir.remove_file(filename));
 }
@@ -499,7 +499,7 @@ fn file_test_directoryinfo_readdir() {
     for n in 0..3 {
         let f = format!("{}.txt", n);
         let mut w = check!(tmpdir.create(&f));
-        let msg_str = format!("{}{}", prefix, n.to_string());
+        let msg_str = format!("{}{}", prefix, n);
         let msg = msg_str.as_bytes();
         check!(w.write(msg));
     }
@@ -524,7 +524,7 @@ fn file_create_new_already_exists_error() {
     let file = "file_create_new_error_exists";
     check!(tmpdir.create(file));
     let e = tmpdir
-        .open_with(file, &fs::OpenOptions::new().write(true).create_new(true))
+        .open_with(file, fs::OpenOptions::new().write(true).create_new(true))
         .unwrap_err();
     assert_eq!(e.kind(), ErrorKind::AlreadyExists);
 }
@@ -552,10 +552,10 @@ fn recursive_mkdir_failure() {
     let dir = "d1";
     let file = "f1";
 
-    check!(tmpdir.create_dir_all(&dir));
-    check!(tmpdir.create(&file));
+    check!(tmpdir.create_dir_all(dir));
+    check!(tmpdir.create(file));
 
-    let result = tmpdir.create_dir_all(&file);
+    let result = tmpdir.create_dir_all(file);
 
     assert!(result.is_err());
 }
@@ -615,8 +615,8 @@ fn recursive_rmdir() {
     check!(tmpdir.create_dir_all(&dtt));
     check!(tmpdir.create_dir_all(&d2));
     check!(check!(tmpdir.create(&canary)).write(b"foo"));
-    check!(symlink_junction(d2, &tmpdir, &dt.join("d2")));
-    let _ = symlink_file(&canary, &tmpdir, &d1.join("canary"));
+    check!(symlink_junction(d2, &tmpdir, dt.join("d2")));
+    let _ = symlink_file(&canary, &tmpdir, d1.join("canary"));
     check!(tmpdir.remove_dir_all(&d1));
 
     assert!(!tmpdir.is_dir(d1));
@@ -632,9 +632,9 @@ fn recursive_rmdir_of_symlink() {
     let link = "d1";
     let dir = "d2";
     let canary = "do_not_delete";
-    check!(tmpdir.create_dir_all(&dir));
-    check!(check!(tmpdir.create(&canary)).write(b"foo"));
-    check!(symlink_junction(&dir, &tmpdir, link));
+    check!(tmpdir.create_dir_all(dir));
+    check!(check!(tmpdir.create(canary)).write(b"foo"));
+    check!(symlink_junction(dir, &tmpdir, link));
     check!(tmpdir.remove_dir_all(link));
 
     assert!(!tmpdir.is_dir(link));
@@ -769,7 +769,7 @@ fn copy_file_does_not_exist() {
     let from = Path::new("test/nonexistent-bogus-path");
     let to = Path::new("test/other-bogus-path");
 
-    match tmpdir.copy(&from, &tmpdir, &to) {
+    match tmpdir.copy(from, &tmpdir, to) {
         Ok(..) => panic!(),
         Err(..) => {
             assert!(!tmpdir.exists(from));
@@ -783,11 +783,11 @@ fn copy_src_does_not_exist() {
     let tmpdir = tmpdir();
     let from = Path::new("test/nonexistent-bogus-path");
     let to = "out.txt";
-    check!(check!(tmpdir.create(&to)).write(b"hello"));
-    assert!(tmpdir.copy(&from, &tmpdir, &to).is_err());
+    check!(check!(tmpdir.create(to)).write(b"hello"));
+    assert!(tmpdir.copy(from, &tmpdir, to).is_err());
     assert!(!tmpdir.exists(from));
     let mut v = Vec::new();
-    check!(check!(tmpdir.open(&to)).read_to_end(&mut v));
+    check!(check!(tmpdir.open(to)).read_to_end(&mut v));
     assert_eq!(v, b"hello");
 }
 
@@ -797,10 +797,10 @@ fn copy_file_ok() {
     let input = "in.txt";
     let out = "out.txt";
 
-    check!(check!(tmpdir.create(&input)).write(b"hello"));
-    check!(tmpdir.copy(&input, &tmpdir, &out));
+    check!(check!(tmpdir.create(input)).write(b"hello"));
+    check!(tmpdir.copy(input, &tmpdir, out));
     let mut v = Vec::new();
-    check!(check!(tmpdir.open(&out)).read_to_end(&mut v));
+    check!(check!(tmpdir.open(out)).read_to_end(&mut v));
     assert_eq!(v, b"hello");
 
     assert_eq!(
@@ -814,11 +814,8 @@ fn copy_file_dst_dir() {
     let tmpdir = tmpdir();
     let out = "out";
 
-    check!(tmpdir.create(&out));
-    match tmpdir.copy(&*out, &tmpdir, ".") {
-        Ok(..) => panic!(),
-        Err(..) => {}
-    }
+    check!(tmpdir.create(out));
+    if let Ok(..) = tmpdir.copy(out, &tmpdir, ".") { panic!() }
 }
 
 #[test]
@@ -827,12 +824,12 @@ fn copy_file_dst_exists() {
     let input = "in";
     let output = "out";
 
-    check!(check!(tmpdir.create(&input)).write("foo".as_bytes()));
-    check!(check!(tmpdir.create(&output)).write("bar".as_bytes()));
-    check!(tmpdir.copy(&input, &tmpdir, &output));
+    check!(check!(tmpdir.create(input)).write("foo".as_bytes()));
+    check!(check!(tmpdir.create(output)).write("bar".as_bytes()));
+    check!(tmpdir.copy(input, &tmpdir, output));
 
     let mut v = Vec::new();
-    check!(check!(tmpdir.open(&output)).read_to_end(&mut v));
+    check!(check!(tmpdir.open(output)).read_to_end(&mut v));
     assert_eq!(v, b"foo".to_vec());
 }
 
@@ -841,10 +838,7 @@ fn copy_file_src_dir() {
     let tmpdir = tmpdir();
     let out = "out";
 
-    match tmpdir.copy(".", &tmpdir, &out) {
-        Ok(..) => panic!(),
-        Err(..) => {}
-    }
+    if let Ok(..) = tmpdir.copy(".", &tmpdir, out) { panic!() }
     assert!(!tmpdir.exists(out));
 }
 
@@ -854,14 +848,14 @@ fn copy_file_preserves_perm_bits() {
     let input = "in.txt";
     let out = "out.txt";
 
-    let attr = check!(check!(tmpdir.create(&input)).metadata());
+    let attr = check!(check!(tmpdir.create(input)).metadata());
     let mut p = attr.permissions();
     p.set_readonly(true);
-    check!(tmpdir.set_permissions(&input, p));
-    check!(tmpdir.copy(&input, &tmpdir, &out));
+    check!(tmpdir.set_permissions(input, p));
+    check!(tmpdir.copy(input, &tmpdir, out));
     assert!(check!(tmpdir.metadata(out)).permissions().readonly());
-    check!(tmpdir.set_permissions(&input, attr.permissions()));
-    check!(tmpdir.set_permissions(&out, attr.permissions()));
+    check!(tmpdir.set_permissions(input, attr.permissions()));
+    check!(tmpdir.set_permissions(out, attr.permissions()));
 }
 
 #[test]
@@ -881,10 +875,10 @@ fn copy_file_returns_metadata_len() {
     let tmp = tmpdir();
     let in_path = "in.txt";
     let out_path = "out.txt";
-    check!(check!(tmp.create(&in_path)).write(b"lettuce"));
+    check!(check!(tmp.create(in_path)).write(b"lettuce"));
     #[cfg(windows)]
     check!(check!(tmp.create("in.txt:bunny")).write(b"carrot"));
-    let copied_len = check!(tmp.copy(&in_path, &tmp, &out_path));
+    let copied_len = check!(tmp.copy(in_path, &tmp, out_path));
     assert_eq!(check!(tmp.metadata(out_path)).len(), copied_len);
 }
 
@@ -899,17 +893,17 @@ fn copy_file_follows_dst_symlink() {
     let out_path = "out.txt";
     let out_path_symlink = "out_symlink.txt";
 
-    check!(tmp.write(&in_path, "foo"));
-    check!(tmp.write(&out_path, "bar"));
-    check!(symlink_file(&out_path, &tmp, &out_path_symlink));
+    check!(tmp.write(in_path, "foo"));
+    check!(tmp.write(out_path, "bar"));
+    check!(symlink_file(out_path, &tmp, out_path_symlink));
 
-    check!(tmp.copy(&in_path, &tmp, &out_path_symlink));
+    check!(tmp.copy(in_path, &tmp, out_path_symlink));
 
     assert!(check!(tmp.symlink_metadata(out_path_symlink))
         .file_type()
         .is_symlink());
-    assert_eq!(check!(tmp.read(&out_path_symlink)), b"foo".to_vec());
-    assert_eq!(check!(tmp.read(&out_path)), b"foo".to_vec());
+    assert_eq!(check!(tmp.read(out_path_symlink)), b"foo".to_vec());
+    assert_eq!(check!(tmp.read(out_path)), b"foo".to_vec());
 }
 
 #[test]
@@ -922,17 +916,17 @@ fn symlinks_work() {
     let input = "in.txt";
     let out = "out.txt";
 
-    check!(check!(tmpdir.create(&input)).write("foobar".as_bytes()));
-    check!(symlink_file(&input, &tmpdir, &out));
+    check!(check!(tmpdir.create(input)).write("foobar".as_bytes()));
+    check!(symlink_file(input, &tmpdir, out));
     assert!(check!(tmpdir.symlink_metadata(out))
         .file_type()
         .is_symlink());
     assert_eq!(
-        check!(tmpdir.metadata(&out)).len(),
-        check!(tmpdir.metadata(&input)).len()
+        check!(tmpdir.metadata(out)).len(),
+        check!(tmpdir.metadata(input)).len()
     );
     let mut v = Vec::new();
-    check!(check!(tmpdir.open(&out)).read_to_end(&mut v));
+    check!(check!(tmpdir.open(out)).read_to_end(&mut v));
     assert_eq!(v, b"foobar".to_vec());
 }
 
@@ -946,7 +940,7 @@ fn symlink_noexist() {
 
     // Use a relative path for testing. Symlinks get normalized by Windows,
     // so we might not get the same path back for absolute paths
-    check!(symlink_file(&"foo", &tmpdir, "bar"));
+    check!(symlink_file("foo", &tmpdir, "bar"));
     assert_eq!(check!(tmpdir.read_link("bar")).to_str().unwrap(), "foo");
 }
 
@@ -975,17 +969,14 @@ fn read_link() {
     if !got_symlink_permission(&tmpdir) {
         return;
     };
-    check!(symlink_file(&"foo", &tmpdir, &link));
-    assert_eq!(check!(tmpdir.read_link(&link)).to_str().unwrap(), "foo");
+    check!(symlink_file("foo", &tmpdir, link));
+    assert_eq!(check!(tmpdir.read_link(link)).to_str().unwrap(), "foo");
 }
 
 #[test]
 fn readlink_not_symlink() {
     let tmpdir = tmpdir();
-    match tmpdir.read_link(".") {
-        Ok(..) => panic!("wanted a failure"),
-        Err(..) => {}
-    }
+    if tmpdir.read_link(".").is_ok() { panic!("wanted a failure") }
 }
 
 #[cfg(not(windows))]
@@ -996,9 +987,9 @@ fn read_link_contents() {
     if !got_symlink_permission(&tmpdir) {
         return;
     };
-    check!(symlink_file(&"foo", &tmpdir, &link));
+    check!(symlink_file("foo", &tmpdir, link));
     assert_eq!(
-        check!(tmpdir.read_link_contents(&link)).to_str().unwrap(),
+        check!(tmpdir.read_link_contents(link)).to_str().unwrap(),
         "foo"
     );
 }
@@ -1011,9 +1002,9 @@ fn read_link_contents_absolute() {
     if !got_symlink_permission(&tmpdir) {
         return;
     };
-    check!(symlink_contents(&"/foo", &tmpdir, &link));
+    check!(symlink_contents("/foo", &tmpdir, link));
     assert_eq!(
-        check!(tmpdir.read_link_contents(&link)).to_str().unwrap(),
+        check!(tmpdir.read_link_contents(link)).to_str().unwrap(),
         "/foo"
     );
 }
@@ -1024,30 +1015,24 @@ fn links_work() {
     let input = "in.txt";
     let out = "out.txt";
 
-    check!(check!(tmpdir.create(&input)).write("foobar".as_bytes()));
-    check!(tmpdir.hard_link(&input, &tmpdir, &out));
+    check!(check!(tmpdir.create(input)).write("foobar".as_bytes()));
+    check!(tmpdir.hard_link(input, &tmpdir, out));
     assert_eq!(
-        check!(tmpdir.metadata(&out)).len(),
-        check!(tmpdir.metadata(&input)).len()
+        check!(tmpdir.metadata(out)).len(),
+        check!(tmpdir.metadata(input)).len()
     );
     assert_eq!(
-        check!(tmpdir.metadata(&out)).len(),
+        check!(tmpdir.metadata(out)).len(),
         check!(tmpdir.metadata(input)).len()
     );
     let mut v = Vec::new();
-    check!(check!(tmpdir.open(&out)).read_to_end(&mut v));
+    check!(check!(tmpdir.open(out)).read_to_end(&mut v));
     assert_eq!(v, b"foobar".to_vec());
 
     // can't link to yourself
-    match tmpdir.hard_link(&input, &tmpdir, &input) {
-        Ok(..) => panic!("wanted a failure"),
-        Err(..) => {}
-    }
+    if let Ok(..) = tmpdir.hard_link(input, &tmpdir, input) { panic!("wanted a failure") }
     // can't link to something that doesn't exist
-    match tmpdir.hard_link("foo", &tmpdir, "bar") {
-        Ok(..) => panic!("wanted a failure"),
-        Err(..) => {}
-    }
+    if tmpdir.hard_link("foo", &tmpdir, "bar").is_ok() { panic!("wanted a failure") }
 }
 
 #[test]
@@ -1055,22 +1040,19 @@ fn chmod_works() {
     let tmpdir = tmpdir();
     let file = "in.txt";
 
-    check!(tmpdir.create(&file));
-    let attr = check!(tmpdir.metadata(&file));
+    check!(tmpdir.create(file));
+    let attr = check!(tmpdir.metadata(file));
     assert!(!attr.permissions().readonly());
     let mut p = attr.permissions();
     p.set_readonly(true);
-    check!(tmpdir.set_permissions(&file, p.clone()));
-    let attr = check!(tmpdir.metadata(&file));
+    check!(tmpdir.set_permissions(file, p.clone()));
+    let attr = check!(tmpdir.metadata(file));
     assert!(attr.permissions().readonly());
 
-    match tmpdir.set_permissions("foo", p.clone()) {
-        Ok(..) => panic!("wanted an error"),
-        Err(..) => {}
-    }
+    if tmpdir.set_permissions("foo", p.clone()).is_ok() { panic!("wanted an error") }
 
     p.set_readonly(false);
-    check!(tmpdir.set_permissions(&file, p));
+    check!(tmpdir.set_permissions(file, p));
 }
 
 #[test]
@@ -1078,13 +1060,13 @@ fn fchmod_works() {
     let tmpdir = tmpdir();
     let path = "in.txt";
 
-    let file = check!(tmpdir.create(&path));
-    let attr = check!(tmpdir.metadata(&path));
+    let file = check!(tmpdir.create(path));
+    let attr = check!(tmpdir.metadata(path));
     assert!(!attr.permissions().readonly());
     let mut p = attr.permissions();
     p.set_readonly(true);
     check!(file.set_permissions(p.clone()));
-    let attr = check!(tmpdir.metadata(&path));
+    let attr = check!(tmpdir.metadata(path));
     assert!(attr.permissions().readonly());
 
     p.set_readonly(false);
@@ -1096,7 +1078,7 @@ fn sync_doesnt_kill_anything() {
     let tmpdir = tmpdir();
     let path = "in.txt";
 
-    let mut file = check!(tmpdir.create(&path));
+    let mut file = check!(tmpdir.create(path));
     check!(file.sync_all());
     check!(file.sync_data());
     check!(file.write(b"foo"));
@@ -1109,7 +1091,7 @@ fn truncate_works() {
     let tmpdir = tmpdir();
     let path = "in.txt";
 
-    let mut file = check!(tmpdir.create(&path));
+    let mut file = check!(tmpdir.create(path));
     check!(file.write(b"foo"));
     check!(file.sync_all());
 
@@ -1122,7 +1104,7 @@ fn truncate_works() {
     assert_eq!(check!(file.metadata()).len(), 10);
 
     let mut v = Vec::new();
-    check!(check!(tmpdir.open(&path)).read_to_end(&mut v));
+    check!(check!(tmpdir.open(path)).read_to_end(&mut v));
     assert_eq!(v, b"foobar\0\0\0\0".to_vec());
 
     // Truncate to a smaller length, don't seek, and then write something.
@@ -1134,7 +1116,7 @@ fn truncate_works() {
     check!(file.sync_all());
     assert_eq!(check!(file.metadata()).len(), 9);
     let mut v = Vec::new();
-    check!(check!(tmpdir.open(&path)).read_to_end(&mut v));
+    check!(check!(tmpdir.open(path)).read_to_end(&mut v));
     assert_eq!(v, b"fo\0\0\0\0wut".to_vec());
 }
 
@@ -1295,7 +1277,7 @@ fn binary_file() {
     check!(check!(tmpdir.create("test")).write(&bytes));
     let mut v = Vec::new();
     check!(check!(tmpdir.open("test")).read_to_end(&mut v));
-    assert!(v == &bytes[..]);
+    assert!(v == bytes[..]);
 }
 
 #[test]
@@ -1307,9 +1289,9 @@ fn write_then_read() {
 
     check!(tmpdir.write("test", &bytes[..]));
     let v = check!(tmpdir.read("test"));
-    assert!(v == &bytes[..]);
+    assert!(v == bytes[..]);
 
-    check!(tmpdir.write("not-utf8", &[0xFF]));
+    check!(tmpdir.write("not-utf8", [0xFF]));
     error_contains!(
         tmpdir.read_to_string("not-utf8"),
         "stream did not contain valid UTF-8"
@@ -1347,26 +1329,26 @@ fn file_try_clone() {
 fn unlink_readonly() {
     let tmpdir = tmpdir();
     let path = "file";
-    check!(tmpdir.create(&path));
-    let mut perm = check!(tmpdir.metadata(&path)).permissions();
+    check!(tmpdir.create(path));
+    let mut perm = check!(tmpdir.metadata(path)).permissions();
     perm.set_readonly(true);
-    check!(tmpdir.set_permissions(&path, perm));
-    check!(tmpdir.remove_file(&path));
+    check!(tmpdir.set_permissions(path, perm));
+    check!(tmpdir.remove_file(path));
 }
 
 #[test]
 fn mkdir_trailing_slash() {
     let tmpdir = tmpdir();
     let path = PathBuf::from("file");
-    check!(tmpdir.create_dir_all(&path.join("a/")));
+    check!(tmpdir.create_dir_all(path.join("a/")));
 }
 
 #[test]
 fn canonicalize_works_simple() {
     let tmpdir = tmpdir();
     let file = Path::new("test");
-    tmpdir.create(&file).unwrap();
-    assert_eq!(tmpdir.canonicalize(&file).unwrap(), file);
+    tmpdir.create(file).unwrap();
+    assert_eq!(tmpdir.canonicalize(file).unwrap(), file);
 }
 
 #[test]
@@ -1396,7 +1378,7 @@ fn realpath_works() {
     assert_eq!(tmpdir.canonicalize(&file).unwrap(), file);
     assert_eq!(tmpdir.canonicalize(&link).unwrap(), file);
     assert_eq!(tmpdir.canonicalize(&linkdir).unwrap(), dir);
-    assert_eq!(tmpdir.canonicalize(&linkdir.join("link")).unwrap(), file);
+    assert_eq!(tmpdir.canonicalize(linkdir.join("link")).unwrap(), file);
 }
 
 #[test]
@@ -1488,9 +1470,9 @@ fn create_dir_all_with_junctions() {
     let link = PathBuf::from("link");
     let d = link.join("c/d");
 
-    tmpdir.create_dir(&target).unwrap();
+    tmpdir.create_dir(target).unwrap();
 
-    check!(symlink_junction(&target, &tmpdir, &junction));
+    check!(symlink_junction(target, &tmpdir, &junction));
     check!(tmpdir.create_dir_all(&b));
     // the junction itself is not a directory, but `is_dir()` on a Path
     // follows links
@@ -1500,7 +1482,7 @@ fn create_dir_all_with_junctions() {
     if !got_symlink_permission(&tmpdir) {
         return;
     };
-    check!(symlink_dir(&target, &tmpdir, &link));
+    check!(symlink_dir(target, &tmpdir, &link));
     check!(tmpdir.create_dir_all(&d));
     assert!(tmpdir.is_dir(link));
     assert!(tmpdir.exists(d));
@@ -1511,10 +1493,10 @@ fn metadata_access_times() {
     let tmpdir = tmpdir();
 
     let b = "b";
-    tmpdir.create(&b).unwrap();
+    tmpdir.create(b).unwrap();
 
     let a = check!(tmpdir.metadata("."));
-    let b = check!(tmpdir.metadata(&b));
+    let b = check!(tmpdir.metadata(b));
 
     assert_eq!(check!(a.accessed()), check!(a.accessed()));
     assert_eq!(check!(a.modified()), check!(a.modified()));

--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -233,16 +233,16 @@ fn optionally_recursive_mkdir() {
 #[test]
 fn try_exists() {
     let tmpdir = tmpdir();
-    assert_eq!(tmpdir.try_exists("somefile").unwrap(), false);
+    assert!(!tmpdir.try_exists("somefile").unwrap());
     let dir = Path::new("d1/d2");
     let parent = dir.parent().unwrap();
-    assert_eq!(tmpdir.try_exists(parent).unwrap(), false);
-    assert_eq!(tmpdir.try_exists(dir).unwrap(), false);
+    assert!(!tmpdir.try_exists(parent).unwrap());
+    assert!(!tmpdir.try_exists(dir).unwrap());
     check!(tmpdir.create_dir(parent));
-    assert_eq!(tmpdir.try_exists(parent).unwrap(), true);
-    assert_eq!(tmpdir.try_exists(dir).unwrap(), false);
+    assert!(tmpdir.try_exists(parent).unwrap());
+    assert!(!tmpdir.try_exists(dir).unwrap());
     check!(tmpdir.create_dir(dir));
-    assert_eq!(tmpdir.try_exists(dir).unwrap(), true);
+    assert!(tmpdir.try_exists(dir).unwrap());
 }
 
 #[test]
@@ -269,7 +269,7 @@ fn file_test_directoryinfo_readdir() {
     for n in 0..3 {
         let f = format!("{}.txt", n);
         let mut w = check!(tmpdir.create(&f));
-        let msg_str = format!("{}{}", prefix, n.to_string());
+        let msg_str = format!("{}{}", prefix, n);
         let msg = msg_str.as_bytes();
         check!(w.write(msg));
     }

--- a/tests/fs_utf8.rs
+++ b/tests/fs_utf8.rs
@@ -90,7 +90,7 @@ fn able_to_not_follow_symlinks_while_hard_linking() -> bool {
 
 #[cfg(not(target_os = "macos"))]
 fn able_to_not_follow_symlinks_while_hard_linking() -> bool {
-    return true;
+    true
 }
 
 #[test]
@@ -173,7 +173,7 @@ fn file_test_io_non_positional_read() {
 fn file_test_io_seek_and_tell_smoke_test() {
     let message = "ten-four";
     let mut read_mem = [0; 4];
-    let set_cursor = 4 as u64;
+    let set_cursor = 4_u64;
     let tell_pos_pre_read;
     let tell_pos_post_read;
     let tmpdir = tmpdir();
@@ -185,9 +185,9 @@ fn file_test_io_seek_and_tell_smoke_test() {
     {
         let mut read_stream = check!(tmpdir.open(filename));
         check!(read_stream.seek(SeekFrom::Start(set_cursor)));
-        tell_pos_pre_read = check!(read_stream.seek(SeekFrom::Current(0)));
+        tell_pos_pre_read = check!(read_stream.stream_position());
         check!(read_stream.read(&mut read_mem));
-        tell_pos_post_read = check!(read_stream.seek(SeekFrom::Current(0)));
+        tell_pos_post_read = check!(read_stream.stream_position());
     }
     check!(tmpdir.remove_file(filename));
     let read_str = str::from_utf8(&read_mem).unwrap();
@@ -290,48 +290,48 @@ fn file_test_io_read_write_at() {
             .clone();
         let mut rw = check!(tmpdir.open_with(filename, &oo));
         assert_eq!(check!(rw.write_at(write1.as_bytes(), 5)), write1.len());
-        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 0);
+        assert_eq!(check!(rw.stream_position()), 0);
         assert_eq!(check!(rw.read_at(&mut buf, 5)), write1.len());
         assert_eq!(str::from_utf8(&buf[..write1.len()]), Ok(write1));
-        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 0);
+        assert_eq!(check!(rw.stream_position()), 0);
         assert_eq!(
             check!(rw.read_at(&mut buf[..write2.len()], 0)),
             write2.len()
         );
         assert_eq!(str::from_utf8(&buf[..write2.len()]), Ok("\0\0\0\0\0"));
-        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 0);
+        assert_eq!(check!(rw.stream_position()), 0);
         assert_eq!(check!(rw.write(write2.as_bytes())), write2.len());
-        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 5);
+        assert_eq!(check!(rw.stream_position()), 5);
         assert_eq!(check!(rw.read(&mut buf)), write1.len());
         assert_eq!(str::from_utf8(&buf[..write1.len()]), Ok(write1));
-        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 9);
+        assert_eq!(check!(rw.stream_position()), 9);
         assert_eq!(
             check!(rw.read_at(&mut buf[..write2.len()], 0)),
             write2.len()
         );
         assert_eq!(str::from_utf8(&buf[..write2.len()]), Ok(write2));
-        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 9);
+        assert_eq!(check!(rw.stream_position()), 9);
         assert_eq!(check!(rw.write_at(write3.as_bytes(), 9)), write3.len());
-        assert_eq!(check!(rw.seek(SeekFrom::Current(0))), 9);
+        assert_eq!(check!(rw.stream_position()), 9);
     }
     {
         let mut read = check!(tmpdir.open(filename));
         assert_eq!(check!(read.read_at(&mut buf, 0)), content.len());
         assert_eq!(str::from_utf8(&buf[..content.len()]), Ok(content));
-        assert_eq!(check!(read.seek(SeekFrom::Current(0))), 0);
+        assert_eq!(check!(read.stream_position()), 0);
         assert_eq!(check!(read.seek(SeekFrom::End(-5))), 9);
         assert_eq!(check!(read.read_at(&mut buf, 0)), content.len());
         assert_eq!(str::from_utf8(&buf[..content.len()]), Ok(content));
-        assert_eq!(check!(read.seek(SeekFrom::Current(0))), 9);
+        assert_eq!(check!(read.stream_position()), 9);
         assert_eq!(check!(read.read(&mut buf)), write3.len());
         assert_eq!(str::from_utf8(&buf[..write3.len()]), Ok(write3));
-        assert_eq!(check!(read.seek(SeekFrom::Current(0))), 14);
+        assert_eq!(check!(read.stream_position()), 14);
         assert_eq!(check!(read.read_at(&mut buf, 0)), content.len());
         assert_eq!(str::from_utf8(&buf[..content.len()]), Ok(content));
-        assert_eq!(check!(read.seek(SeekFrom::Current(0))), 14);
+        assert_eq!(check!(read.stream_position()), 14);
         assert_eq!(check!(read.read_at(&mut buf, 14)), 0);
         assert_eq!(check!(read.read_at(&mut buf, 15)), 0);
-        assert_eq!(check!(read.seek(SeekFrom::Current(0))), 14);
+        assert_eq!(check!(read.stream_position()), 14);
     }
     check!(tmpdir.remove_file(filename));
 }
@@ -502,7 +502,7 @@ fn file_test_directoryinfo_readdir() {
     for n in 0..3 {
         let f = format!("{}.txt", n);
         let mut w = check!(tmpdir.create(&f));
-        let msg_str = format!("{}{}", prefix, n.to_string());
+        let msg_str = format!("{}{}", prefix, n);
         let msg = msg_str.as_bytes();
         check!(w.write(msg));
     }
@@ -527,7 +527,7 @@ fn file_create_new_already_exists_error() {
     let file = "file_create_new_error_exists";
     check!(tmpdir.create(file));
     let e = tmpdir
-        .open_with(file, &fs::OpenOptions::new().write(true).create_new(true))
+        .open_with(file, fs::OpenOptions::new().write(true).create_new(true))
         .unwrap_err();
     assert_eq!(e.kind(), ErrorKind::AlreadyExists);
 }
@@ -555,10 +555,10 @@ fn recursive_mkdir_failure() {
     let dir = "d1";
     let file = "f1";
 
-    check!(tmpdir.create_dir_all(&dir));
-    check!(tmpdir.create(&file));
+    check!(tmpdir.create_dir_all(dir));
+    check!(tmpdir.create(file));
 
-    let result = tmpdir.create_dir_all(&file);
+    let result = tmpdir.create_dir_all(file);
 
     assert!(result.is_err());
 }
@@ -618,8 +618,8 @@ fn recursive_rmdir() {
     check!(tmpdir.create_dir_all(&dtt));
     check!(tmpdir.create_dir_all(&d2));
     check!(check!(tmpdir.create(&canary)).write(b"foo"));
-    check!(symlink_junction(d2, &tmpdir, &dt.join("d2")));
-    let _ = symlink_file(&canary, &tmpdir, &d1.join("canary"));
+    check!(symlink_junction(d2, &tmpdir, dt.join("d2")));
+    let _ = symlink_file(&canary, &tmpdir, d1.join("canary"));
     check!(tmpdir.remove_dir_all(&d1));
 
     assert!(!tmpdir.is_dir(d1));
@@ -635,9 +635,9 @@ fn recursive_rmdir_of_symlink() {
     let link = "d1";
     let dir = "d2";
     let canary = "do_not_delete";
-    check!(tmpdir.create_dir_all(&dir));
-    check!(check!(tmpdir.create(&canary)).write(b"foo"));
-    check!(symlink_junction(&dir, &tmpdir, link));
+    check!(tmpdir.create_dir_all(dir));
+    check!(check!(tmpdir.create(canary)).write(b"foo"));
+    check!(symlink_junction(dir, &tmpdir, link));
     check!(tmpdir.remove_dir_all(link));
 
     assert!(!tmpdir.is_dir(link));
@@ -772,7 +772,7 @@ fn copy_file_does_not_exist() {
     let from = Path::new("test/nonexistent-bogus-path");
     let to = Path::new("test/other-bogus-path");
 
-    match tmpdir.copy(&from, &tmpdir, &to) {
+    match tmpdir.copy(from, &tmpdir, to) {
         Ok(..) => panic!(),
         Err(..) => {
             assert!(!tmpdir.exists(from));
@@ -786,11 +786,11 @@ fn copy_src_does_not_exist() {
     let tmpdir = tmpdir();
     let from = Path::new("test/nonexistent-bogus-path");
     let to = "out.txt";
-    check!(check!(tmpdir.create(&to)).write(b"hello"));
-    assert!(tmpdir.copy(&from, &tmpdir, &to).is_err());
+    check!(check!(tmpdir.create(to)).write(b"hello"));
+    assert!(tmpdir.copy(from, &tmpdir, to).is_err());
     assert!(!tmpdir.exists(from));
     let mut v = Vec::new();
-    check!(check!(tmpdir.open(&to)).read_to_end(&mut v));
+    check!(check!(tmpdir.open(to)).read_to_end(&mut v));
     assert_eq!(v, b"hello");
 }
 
@@ -800,10 +800,10 @@ fn copy_file_ok() {
     let input = "in.txt";
     let out = "out.txt";
 
-    check!(check!(tmpdir.create(&input)).write(b"hello"));
-    check!(tmpdir.copy(&input, &tmpdir, &out));
+    check!(check!(tmpdir.create(input)).write(b"hello"));
+    check!(tmpdir.copy(input, &tmpdir, out));
     let mut v = Vec::new();
-    check!(check!(tmpdir.open(&out)).read_to_end(&mut v));
+    check!(check!(tmpdir.open(out)).read_to_end(&mut v));
     assert_eq!(v, b"hello");
 
     assert_eq!(
@@ -817,11 +817,8 @@ fn copy_file_dst_dir() {
     let tmpdir = tmpdir();
     let out = "out";
 
-    check!(tmpdir.create(&out));
-    match tmpdir.copy(&*out, &tmpdir, ".") {
-        Ok(..) => panic!(),
-        Err(..) => {}
-    }
+    check!(tmpdir.create(out));
+    if let Ok(..) = tmpdir.copy(out, &tmpdir, ".") { panic!() }
 }
 
 #[test]
@@ -830,12 +827,12 @@ fn copy_file_dst_exists() {
     let input = "in";
     let output = "out";
 
-    check!(check!(tmpdir.create(&input)).write("foo".as_bytes()));
-    check!(check!(tmpdir.create(&output)).write("bar".as_bytes()));
-    check!(tmpdir.copy(&input, &tmpdir, &output));
+    check!(check!(tmpdir.create(input)).write("foo".as_bytes()));
+    check!(check!(tmpdir.create(output)).write("bar".as_bytes()));
+    check!(tmpdir.copy(input, &tmpdir, output));
 
     let mut v = Vec::new();
-    check!(check!(tmpdir.open(&output)).read_to_end(&mut v));
+    check!(check!(tmpdir.open(output)).read_to_end(&mut v));
     assert_eq!(v, b"foo".to_vec());
 }
 
@@ -844,10 +841,7 @@ fn copy_file_src_dir() {
     let tmpdir = tmpdir();
     let out = "out";
 
-    match tmpdir.copy(".", &tmpdir, &out) {
-        Ok(..) => panic!(),
-        Err(..) => {}
-    }
+    if let Ok(..) = tmpdir.copy(".", &tmpdir, out) { panic!() }
     assert!(!tmpdir.exists(out));
 }
 
@@ -857,14 +851,14 @@ fn copy_file_preserves_perm_bits() {
     let input = "in.txt";
     let out = "out.txt";
 
-    let attr = check!(check!(tmpdir.create(&input)).metadata());
+    let attr = check!(check!(tmpdir.create(input)).metadata());
     let mut p = attr.permissions();
     p.set_readonly(true);
-    check!(tmpdir.set_permissions(&input, p));
-    check!(tmpdir.copy(&input, &tmpdir, &out));
+    check!(tmpdir.set_permissions(input, p));
+    check!(tmpdir.copy(input, &tmpdir, out));
     assert!(check!(tmpdir.metadata(out)).permissions().readonly());
-    check!(tmpdir.set_permissions(&input, attr.permissions()));
-    check!(tmpdir.set_permissions(&out, attr.permissions()));
+    check!(tmpdir.set_permissions(input, attr.permissions()));
+    check!(tmpdir.set_permissions(out, attr.permissions()));
 }
 
 #[test]
@@ -884,10 +878,10 @@ fn copy_file_returns_metadata_len() {
     let tmp = tmpdir();
     let in_path = "in.txt";
     let out_path = "out.txt";
-    check!(check!(tmp.create(&in_path)).write(b"lettuce"));
+    check!(check!(tmp.create(in_path)).write(b"lettuce"));
     #[cfg(windows)]
     check!(check!(tmp.create("in.txt:bunny")).write(b"carrot"));
-    let copied_len = check!(tmp.copy(&in_path, &tmp, &out_path));
+    let copied_len = check!(tmp.copy(in_path, &tmp, out_path));
     assert_eq!(check!(tmp.metadata(out_path)).len(), copied_len);
 }
 
@@ -902,17 +896,17 @@ fn copy_file_follows_dst_symlink() {
     let out_path = "out.txt";
     let out_path_symlink = "out_symlink.txt";
 
-    check!(tmp.write(&in_path, "foo"));
-    check!(tmp.write(&out_path, "bar"));
-    check!(symlink_file(&out_path, &tmp, &out_path_symlink));
+    check!(tmp.write(in_path, "foo"));
+    check!(tmp.write(out_path, "bar"));
+    check!(symlink_file(out_path, &tmp, out_path_symlink));
 
-    check!(tmp.copy(&in_path, &tmp, &out_path_symlink));
+    check!(tmp.copy(in_path, &tmp, out_path_symlink));
 
     assert!(check!(tmp.symlink_metadata(out_path_symlink))
         .file_type()
         .is_symlink());
-    assert_eq!(check!(tmp.read(&out_path_symlink)), b"foo".to_vec());
-    assert_eq!(check!(tmp.read(&out_path)), b"foo".to_vec());
+    assert_eq!(check!(tmp.read(out_path_symlink)), b"foo".to_vec());
+    assert_eq!(check!(tmp.read(out_path)), b"foo".to_vec());
 }
 
 #[test]
@@ -925,17 +919,17 @@ fn symlinks_work() {
     let input = "in.txt";
     let out = "out.txt";
 
-    check!(check!(tmpdir.create(&input)).write("foobar".as_bytes()));
-    check!(symlink_file(&input, &tmpdir, &out));
+    check!(check!(tmpdir.create(input)).write("foobar".as_bytes()));
+    check!(symlink_file(input, &tmpdir, out));
     assert!(check!(tmpdir.symlink_metadata(out))
         .file_type()
         .is_symlink());
     assert_eq!(
-        check!(tmpdir.metadata(&out)).len(),
-        check!(tmpdir.metadata(&input)).len()
+        check!(tmpdir.metadata(out)).len(),
+        check!(tmpdir.metadata(input)).len()
     );
     let mut v = Vec::new();
-    check!(check!(tmpdir.open(&out)).read_to_end(&mut v));
+    check!(check!(tmpdir.open(out)).read_to_end(&mut v));
     assert_eq!(v, b"foobar".to_vec());
 }
 
@@ -949,7 +943,7 @@ fn symlink_noexist() {
 
     // Use a relative path for testing. Symlinks get normalized by Windows,
     // so we might not get the same path back for absolute paths
-    check!(symlink_file(&"foo", &tmpdir, "bar"));
+    check!(symlink_file("foo", &tmpdir, "bar"));
     assert_eq!(check!(tmpdir.read_link("bar")).as_str(), "foo");
 }
 
@@ -978,17 +972,14 @@ fn read_link() {
     if !got_symlink_permission(&tmpdir) {
         return;
     };
-    check!(symlink_file(&"foo", &tmpdir, &link));
-    assert_eq!(check!(tmpdir.read_link(&link)).as_str(), "foo");
+    check!(symlink_file("foo", &tmpdir, link));
+    assert_eq!(check!(tmpdir.read_link(link)).as_str(), "foo");
 }
 
 #[test]
 fn readlink_not_symlink() {
     let tmpdir = tmpdir();
-    match tmpdir.read_link(".") {
-        Ok(..) => panic!("wanted a failure"),
-        Err(..) => {}
-    }
+    if tmpdir.read_link(".").is_ok() { panic!("wanted a failure") }
 }
 
 #[cfg(not(windows))]
@@ -999,8 +990,8 @@ fn read_link_contents() {
     if !got_symlink_permission(&tmpdir) {
         return;
     };
-    check!(symlink_file(&"foo", &tmpdir, &link));
-    assert_eq!(check!(tmpdir.read_link_contents(&link)).as_str(), "foo");
+    check!(symlink_file("foo", &tmpdir, link));
+    assert_eq!(check!(tmpdir.read_link_contents(link)).as_str(), "foo");
 }
 
 #[cfg(not(windows))]
@@ -1011,8 +1002,8 @@ fn read_link_contents_absolute() {
     if !got_symlink_permission(&tmpdir) {
         return;
     };
-    check!(symlink_contents(&"/foo", &tmpdir, &link));
-    assert_eq!(check!(tmpdir.read_link_contents(&link)).as_str(), "/foo");
+    check!(symlink_contents("/foo", &tmpdir, link));
+    assert_eq!(check!(tmpdir.read_link_contents(link)).as_str(), "/foo");
 }
 
 #[test]
@@ -1021,30 +1012,24 @@ fn links_work() {
     let input = "in.txt";
     let out = "out.txt";
 
-    check!(check!(tmpdir.create(&input)).write("foobar".as_bytes()));
-    check!(tmpdir.hard_link(&input, &tmpdir, &out));
+    check!(check!(tmpdir.create(input)).write("foobar".as_bytes()));
+    check!(tmpdir.hard_link(input, &tmpdir, out));
     assert_eq!(
-        check!(tmpdir.metadata(&out)).len(),
-        check!(tmpdir.metadata(&input)).len()
+        check!(tmpdir.metadata(out)).len(),
+        check!(tmpdir.metadata(input)).len()
     );
     assert_eq!(
-        check!(tmpdir.metadata(&out)).len(),
+        check!(tmpdir.metadata(out)).len(),
         check!(tmpdir.metadata(input)).len()
     );
     let mut v = Vec::new();
-    check!(check!(tmpdir.open(&out)).read_to_end(&mut v));
+    check!(check!(tmpdir.open(out)).read_to_end(&mut v));
     assert_eq!(v, b"foobar".to_vec());
 
     // can't link to yourself
-    match tmpdir.hard_link(&input, &tmpdir, &input) {
-        Ok(..) => panic!("wanted a failure"),
-        Err(..) => {}
-    }
+    if let Ok(..) = tmpdir.hard_link(input, &tmpdir, input) { panic!("wanted a failure") }
     // can't link to something that doesn't exist
-    match tmpdir.hard_link("foo", &tmpdir, "bar") {
-        Ok(..) => panic!("wanted a failure"),
-        Err(..) => {}
-    }
+    if tmpdir.hard_link("foo", &tmpdir, "bar").is_ok() { panic!("wanted a failure") }
 }
 
 #[test]
@@ -1052,22 +1037,19 @@ fn chmod_works() {
     let tmpdir = tmpdir();
     let file = "in.txt";
 
-    check!(tmpdir.create(&file));
-    let attr = check!(tmpdir.metadata(&file));
+    check!(tmpdir.create(file));
+    let attr = check!(tmpdir.metadata(file));
     assert!(!attr.permissions().readonly());
     let mut p = attr.permissions();
     p.set_readonly(true);
-    check!(tmpdir.set_permissions(&file, p.clone()));
-    let attr = check!(tmpdir.metadata(&file));
+    check!(tmpdir.set_permissions(file, p.clone()));
+    let attr = check!(tmpdir.metadata(file));
     assert!(attr.permissions().readonly());
 
-    match tmpdir.set_permissions("foo", p.clone()) {
-        Ok(..) => panic!("wanted an error"),
-        Err(..) => {}
-    }
+    if tmpdir.set_permissions("foo", p.clone()).is_ok() { panic!("wanted an error") }
 
     p.set_readonly(false);
-    check!(tmpdir.set_permissions(&file, p));
+    check!(tmpdir.set_permissions(file, p));
 }
 
 #[test]
@@ -1075,13 +1057,13 @@ fn fchmod_works() {
     let tmpdir = tmpdir();
     let path = "in.txt";
 
-    let file = check!(tmpdir.create(&path));
-    let attr = check!(tmpdir.metadata(&path));
+    let file = check!(tmpdir.create(path));
+    let attr = check!(tmpdir.metadata(path));
     assert!(!attr.permissions().readonly());
     let mut p = attr.permissions();
     p.set_readonly(true);
     check!(file.set_permissions(p.clone()));
-    let attr = check!(tmpdir.metadata(&path));
+    let attr = check!(tmpdir.metadata(path));
     assert!(attr.permissions().readonly());
 
     p.set_readonly(false);
@@ -1093,7 +1075,7 @@ fn sync_doesnt_kill_anything() {
     let tmpdir = tmpdir();
     let path = "in.txt";
 
-    let mut file = check!(tmpdir.create(&path));
+    let mut file = check!(tmpdir.create(path));
     check!(file.sync_all());
     check!(file.sync_data());
     check!(file.write(b"foo"));
@@ -1106,7 +1088,7 @@ fn truncate_works() {
     let tmpdir = tmpdir();
     let path = "in.txt";
 
-    let mut file = check!(tmpdir.create(&path));
+    let mut file = check!(tmpdir.create(path));
     check!(file.write(b"foo"));
     check!(file.sync_all());
 
@@ -1119,7 +1101,7 @@ fn truncate_works() {
     assert_eq!(check!(file.metadata()).len(), 10);
 
     let mut v = Vec::new();
-    check!(check!(tmpdir.open(&path)).read_to_end(&mut v));
+    check!(check!(tmpdir.open(path)).read_to_end(&mut v));
     assert_eq!(v, b"foobar\0\0\0\0".to_vec());
 
     // Truncate to a smaller length, don't seek, and then write something.
@@ -1131,7 +1113,7 @@ fn truncate_works() {
     check!(file.sync_all());
     assert_eq!(check!(file.metadata()).len(), 9);
     let mut v = Vec::new();
-    check!(check!(tmpdir.open(&path)).read_to_end(&mut v));
+    check!(check!(tmpdir.open(path)).read_to_end(&mut v));
     assert_eq!(v, b"fo\0\0\0\0wut".to_vec());
 }
 
@@ -1292,7 +1274,7 @@ fn binary_file() {
     check!(check!(tmpdir.create("test")).write(&bytes));
     let mut v = Vec::new();
     check!(check!(tmpdir.open("test")).read_to_end(&mut v));
-    assert!(v == &bytes[..]);
+    assert!(v == bytes[..]);
 }
 
 #[test]
@@ -1304,9 +1286,9 @@ fn write_then_read() {
 
     check!(tmpdir.write("test", &bytes[..]));
     let v = check!(tmpdir.read("test"));
-    assert!(v == &bytes[..]);
+    assert!(v == bytes[..]);
 
-    check!(tmpdir.write("not-utf8", &[0xFF]));
+    check!(tmpdir.write("not-utf8", [0xFF]));
     error_contains!(
         tmpdir.read_to_string("not-utf8"),
         "stream did not contain valid UTF-8"
@@ -1344,26 +1326,26 @@ fn file_try_clone() {
 fn unlink_readonly() {
     let tmpdir = tmpdir();
     let path = "file";
-    check!(tmpdir.create(&path));
-    let mut perm = check!(tmpdir.metadata(&path)).permissions();
+    check!(tmpdir.create(path));
+    let mut perm = check!(tmpdir.metadata(path)).permissions();
     perm.set_readonly(true);
-    check!(tmpdir.set_permissions(&path, perm));
-    check!(tmpdir.remove_file(&path));
+    check!(tmpdir.set_permissions(path, perm));
+    check!(tmpdir.remove_file(path));
 }
 
 #[test]
 fn mkdir_trailing_slash() {
     let tmpdir = tmpdir();
     let path = PathBuf::from("file");
-    check!(tmpdir.create_dir_all(&path.join("a/")));
+    check!(tmpdir.create_dir_all(path.join("a/")));
 }
 
 #[test]
 fn canonicalize_works_simple() {
     let tmpdir = tmpdir();
     let file = Path::new("test");
-    tmpdir.create(&file).unwrap();
-    assert_eq!(tmpdir.canonicalize(&file).unwrap(), file);
+    tmpdir.create(file).unwrap();
+    assert_eq!(tmpdir.canonicalize(file).unwrap(), file);
 }
 
 #[test]
@@ -1393,7 +1375,7 @@ fn realpath_works() {
     assert_eq!(tmpdir.canonicalize(&file).unwrap(), file);
     assert_eq!(tmpdir.canonicalize(&link).unwrap(), file);
     assert_eq!(tmpdir.canonicalize(&linkdir).unwrap(), dir);
-    assert_eq!(tmpdir.canonicalize(&linkdir.join("link")).unwrap(), file);
+    assert_eq!(tmpdir.canonicalize(linkdir.join("link")).unwrap(), file);
 }
 
 #[test]
@@ -1480,9 +1462,9 @@ fn create_dir_all_with_junctions() {
     let link = PathBuf::from("link");
     let d = link.join("c/d");
 
-    tmpdir.create_dir(&target).unwrap();
+    tmpdir.create_dir(target).unwrap();
 
-    check!(symlink_junction(&target, &tmpdir, &junction));
+    check!(symlink_junction(target, &tmpdir, &junction));
     check!(tmpdir.create_dir_all(&b));
     // the junction itself is not a directory, but `is_dir()` on a Path
     // follows links
@@ -1492,7 +1474,7 @@ fn create_dir_all_with_junctions() {
     if !got_symlink_permission(&tmpdir) {
         return;
     };
-    check!(symlink_dir(&target, &tmpdir, &link));
+    check!(symlink_dir(target, &tmpdir, &link));
     check!(tmpdir.create_dir_all(&d));
     assert!(tmpdir.is_dir(link));
     assert!(tmpdir.exists(d));
@@ -1503,10 +1485,10 @@ fn metadata_access_times() {
     let tmpdir = tmpdir();
 
     let b = "b";
-    tmpdir.create(&b).unwrap();
+    tmpdir.create(b).unwrap();
 
     let a = check!(tmpdir.metadata("."));
-    let b = check!(tmpdir.metadata(&b));
+    let b = check!(tmpdir.metadata(b));
 
     assert_eq!(check!(a.accessed()), check!(a.accessed()));
     assert_eq!(check!(a.modified()), check!(a.modified()));

--- a/tests/paths-containing-nul.rs
+++ b/tests/paths-containing-nul.rs
@@ -51,11 +51,11 @@ fn paths_containing_nul() {
     tmpdir.create(dummy_file).expect("creating dummy_file");
 
     assert_invalid_input("rename1", tmpdir.rename("\0", &tmpdir, "a"));
-    assert_invalid_input("rename2", tmpdir.rename(&dummy_file, &tmpdir, "\0"));
+    assert_invalid_input("rename2", tmpdir.rename(dummy_file, &tmpdir, "\0"));
     assert_invalid_input("copy1", tmpdir.copy("\0", &tmpdir, "a"));
-    assert_invalid_input("copy2", tmpdir.copy(&dummy_file, &tmpdir, "\0"));
+    assert_invalid_input("copy2", tmpdir.copy(dummy_file, &tmpdir, "\0"));
     assert_invalid_input("hard_link1", tmpdir.hard_link("\0", &tmpdir, "a"));
-    assert_invalid_input("hard_link2", tmpdir.hard_link(&dummy_file, &tmpdir, "\0"));
+    assert_invalid_input("hard_link2", tmpdir.hard_link(dummy_file, &tmpdir, "\0"));
     //fixmeassert_invalid_input("soft_link1", tmpdir.soft_link("\0", &tmpdir,
     // "a")); fixmeassert_invalid_input("soft_link2",
     // tmpdir.soft_link(&dummy_file, &tmpdir, "\0"));

--- a/tests/readdir.rs
+++ b/tests/readdir.rs
@@ -7,12 +7,12 @@ use std::path::Path;
 fn test_dir_entries() {
     let tmpdir = tempfile::tempdir().expect("construct tempdir");
 
-    let entries = dir_entries(&tmpdir.path());
+    let entries = dir_entries(tmpdir.path());
     assert_eq!(entries.len(), 0, "empty dir");
 
     let _f1 = std::fs::File::create(tmpdir.path().join("file1")).expect("create file1");
 
-    let entries = dir_entries(&tmpdir.path());
+    let entries = dir_entries(tmpdir.path());
     assert!(
         entries.get("file1").is_some(),
         "directory contains `file1`: {:?}",
@@ -21,7 +21,7 @@ fn test_dir_entries() {
     assert_eq!(entries.len(), 1);
 
     let _f2 = std::fs::File::create(tmpdir.path().join("file2")).expect("create file1");
-    let entries = dir_entries(&tmpdir.path());
+    let entries = dir_entries(tmpdir.path());
     assert!(
         entries.get("file1").is_some(),
         "directory contains `file1`: {:?}",

--- a/tests/rename-directory.rs
+++ b/tests/rename-directory.rs
@@ -23,14 +23,14 @@ use sys_common::io::tmpdir;
 fn rename_directory() {
     let tmpdir = tmpdir();
     let old_path = Path::new("foo/bar/baz");
-    tmpdir.create_dir_all(&old_path).unwrap();
+    tmpdir.create_dir_all(old_path).unwrap();
     let test_file = &old_path.join("temp.txt");
 
     tmpdir.create(test_file).unwrap();
 
     let new_path = Path::new("quux/blat");
-    tmpdir.create_dir_all(&new_path).unwrap();
-    tmpdir.rename(&old_path, &tmpdir, &new_path.join("newdir"));
+    tmpdir.create_dir_all(new_path).unwrap();
+    tmpdir.rename(old_path, &tmpdir, new_path.join("newdir"));
     assert!(tmpdir.is_dir(new_path.join("newdir")));
     assert!(tmpdir.exists(new_path.join("newdir/temp.txt")));
 }


### PR DESCRIPTION
Mostly a 'cargo clippy --fix --all-features --all-targets',
plus some manual fixes for elided lifetimes.
