### PR TITLE
Remove `maybe-owned` dependency

### DIFF
--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -16,7 +16,6 @@ edition = "2021"
 ambient-authority = "0.0.2"
 arbitrary = { version = "1.0.0", optional = true, features = ["derive"] }
 ipnet = "2.5.0"
-maybe-owned = "0.3.4"
 fs-set-times = "0.20.0"
 io-extras = "0.19.0"
 io-lifetimes = { version = "3.0.1", default-features = false }

--- a/cap-primitives/src/fs/maybe_owned_file.rs
+++ b/cap-primitives/src/fs/maybe_owned_file.rs
@@ -1,5 +1,4 @@
 use crate::fs::{open_unchecked, OpenOptions};
-use maybe_owned::MaybeOwned;
 use std::ops::Deref;
 use std::path::Component;
 use std::{fmt, fs, io, mem};
@@ -25,6 +24,28 @@ pub(super) struct MaybeOwnedFile<'borrow> {
 
     #[cfg(racy_asserts)]
     path: Option<PathBuf>,
+}
+
+enum MaybeOwned<'a, T: 'a> {
+    Owned(T),
+    Borrowed(&'a T),
+}
+
+impl<T> Deref for MaybeOwned<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        match self {
+            Self::Owned(v) => v,
+            Self::Borrowed(v) => v,
+        }
+    }
+}
+
+impl<T> AsRef<T> for MaybeOwned<'_, T> {
+    fn as_ref(&self) -> &T {
+        self
+    }
 }
 
 impl<'borrow> MaybeOwnedFile<'borrow> {


### PR DESCRIPTION
The dependency is very old and unmaintained, and it can be replaced very easily.